### PR TITLE
SDR-63 리뷰 작성(생성) API 기능 구현과 테스트

### DIFF
--- a/be/build.gradle
+++ b/be/build.gradle
@@ -32,6 +32,8 @@ dependencies {
 
 	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'io.rest-assured:rest-assured'
+
 }
 
 tasks.named('test') {

--- a/be/build.gradle
+++ b/be/build.gradle
@@ -21,6 +21,7 @@ repositories {
 dependencies {
 	// Web
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 
 	// Database
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/be/src/main/java/com/jjikmuk/sikdorak/SikdorakApplication.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/SikdorakApplication.java
@@ -2,8 +2,10 @@ package com.jjikmuk.sikdorak;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class SikdorakApplication {
 
 	public static void main(String[] args) {

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/BaseResponse.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/BaseResponse.java
@@ -5,11 +5,11 @@ import lombok.Getter;
 @Getter
 public class BaseResponse<T> {
 
-	private final int code;
+	private final String code;
 	private final String message;
 	private final T data;
 
-	public BaseResponse(int code, String message, T data) {
+	public BaseResponse(String code, String message, T data) {
 		this.code = code;
 		this.message = message;
 		this.data = data;

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/BaseResponse.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/BaseResponse.java
@@ -1,0 +1,17 @@
+package com.jjikmuk.sikdorak.common;
+
+import lombok.Getter;
+
+@Getter
+public class BaseResponse<T> {
+
+	private final int code;
+	private final String message;
+	private final T data;
+
+	public BaseResponse(int code, String message, T data) {
+		this.code = code;
+		this.message = message;
+		this.data = data;
+	}
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/CodeAndMessages.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/CodeAndMessages.java
@@ -1,0 +1,7 @@
+package com.jjikmuk.sikdorak.common;
+
+public interface CodeAndMessages {
+
+    String getCode();
+    String getMessage();
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/ResponseCodeAndMessages.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/ResponseCodeAndMessages.java
@@ -1,0 +1,15 @@
+package com.jjikmuk.sikdorak.common;
+
+public enum ResponseCodeAndMessages implements CodeAndMessages {
+    ;
+
+    @Override
+    public String getCode() {
+        return null;
+    }
+
+    @Override
+    public String getMessage() {
+        return null;
+    }
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/ResponseCodeAndMessages.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/ResponseCodeAndMessages.java
@@ -1,15 +1,24 @@
 package com.jjikmuk.sikdorak.common;
 
 public enum ResponseCodeAndMessages implements CodeAndMessages {
-    ;
+
+    REVIEW_CREATED("T-R001", "리뷰 생성 성공했습니다.");
+
+    private final String code;
+    private final String message;
+
+    ResponseCodeAndMessages(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
 
     @Override
     public String getCode() {
-        return null;
+        return code;
     }
 
     @Override
     public String getMessage() {
-        return null;
+        return message;
     }
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/domain/BaseTimeEntity.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/domain/BaseTimeEntity.java
@@ -1,0 +1,22 @@
+package com.jjikmuk.sikdorak.common.domain;
+
+import java.time.LocalDateTime;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+	@CreatedDate
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	private LocalDateTime updatedAt;
+
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/exception/ExceptionCodeAndMessages.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/exception/ExceptionCodeAndMessages.java
@@ -1,0 +1,33 @@
+package com.jjikmuk.sikdorak.common.exception;
+
+import com.jjikmuk.sikdorak.common.CodeAndMessages;
+import com.jjikmuk.sikdorak.review.exception.InvalidReviewContentException;
+import lombok.Getter;
+
+import java.util.Arrays;
+
+@Getter
+public enum ExceptionCodeAndMessages implements CodeAndMessages {
+    NOT_FOUND_ERROR_CODE("F-G001", "에러 코드를 찾을 수 없습니다.", NotFoundErrorCodeException.class),
+
+    // Review
+    INVALID_REVIEW_CONTENT("F-R001", "유효하지 않은 리뷰 컨텐츠 입니다.", InvalidReviewContentException.class);
+
+    private final String code;
+
+    private final String message;
+    private final Class<? extends Exception> type;
+
+    ExceptionCodeAndMessages(String code, String message, Class<? extends Exception> type) {
+        this.code = code;
+        this.message = message;
+        this.type = type;
+    }
+
+    public static ExceptionCodeAndMessages findByExceptionClass(Class<? extends Exception> type) {
+        return Arrays.stream(values())
+                .filter(codeAndMessage -> codeAndMessage.type.equals(type))
+                .findAny()
+                .orElseThrow(NotFoundErrorCodeException::new);
+    }
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/exception/ExceptionCodeAndMessages.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/exception/ExceptionCodeAndMessages.java
@@ -5,6 +5,7 @@ import com.jjikmuk.sikdorak.review.exception.InvalidReviewContentException;
 import com.jjikmuk.sikdorak.review.exception.InvalidReviewScoreException;
 import com.jjikmuk.sikdorak.review.exception.InvalidReviewVisibilityException;
 import com.jjikmuk.sikdorak.review.exception.InvalidReviewVisitedDateException;
+import com.jjikmuk.sikdorak.store.exception.StoreNotFoundException;
 import lombok.Getter;
 
 import java.util.Arrays;
@@ -17,7 +18,10 @@ public enum ExceptionCodeAndMessages implements CodeAndMessages {
     INVALID_REVIEW_CONTENT("F-R001", "유효하지 않은 리뷰 컨텐츠 입니다.", InvalidReviewContentException.class),
     INVALID_REVIEW_SCORE("F-R002", "유효하지 않은 리뷰 평점 입니다.", InvalidReviewScoreException.class),
     INVALID_REVIEW_VISIBILITY("F-R003", "유효하지 않은 리뷰 공개 범위 입니다.", InvalidReviewVisibilityException .class),
-    INVALID_REVIEW_VISITEDDATE("F-R004", "유효하지 않은 방문일자 입니다.", InvalidReviewVisitedDateException.class);
+    INVALID_REVIEW_VISITEDDATE("F-R004", "유효하지 않은 방문일자 입니다.", InvalidReviewVisitedDateException.class),
+
+    // Store
+    NOT_FOUND_STORE("F-S001", "Store Id를 찾을 수 없습니다.", StoreNotFoundException.class);
 
     private final String code;
 

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/exception/ExceptionCodeAndMessages.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/exception/ExceptionCodeAndMessages.java
@@ -2,6 +2,7 @@ package com.jjikmuk.sikdorak.common.exception;
 
 import com.jjikmuk.sikdorak.common.CodeAndMessages;
 import com.jjikmuk.sikdorak.review.exception.InvalidReviewContentException;
+import com.jjikmuk.sikdorak.review.exception.InvalidReviewScoreException;
 import lombok.Getter;
 
 import java.util.Arrays;
@@ -11,7 +12,8 @@ public enum ExceptionCodeAndMessages implements CodeAndMessages {
     NOT_FOUND_ERROR_CODE("F-G001", "에러 코드를 찾을 수 없습니다.", NotFoundErrorCodeException.class),
 
     // Review
-    INVALID_REVIEW_CONTENT("F-R001", "유효하지 않은 리뷰 컨텐츠 입니다.", InvalidReviewContentException.class);
+    INVALID_REVIEW_CONTENT("F-R001", "유효하지 않은 리뷰 컨텐츠 입니다.", InvalidReviewContentException.class),
+    INVALID_REVIEW_SCORE("F-R002", "유효하지 않은 리뷰 평점 입니다.",InvalidReviewScoreException .class);
 
     private final String code;
 

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/exception/ExceptionCodeAndMessages.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/exception/ExceptionCodeAndMessages.java
@@ -4,6 +4,7 @@ import com.jjikmuk.sikdorak.common.CodeAndMessages;
 import com.jjikmuk.sikdorak.review.exception.InvalidReviewContentException;
 import com.jjikmuk.sikdorak.review.exception.InvalidReviewScoreException;
 import com.jjikmuk.sikdorak.review.exception.InvalidReviewVisibilityException;
+import com.jjikmuk.sikdorak.review.exception.InvalidReviewVisitedDateException;
 import lombok.Getter;
 
 import java.util.Arrays;
@@ -14,8 +15,9 @@ public enum ExceptionCodeAndMessages implements CodeAndMessages {
 
     // Review
     INVALID_REVIEW_CONTENT("F-R001", "유효하지 않은 리뷰 컨텐츠 입니다.", InvalidReviewContentException.class),
-    INVALID_REVIEW_SCORE("F-R002", "유효하지 않은 리뷰 평점 입니다.",InvalidReviewScoreException.class),
-    INVALID_REVIEW_VISIBILITY("F-R003", "유효하지 않은 리뷰 공개 범위 입니다.",InvalidReviewVisibilityException .class);
+    INVALID_REVIEW_SCORE("F-R002", "유효하지 않은 리뷰 평점 입니다.", InvalidReviewScoreException.class),
+    INVALID_REVIEW_VISIBILITY("F-R003", "유효하지 않은 리뷰 공개 범위 입니다.", InvalidReviewVisibilityException .class),
+    INVALID_REVIEW_VISITEDDATE("F-R004", "유효하지 않은 방문일자 입니다.", InvalidReviewVisitedDateException.class);
 
     private final String code;
 

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/exception/ExceptionCodeAndMessages.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/exception/ExceptionCodeAndMessages.java
@@ -3,6 +3,7 @@ package com.jjikmuk.sikdorak.common.exception;
 import com.jjikmuk.sikdorak.common.CodeAndMessages;
 import com.jjikmuk.sikdorak.review.exception.InvalidReviewContentException;
 import com.jjikmuk.sikdorak.review.exception.InvalidReviewScoreException;
+import com.jjikmuk.sikdorak.review.exception.InvalidReviewVisibilityException;
 import lombok.Getter;
 
 import java.util.Arrays;
@@ -13,7 +14,8 @@ public enum ExceptionCodeAndMessages implements CodeAndMessages {
 
     // Review
     INVALID_REVIEW_CONTENT("F-R001", "유효하지 않은 리뷰 컨텐츠 입니다.", InvalidReviewContentException.class),
-    INVALID_REVIEW_SCORE("F-R002", "유효하지 않은 리뷰 평점 입니다.",InvalidReviewScoreException .class);
+    INVALID_REVIEW_SCORE("F-R002", "유효하지 않은 리뷰 평점 입니다.",InvalidReviewScoreException.class),
+    INVALID_REVIEW_VISIBILITY("F-R003", "유효하지 않은 리뷰 공개 범위 입니다.",InvalidReviewVisibilityException .class);
 
     private final String code;
 

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/exception/ExceptionCodeAndMessages.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/exception/ExceptionCodeAndMessages.java
@@ -5,6 +5,7 @@ import com.jjikmuk.sikdorak.review.exception.InvalidReviewContentException;
 import com.jjikmuk.sikdorak.review.exception.InvalidReviewScoreException;
 import com.jjikmuk.sikdorak.review.exception.InvalidReviewVisibilityException;
 import com.jjikmuk.sikdorak.review.exception.InvalidReviewVisitedDateException;
+import com.jjikmuk.sikdorak.review.exception.InvalidTagException;
 import com.jjikmuk.sikdorak.review.exception.InvalidTagsException;
 import com.jjikmuk.sikdorak.store.exception.StoreNotFoundException;
 import lombok.Getter;
@@ -21,6 +22,7 @@ public enum ExceptionCodeAndMessages implements CodeAndMessages {
     INVALID_REVIEW_VISIBILITY("F-R003", "유효하지 않은 리뷰 공개 범위 입니다.", InvalidReviewVisibilityException .class),
     INVALID_REVIEW_VISITEDDATE("F-R004", "유효하지 않은 방문일자 입니다.", InvalidReviewVisitedDateException.class),
     INVALID_REVIEW_TAGS("F-R005", "유효하지 않은 태그들 입니다.", InvalidTagsException.class),
+    INVALID_REVIEW_TAG("F-R006", "유효하지 않은 태그 입니다.", InvalidTagException.class),
 
     // Store
     NOT_FOUND_STORE("F-S001", "Store Id를 찾을 수 없습니다.", StoreNotFoundException.class);

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/exception/ExceptionCodeAndMessages.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/exception/ExceptionCodeAndMessages.java
@@ -5,6 +5,7 @@ import com.jjikmuk.sikdorak.review.exception.InvalidReviewContentException;
 import com.jjikmuk.sikdorak.review.exception.InvalidReviewScoreException;
 import com.jjikmuk.sikdorak.review.exception.InvalidReviewVisibilityException;
 import com.jjikmuk.sikdorak.review.exception.InvalidReviewVisitedDateException;
+import com.jjikmuk.sikdorak.review.exception.InvalidTagsException;
 import com.jjikmuk.sikdorak.store.exception.StoreNotFoundException;
 import lombok.Getter;
 
@@ -19,6 +20,7 @@ public enum ExceptionCodeAndMessages implements CodeAndMessages {
     INVALID_REVIEW_SCORE("F-R002", "유효하지 않은 리뷰 평점 입니다.", InvalidReviewScoreException.class),
     INVALID_REVIEW_VISIBILITY("F-R003", "유효하지 않은 리뷰 공개 범위 입니다.", InvalidReviewVisibilityException .class),
     INVALID_REVIEW_VISITEDDATE("F-R004", "유효하지 않은 방문일자 입니다.", InvalidReviewVisitedDateException.class),
+    INVALID_REVIEW_TAGS("F-R005", "유효하지 않은 태그들 입니다.", InvalidTagsException.class),
 
     // Store
     NOT_FOUND_STORE("F-S001", "Store Id를 찾을 수 없습니다.", StoreNotFoundException.class);

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/exception/GlobalExceptionHandler.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/exception/GlobalExceptionHandler.java
@@ -2,11 +2,13 @@ package com.jjikmuk.sikdorak.common.exception;
 
 import com.jjikmuk.sikdorak.common.BaseResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    @ExceptionHandler(SikdorakRuntimeException.class)
     public ResponseEntity<BaseResponse> handle(SikdorakRuntimeException exception) {
         ExceptionCodeAndMessages codeAndMessages = exception.getCodeAndMessages();
 

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/exception/GlobalExceptionHandler.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,19 @@
+package com.jjikmuk.sikdorak.common.exception;
+
+import com.jjikmuk.sikdorak.common.BaseResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    public ResponseEntity<BaseResponse> handle(SikdorakRuntimeException exception) {
+        ExceptionCodeAndMessages codeAndMessages = exception.getCodeAndMessages();
+
+        return new ResponseEntity<>(
+                new BaseResponse<>(codeAndMessages.getCode(), codeAndMessages.getMessage(), null),
+                exception.getHttpStatus()
+        );
+    }
+
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/exception/GlobalExceptionHandler.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/exception/GlobalExceptionHandler.java
@@ -1,7 +1,6 @@
 package com.jjikmuk.sikdorak.common.exception;
 
-import com.jjikmuk.sikdorak.common.BaseResponse;
-import org.springframework.http.ResponseEntity;
+import com.jjikmuk.sikdorak.common.response.CommonResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -9,13 +8,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(SikdorakRuntimeException.class)
-    public ResponseEntity<BaseResponse> handle(SikdorakRuntimeException exception) {
-        ExceptionCodeAndMessages codeAndMessages = exception.getCodeAndMessages();
-
-        return new ResponseEntity<>(
-                new BaseResponse<>(codeAndMessages.getCode(), codeAndMessages.getMessage(), null),
-                exception.getHttpStatus()
-        );
+    public CommonResponseEntity<Void> handle(SikdorakRuntimeException exception) {
+        return new CommonResponseEntity<>(exception.getCodeAndMessages(), null, exception.getHttpStatus());
     }
 
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/exception/NotFoundErrorCodeException.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/exception/NotFoundErrorCodeException.java
@@ -1,0 +1,11 @@
+package com.jjikmuk.sikdorak.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class NotFoundErrorCodeException extends SikdorakRuntimeException {
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HttpStatus.INTERNAL_SERVER_ERROR;
+    }
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/exception/SikdorakRuntimeException.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/exception/SikdorakRuntimeException.java
@@ -6,7 +6,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 public abstract class SikdorakRuntimeException extends RuntimeException {
 
-    private final ExceptionCodeAndMessages codeAndMessages = ExceptionCodeAndMessages.findByExceptionClass(this.getClass());
+    private final ExceptionCodeAndMessages codeAndMessages = ExceptionCodeAndMessages.findByExceptionClass(getClass());
 
     public SikdorakRuntimeException() {
     }
@@ -14,6 +14,7 @@ public abstract class SikdorakRuntimeException extends RuntimeException {
     public SikdorakRuntimeException(Throwable cause) {
         super(cause);
     }
+
 
     public abstract HttpStatus getHttpStatus();
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/exception/SikdorakRuntimeException.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/exception/SikdorakRuntimeException.java
@@ -8,5 +8,12 @@ public abstract class SikdorakRuntimeException extends RuntimeException {
 
     private final ExceptionCodeAndMessages codeAndMessages = ExceptionCodeAndMessages.findByExceptionClass(this.getClass());
 
+    public SikdorakRuntimeException() {
+    }
+
+    public SikdorakRuntimeException(Throwable cause) {
+        super(cause);
+    }
+
     public abstract HttpStatus getHttpStatus();
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/exception/SikdorakRuntimeException.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/exception/SikdorakRuntimeException.java
@@ -1,0 +1,12 @@
+package com.jjikmuk.sikdorak.common.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public abstract class SikdorakRuntimeException extends RuntimeException {
+
+    private final ExceptionCodeAndMessages codeAndMessages = ExceptionCodeAndMessages.findByExceptionClass(this.getClass());
+
+    public abstract HttpStatus getHttpStatus();
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/response/CommonResponseEntity.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/response/CommonResponseEntity.java
@@ -1,0 +1,12 @@
+package com.jjikmuk.sikdorak.common.response;
+
+import com.jjikmuk.sikdorak.common.BaseResponse;
+import com.jjikmuk.sikdorak.common.CodeAndMessages;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+public class CommonResponseEntity<T> extends ResponseEntity<BaseResponse<T>> {
+    public CommonResponseEntity(CodeAndMessages codeAndMessages, T data, HttpStatus httpStatus) {
+        super(new BaseResponse<>(codeAndMessages.getCode(), codeAndMessages.getMessage(), data), httpStatus);
+    }
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/controller/ReviewController.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/controller/ReviewController.java
@@ -1,0 +1,20 @@
+package com.jjikmuk.sikdorak.review.controller;
+
+import com.jjikmuk.sikdorak.review.controller.request.ReviewInsertRequest;
+import javax.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ReviewController {
+
+
+	@PostMapping("/api/reviews")
+	@ResponseStatus(HttpStatus.CREATED)
+	public void insertReview(@Valid ReviewInsertRequest reviewInsertRequest) {
+
+
+	}
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/controller/ReviewController.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/controller/ReviewController.java
@@ -1,12 +1,11 @@
 package com.jjikmuk.sikdorak.review.controller;
 
-import com.jjikmuk.sikdorak.common.BaseResponse;
+import com.jjikmuk.sikdorak.common.ResponseCodeAndMessages;
+import com.jjikmuk.sikdorak.common.response.CommonResponseEntity;
 import com.jjikmuk.sikdorak.review.controller.request.ReviewInsertRequest;
 import com.jjikmuk.sikdorak.review.service.ReviewService;
-import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -15,14 +14,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class ReviewController {
 
-	private final ReviewService reviewService;
+    private final ReviewService reviewService;
 
-	@PostMapping("/api/reviews")
-	public ResponseEntity<BaseResponse<Void>> insertReview(@RequestBody ReviewInsertRequest reviewInsertRequest) {
-		reviewService.insertReview(reviewInsertRequest);
+    @PostMapping("/api/reviews")
+    public CommonResponseEntity<Void> insertReview(@RequestBody ReviewInsertRequest reviewInsertRequest) {
+        reviewService.insertReview(reviewInsertRequest);
 
-		return new ResponseEntity<>(
-			new BaseResponse<>("201", "리뷰 생성 성공했습니다.", null),
-			HttpStatus.CREATED);
-	}
+        return new CommonResponseEntity<>(ResponseCodeAndMessages.REVIEW_CREATED, null, HttpStatus.CREATED);
+    }
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/controller/ReviewController.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/controller/ReviewController.java
@@ -1,20 +1,29 @@
 package com.jjikmuk.sikdorak.review.controller;
 
+import com.jjikmuk.sikdorak.common.BaseResponse;
 import com.jjikmuk.sikdorak.review.controller.request.ReviewInsertRequest;
+import com.jjikmuk.sikdorak.store.service.StoreService;
 import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequiredArgsConstructor
 public class ReviewController {
 
+	private final StoreService storeService;
 
 	@PostMapping("/api/reviews")
-	@ResponseStatus(HttpStatus.CREATED)
-	public void insertReview(@Valid ReviewInsertRequest reviewInsertRequest) {
+	public ResponseEntity<BaseResponse<Void>> insertReview(@Valid @RequestBody ReviewInsertRequest reviewInsertRequest) {
+		if (!storeService.existsById(reviewInsertRequest.getStoreId())) {
+			return new ResponseEntity<>(new BaseResponse<>(400, "리뷰를 추가할 수 없습니다.", null),
+				HttpStatus.BAD_REQUEST);
+		}
 
-
+		return new ResponseEntity<>(HttpStatus.CREATED);
 	}
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/controller/ReviewController.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/controller/ReviewController.java
@@ -2,6 +2,8 @@ package com.jjikmuk.sikdorak.review.controller;
 
 import com.jjikmuk.sikdorak.common.BaseResponse;
 import com.jjikmuk.sikdorak.review.controller.request.ReviewInsertRequest;
+import com.jjikmuk.sikdorak.review.controller.response.ReviewInsertResponse;
+import com.jjikmuk.sikdorak.review.service.ReviewService;
 import com.jjikmuk.sikdorak.store.service.StoreService;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -16,14 +18,17 @@ import org.springframework.web.bind.annotation.RestController;
 public class ReviewController {
 
 	private final StoreService storeService;
+	private final ReviewService reviewService;
 
 	@PostMapping("/api/reviews")
-	public ResponseEntity<BaseResponse<Void>> insertReview(@Valid @RequestBody ReviewInsertRequest reviewInsertRequest) {
+	public ResponseEntity<BaseResponse<ReviewInsertResponse>> insertReview(@Valid @RequestBody ReviewInsertRequest reviewInsertRequest) {
 		if (!storeService.existsById(reviewInsertRequest.getStoreId())) {
-			return new ResponseEntity<>(new BaseResponse<>(400, "리뷰를 추가할 수 없습니다.", null),
+			return new ResponseEntity<>(new BaseResponse<>("400", "리뷰를 추가할 수 없습니다.", null),
 				HttpStatus.BAD_REQUEST);
 		}
 
-		return new ResponseEntity<>(HttpStatus.CREATED);
+		return new ResponseEntity<>(
+			new BaseResponse<>("201", "리뷰 생성 성공했습니다.", reviewService.insertReview(reviewInsertRequest)),
+			HttpStatus.CREATED);
 	}
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/controller/ReviewController.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/controller/ReviewController.java
@@ -2,9 +2,7 @@ package com.jjikmuk.sikdorak.review.controller;
 
 import com.jjikmuk.sikdorak.common.BaseResponse;
 import com.jjikmuk.sikdorak.review.controller.request.ReviewInsertRequest;
-import com.jjikmuk.sikdorak.review.controller.response.ReviewInsertResponse;
 import com.jjikmuk.sikdorak.review.service.ReviewService;
-import com.jjikmuk.sikdorak.store.service.StoreService;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -17,18 +15,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class ReviewController {
 
-	private final StoreService storeService;
 	private final ReviewService reviewService;
 
 	@PostMapping("/api/reviews")
-	public ResponseEntity<BaseResponse<ReviewInsertResponse>> insertReview(@Valid @RequestBody ReviewInsertRequest reviewInsertRequest) {
-		if (!storeService.existsById(reviewInsertRequest.getStoreId())) {
-			return new ResponseEntity<>(new BaseResponse<>("400", "리뷰를 추가할 수 없습니다.", null),
-				HttpStatus.BAD_REQUEST);
-		}
+	public ResponseEntity<BaseResponse<Void>> insertReview(@RequestBody ReviewInsertRequest reviewInsertRequest) {
+		reviewService.insertReview(reviewInsertRequest);
 
 		return new ResponseEntity<>(
-			new BaseResponse<>("201", "리뷰 생성 성공했습니다.", reviewService.insertReview(reviewInsertRequest)),
+			new BaseResponse<>("201", "리뷰 생성 성공했습니다.", null),
 			HttpStatus.CREATED);
 	}
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/controller/request/ReviewInsertRequest.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/controller/request/ReviewInsertRequest.java
@@ -1,7 +1,9 @@
 package com.jjikmuk.sikdorak.review.controller.request;
 
+import java.time.LocalDate;
 import java.util.List;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.PastOrPresent;
 import javax.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -22,6 +24,10 @@ public class ReviewInsertRequest {
 
 	@NotNull
 	private String reviewVisibility;
+
+	@NotNull
+	@PastOrPresent
+	private LocalDate visitedDate;
 
 	private List<String> tags;
 

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/controller/request/ReviewInsertRequest.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/controller/request/ReviewInsertRequest.java
@@ -1,32 +1,23 @@
 package com.jjikmuk.sikdorak.review.controller.request;
 
-import java.time.LocalDate;
-import java.util.List;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.PastOrPresent;
-import javax.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor
 public class ReviewInsertRequest {
 
-	@NotNull
-	@Size(min = 1, max = 500)
 	private String reviewContent;
 
-	@NotNull
 	private Long storeId;
 
-	@NotNull
 	private Float reviewScore;
 
-	@NotNull
 	private String reviewVisibility;
 
-	@NotNull
-	@PastOrPresent
 	private LocalDate visitedDate;
 
 	private List<String> tags;

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/controller/request/ReviewInsertRequest.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/controller/request/ReviewInsertRequest.java
@@ -1,0 +1,29 @@
+package com.jjikmuk.sikdorak.review.controller.request;
+
+import java.util.List;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ReviewInsertRequest {
+
+	@NotNull
+	@Size(min = 1, max = 500)
+	private String reviewContent;
+
+	@NotNull
+	private Long storeId;
+
+	@NotNull
+	private Float reviewScore;
+
+	@NotNull
+	private String reviewVisibility;
+
+	private List<String> tags;
+
+	private List<String> images;
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/controller/response/ReviewInsertResponse.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/controller/response/ReviewInsertResponse.java
@@ -1,0 +1,8 @@
+package com.jjikmuk.sikdorak.review.controller.response;
+
+import lombok.Getter;
+
+@Getter
+public class ReviewInsertResponse {
+
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/domain/Review.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/domain/Review.java
@@ -1,0 +1,38 @@
+package com.jjikmuk.sikdorak.review.domain;
+
+import java.time.LocalDate;
+import java.util.List;
+import javax.persistence.Column;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+public class Review {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "reviewId")
+	private Long id;
+
+	private Long storeId;
+
+	@Embedded
+	private ReviewContent reviewContent;
+
+	@Embedded
+	private ReviewScore reviewScore;
+
+	private String reviewVisibility;
+
+	private LocalDate visitedDate;
+
+	private List<String> tags;
+
+	private List<String> images;
+
+
+
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/domain/Review.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/domain/Review.java
@@ -1,6 +1,7 @@
 package com.jjikmuk.sikdorak.review.domain;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.Embedded;
@@ -37,7 +38,8 @@ public class Review {
 	private ReviewVisitedDate visitedDate;
 
 	@Embedded
-	private Tags tags;
+	private Tags tags = new Tags();
+
 //	private List<String> tags;
 
 	@Transient

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/domain/Review.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/domain/Review.java
@@ -22,7 +22,8 @@ public class Review {
 	@Embedded
 	private ReviewContent reviewContent;
 
-	private String reviewScore;
+	@Embedded
+	private ReviewScore reviewScore;
 
 	private String reviewVisibility;
 

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/domain/Review.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/domain/Review.java
@@ -36,8 +36,9 @@ public class Review {
 	@Embedded
 	private ReviewVisitedDate visitedDate;
 
-	@Transient
-	private List<String> tags;
+	@Embedded
+	private Tags tags;
+//	private List<String> tags;
 
 	@Transient
 	private List<String> images;
@@ -51,7 +52,7 @@ public class Review {
 		this.reviewScore = new ReviewScore(reviewScore);
 		this.reviewVisibility = ReviewVisibility.create(reviewVisibility);
 		this.visitedDate = new ReviewVisitedDate(visitedDate);
-		this.tags = tags;
+		this.tags = new Tags(tags);
 		this.images = images;
 	}
 

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/domain/Review.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/domain/Review.java
@@ -22,16 +22,14 @@ public class Review {
 	@Embedded
 	private ReviewContent reviewContent;
 
-	@Embedded
-	private ReviewScore reviewScore;
+	private String reviewScore;
 
 	private String reviewVisibility;
 
 	private LocalDate visitedDate;
 
-	private List<String> tags;
-
-	private List<String> images;
+//	private List<String> tags;
+//	private List<String> images;
 
 
 

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/domain/Review.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/domain/Review.java
@@ -1,5 +1,6 @@
 package com.jjikmuk.sikdorak.review.domain;
 
+import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
@@ -8,6 +9,7 @@ import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Transient;
 import lombok.NoArgsConstructor;
 
 @Entity
@@ -33,14 +35,29 @@ public class Review {
 	@Embedded
 	private ReviewVisitedDate visitedDate;
 
-	public Review(Long id) {
+	@Transient
+	private List<String> tags;
+
+	@Transient
+	private List<String> images;
+
+	public Review(Long id, Long storeId, ReviewContent reviewContent,
+		ReviewScore reviewScore, ReviewVisibility reviewVisibility,
+		ReviewVisitedDate visitedDate, List<String> tags, List<String> images) {
 		this.id = id;
-		ReviewVisibility.valueOf("asdf");
+		this.storeId = storeId;
+		this.reviewContent = reviewContent;
+		this.reviewScore = reviewScore;
+		this.reviewVisibility = reviewVisibility;
+		this.visitedDate = visitedDate;
+		this.tags = tags;
+		this.images = images;
 	}
 
-	//	private List<String> tags;
-//	private List<String> images;
-
-
-
+	public Review(Long storeId, ReviewContent reviewContent,
+		ReviewScore reviewScore, ReviewVisibility reviewVisibility,
+		ReviewVisitedDate visitedDate, List<String> tags, List<String> images) {
+		this(null, storeId, reviewContent, reviewScore, reviewVisibility, visitedDate, tags,
+			images);
+	}
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/domain/Review.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/domain/Review.java
@@ -1,5 +1,6 @@
 package com.jjikmuk.sikdorak.review.domain;
 
+import java.time.LocalDate;
 import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.Embedded;
@@ -41,22 +42,22 @@ public class Review {
 	@Transient
 	private List<String> images;
 
-	public Review(Long id, Long storeId, ReviewContent reviewContent,
-		ReviewScore reviewScore, ReviewVisibility reviewVisibility,
-		ReviewVisitedDate visitedDate, List<String> tags, List<String> images) {
+	public Review(Long id, Long storeId, String reviewContent, Float reviewScore,
+		String reviewVisibility,
+		LocalDate visitedDate, List<String> tags, List<String> images) {
 		this.id = id;
 		this.storeId = storeId;
-		this.reviewContent = reviewContent;
-		this.reviewScore = reviewScore;
-		this.reviewVisibility = reviewVisibility;
-		this.visitedDate = visitedDate;
+		this.reviewContent = new ReviewContent(reviewContent);
+		this.reviewScore = new ReviewScore(reviewScore);
+		this.reviewVisibility = ReviewVisibility.create(reviewVisibility);
+		this.visitedDate = new ReviewVisitedDate(visitedDate);
 		this.tags = tags;
 		this.images = images;
 	}
 
-	public Review(Long storeId, ReviewContent reviewContent,
-		ReviewScore reviewScore, ReviewVisibility reviewVisibility,
-		ReviewVisitedDate visitedDate, List<String> tags, List<String> images) {
+
+	public Review(Long storeId, String reviewContent, Float reviewScore, String reviewVisibility,
+		LocalDate visitedDate, List<String> tags, List<String> images) {
 		this(null, storeId, reviewContent, reviewScore, reviewVisibility, visitedDate, tags,
 			images);
 	}

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/domain/Review.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/domain/Review.java
@@ -5,6 +5,8 @@ import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
@@ -25,11 +27,17 @@ public class Review {
 	@Embedded
 	private ReviewScore reviewScore;
 
-	private String reviewVisibility;
+	@Enumerated(EnumType.STRING)
+	private ReviewVisibility reviewVisibility;
 
 	private LocalDate visitedDate;
 
-//	private List<String> tags;
+	public Review(Long id) {
+		this.id = id;
+		ReviewVisibility.valueOf("asdf");
+	}
+
+	//	private List<String> tags;
 //	private List<String> images;
 
 

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/domain/Review.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/domain/Review.java
@@ -1,7 +1,5 @@
 package com.jjikmuk.sikdorak.review.domain;
 
-import java.time.LocalDate;
-import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
@@ -10,8 +8,10 @@ import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import lombok.NoArgsConstructor;
 
 @Entity
+@NoArgsConstructor
 public class Review {
 
 	@Id
@@ -30,7 +30,8 @@ public class Review {
 	@Enumerated(EnumType.STRING)
 	private ReviewVisibility reviewVisibility;
 
-	private LocalDate visitedDate;
+	@Embedded
+	private ReviewVisitedDate visitedDate;
 
 	public Review(Long id) {
 		this.id = id;

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/domain/Review.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/domain/Review.java
@@ -1,7 +1,7 @@
 package com.jjikmuk.sikdorak.review.domain;
 
+import com.jjikmuk.sikdorak.common.domain.BaseTimeEntity;
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.Embedded;
@@ -16,7 +16,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor
-public class Review {
+public class Review extends BaseTimeEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -39,8 +39,6 @@ public class Review {
 
 	@Embedded
 	private Tags tags = new Tags();
-
-//	private List<String> tags;
 
 	@Transient
 	private List<String> images;

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/domain/ReviewContent.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/domain/ReviewContent.java
@@ -1,0 +1,29 @@
+package com.jjikmuk.sikdorak.review.domain;
+
+import java.util.Objects;
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+
+import com.jjikmuk.sikdorak.review.exception.InvalidReviewContentException;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReviewContent {
+
+	private static final int LIMIT_LENGTH = 500;
+
+	@Column(length = LIMIT_LENGTH)
+	private String reviewContent;
+
+	public ReviewContent(String reviewContent) {
+		if (Objects.isNull(reviewContent) ||
+			reviewContent.isBlank() ||
+			reviewContent.length() > LIMIT_LENGTH) {
+			throw new InvalidReviewContentException();
+		}
+
+		this.reviewContent = reviewContent;
+	}
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/domain/ReviewContent.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/domain/ReviewContent.java
@@ -6,10 +6,12 @@ import javax.persistence.Embeddable;
 
 import com.jjikmuk.sikdorak.review.exception.InvalidReviewContentException;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class ReviewContent {
 
 	private static final int LIMIT_LENGTH = 500;

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/domain/ReviewScore.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/domain/ReviewScore.java
@@ -1,0 +1,33 @@
+package com.jjikmuk.sikdorak.review.domain;
+
+import com.jjikmuk.sikdorak.review.exception.InvalidReviewScoreException;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Embeddable;
+import java.util.Objects;
+import java.util.Set;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ReviewScore {
+
+    private static final Set<Float> VALID_VALUES = Set.of(1.0f, 2.0f, 3.0f, 4.0f, 5.0f);
+
+    private Float reviewScore;
+
+    public ReviewScore(Float reviewScore) {
+        if (Objects.isNull(reviewScore) ||
+                !validateReviewScore(reviewScore)) {
+            throw new InvalidReviewScoreException();
+        }
+
+        this.reviewScore = reviewScore;
+    }
+
+    private boolean validateReviewScore(Float reviewScore) {
+        return VALID_VALUES.contains(reviewScore);
+    }
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/domain/ReviewVisibility.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/domain/ReviewVisibility.java
@@ -8,7 +8,7 @@ public enum ReviewVisibility {
     public static ReviewVisibility create(String visibility) {
         try {
             return valueOf(visibility.toUpperCase());
-        } catch (IllegalArgumentException e) {
+        } catch (IllegalArgumentException | NullPointerException e) {
             throw new InvalidReviewVisibilityException(e);
         }
     }

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/domain/ReviewVisibility.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/domain/ReviewVisibility.java
@@ -1,0 +1,15 @@
+package com.jjikmuk.sikdorak.review.domain;
+
+import com.jjikmuk.sikdorak.review.exception.InvalidReviewVisibilityException;
+
+public enum ReviewVisibility {
+    PUBLIC ,PROTECTED, PRIVATE;
+
+    public static ReviewVisibility create(String visibility) {
+        try {
+            return valueOf(visibility.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new InvalidReviewVisibilityException(e);
+        }
+    }
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/domain/ReviewVisitedDate.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/domain/ReviewVisitedDate.java
@@ -1,0 +1,41 @@
+package com.jjikmuk.sikdorak.review.domain;
+
+import com.jjikmuk.sikdorak.review.exception.InvalidReviewVisitedDateException;
+import java.time.LocalDate;
+import java.util.Objects;
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ReviewVisitedDate {
+
+	@Column
+	private LocalDate reviewVisitedDate;
+	private LocalDate currentDate;
+
+
+	public ReviewVisitedDate(LocalDate reviewVisitedDate, LocalDate currentDate) {
+		if (Objects.isNull(reviewVisitedDate) ||
+			Objects.isNull(currentDate) ||
+			!validateReviewVisitedDate(reviewVisitedDate, currentDate)) {
+			throw new InvalidReviewVisitedDateException();
+		}
+
+		this.reviewVisitedDate = reviewVisitedDate;
+	}
+
+	public ReviewVisitedDate(LocalDate reviewVisitedDate) {
+		this(reviewVisitedDate, LocalDate.now());
+	}
+
+
+	private boolean validateReviewVisitedDate(LocalDate reviewVisitedDate,
+		LocalDate currentDate) {
+		return currentDate.isEqual(reviewVisitedDate) || currentDate.isAfter(reviewVisitedDate);
+	}
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/domain/Tag.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/domain/Tag.java
@@ -1,52 +1,44 @@
 package com.jjikmuk.sikdorak.review.domain;
 
 import com.jjikmuk.sikdorak.review.exception.InvalidTagException;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode(of = "text")
 public class Tag {
 
-	public static final int LIMIT_LENGTH = 50;
-	private final String tag;
+    public static final int LIMIT_LENGTH = 50;
+    @Column(name = "tag_text")
+    private String text;
 
-	public Tag(String tag) {
+    public Tag(String text) {
 
-		if (Objects.isNull(tag) ||
-			tag.isBlank() ||
-			tag.length() > LIMIT_LENGTH ||
-			hasSymbols(tag)) {
-			throw new InvalidTagException();
-		}
+        if (Objects.isNull(text) ||
+                text.isBlank() ||
+                text.length() > LIMIT_LENGTH ||
+                hasSymbols(text)) {
+            throw new InvalidTagException();
+        }
 
-		this.tag = tag.toLowerCase(Locale.ROOT);
-	}
+        this.text = text.toLowerCase(Locale.ROOT);
+    }
 
-	private boolean hasSymbols(String tag) {
-		Pattern compile = Pattern.compile("[\\s!@#$%^&*\\+\\-(),.?\":{}|<>]");
-		Matcher matcher = compile.matcher(tag);
-		return matcher.find();
-	}
-
-	@Override
-	public boolean equals(Object o) {
-		if (this == o) {
-			return true;
-		}
-		if (o == null || getClass() != o.getClass()) {
-			return false;
-		}
-		Tag tag1 = (Tag) o;
-		return tag.equals(tag1.tag);
-	}
-
-	@Override
-	public int hashCode() {
-		return Objects.hash(tag);
-	}
-
-	public String getText() {
-		return tag;
-	}
+    private boolean hasSymbols(String tag) {
+        Pattern compile = Pattern.compile("[\\s!@#$%^&*\\+\\-(),.?\":{}|<>]");
+        Matcher matcher = compile.matcher(tag);
+        return matcher.find();
+    }
+    public String getText() {
+        return text;
+    }
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/domain/Tag.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/domain/Tag.java
@@ -1,0 +1,25 @@
+package com.jjikmuk.sikdorak.review.domain;
+
+import java.util.Objects;
+
+public class Tag {
+
+	private final String tag;
+
+	public Tag(String tag) {
+		this.tag = tag;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		Tag tag1 = (Tag) o;
+		return tag.equals(tag1.tag);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(tag);
+	}
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/domain/Tag.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/domain/Tag.java
@@ -1,19 +1,42 @@
 package com.jjikmuk.sikdorak.review.domain;
 
+import com.jjikmuk.sikdorak.review.exception.InvalidTagException;
+import java.util.Locale;
 import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class Tag {
 
+	public static final int LIMIT_LENGTH = 50;
 	private final String tag;
 
 	public Tag(String tag) {
-		this.tag = tag;
+
+		if (Objects.isNull(tag) ||
+			tag.isBlank() ||
+			tag.length() > LIMIT_LENGTH ||
+			hasSymbols(tag)) {
+			throw new InvalidTagException();
+		}
+
+		this.tag = tag.toLowerCase(Locale.ROOT);
+	}
+
+	private boolean hasSymbols(String tag) {
+		Pattern compile = Pattern.compile("[\\s!@#$%^&*\\+\\-(),.?\":{}|<>]");
+		Matcher matcher = compile.matcher(tag);
+		return matcher.find();
 	}
 
 	@Override
 	public boolean equals(Object o) {
-		if (this == o) return true;
-		if (o == null || getClass() != o.getClass()) return false;
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
 		Tag tag1 = (Tag) o;
 		return tag.equals(tag1.tag);
 	}
@@ -21,5 +44,9 @@ public class Tag {
 	@Override
 	public int hashCode() {
 		return Objects.hash(tag);
+	}
+
+	public String getText() {
+		return tag;
 	}
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/domain/Tags.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/domain/Tags.java
@@ -1,20 +1,26 @@
 package com.jjikmuk.sikdorak.review.domain;
 
 import com.jjikmuk.sikdorak.review.exception.InvalidTagsException;
+import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.Embeddable;
+import javax.persistence.*;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 @Embeddable
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Tags {
 
     private static final int LIMIT_SIZE = 30;
 
+    @ElementCollection
+    @CollectionTable(
+            name = "review_tags",
+            joinColumns = @JoinColumn(name = "review_id")
+    )
     private Set<Tag> tags;
 
     public Tags(List<String> tags) {

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/domain/Tags.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/domain/Tags.java
@@ -1,0 +1,39 @@
+package com.jjikmuk.sikdorak.review.domain;
+
+import com.jjikmuk.sikdorak.review.exception.InvalidTagsException;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Embeddable;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Embeddable
+@NoArgsConstructor
+public class Tags {
+
+    private static final int LIMIT_SIZE = 30;
+
+    private Set<Tag> tags;
+
+    public Tags(List<String> tags) {
+        if (Objects.isNull(tags)) {
+            throw new InvalidTagsException();
+        }
+
+        Set<Tag> filteredTags = tags.stream()
+                .map(Tag::new)
+                .collect(Collectors.toSet());
+
+        if (filteredTags.size() > LIMIT_SIZE) {
+            throw new InvalidTagsException();
+        }
+
+        this.tags = filteredTags;
+    }
+
+    public int size() {
+        return tags.size();
+    }
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/exception/InvalidReviewContentException.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/exception/InvalidReviewContentException.java
@@ -1,0 +1,12 @@
+package com.jjikmuk.sikdorak.review.exception;
+
+import com.jjikmuk.sikdorak.common.exception.SikdorakRuntimeException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidReviewContentException extends SikdorakRuntimeException {
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HttpStatus.BAD_REQUEST;
+    }
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/exception/InvalidReviewScoreException.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/exception/InvalidReviewScoreException.java
@@ -1,0 +1,12 @@
+package com.jjikmuk.sikdorak.review.exception;
+
+import com.jjikmuk.sikdorak.common.exception.SikdorakRuntimeException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidReviewScoreException extends SikdorakRuntimeException {
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HttpStatus.BAD_REQUEST;
+    }
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/exception/InvalidReviewVisibilityException.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/exception/InvalidReviewVisibilityException.java
@@ -1,0 +1,16 @@
+package com.jjikmuk.sikdorak.review.exception;
+
+import com.jjikmuk.sikdorak.common.exception.SikdorakRuntimeException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidReviewVisibilityException extends SikdorakRuntimeException {
+
+    public InvalidReviewVisibilityException(Throwable cause) {
+        super(cause);
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HttpStatus.BAD_REQUEST;
+    }
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/exception/InvalidReviewVisitedDateException.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/exception/InvalidReviewVisitedDateException.java
@@ -1,0 +1,11 @@
+package com.jjikmuk.sikdorak.review.exception;
+
+import com.jjikmuk.sikdorak.common.exception.SikdorakRuntimeException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidReviewVisitedDateException extends SikdorakRuntimeException {
+
+	public HttpStatus getHttpStatus() {
+		return HttpStatus.BAD_REQUEST;
+	}
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/exception/InvalidTagException.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/exception/InvalidTagException.java
@@ -1,0 +1,12 @@
+package com.jjikmuk.sikdorak.review.exception;
+
+import com.jjikmuk.sikdorak.common.exception.SikdorakRuntimeException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidTagException extends SikdorakRuntimeException {
+
+	@Override
+	public HttpStatus getHttpStatus() {
+		return HttpStatus.BAD_REQUEST;
+	}
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/exception/InvalidTagsException.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/exception/InvalidTagsException.java
@@ -1,0 +1,11 @@
+package com.jjikmuk.sikdorak.review.exception;
+
+import com.jjikmuk.sikdorak.common.exception.SikdorakRuntimeException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidTagsException extends SikdorakRuntimeException {
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HttpStatus.BAD_REQUEST;
+    }
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/repository/ReviewRepository.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/repository/ReviewRepository.java
@@ -1,0 +1,7 @@
+package com.jjikmuk.sikdorak.review.repository;
+
+import com.jjikmuk.sikdorak.review.domain.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/service/ReviewService.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/service/ReviewService.java
@@ -1,0 +1,13 @@
+package com.jjikmuk.sikdorak.review.service;
+
+import com.jjikmuk.sikdorak.review.controller.request.ReviewInsertRequest;
+import com.jjikmuk.sikdorak.review.controller.response.ReviewInsertResponse;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ReviewService {
+
+	public ReviewInsertResponse insertReview(ReviewInsertRequest reviewInsertRequest) {
+		throw new UnsupportedOperationException("ReviewService#insertReview 아직 구현하지 않음 :)");
+	}
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/service/ReviewService.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/service/ReviewService.java
@@ -1,13 +1,37 @@
 package com.jjikmuk.sikdorak.review.service;
 
 import com.jjikmuk.sikdorak.review.controller.request.ReviewInsertRequest;
-import com.jjikmuk.sikdorak.review.controller.response.ReviewInsertResponse;
+import com.jjikmuk.sikdorak.review.domain.Review;
+import com.jjikmuk.sikdorak.review.domain.ReviewContent;
+import com.jjikmuk.sikdorak.review.domain.ReviewScore;
+import com.jjikmuk.sikdorak.review.domain.ReviewVisibility;
+import com.jjikmuk.sikdorak.review.domain.ReviewVisitedDate;
+import com.jjikmuk.sikdorak.review.repository.ReviewRepository;
+import com.jjikmuk.sikdorak.store.service.StoreService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@RequiredArgsConstructor
 public class ReviewService {
 
-	public ReviewInsertResponse insertReview(ReviewInsertRequest reviewInsertRequest) {
-		throw new UnsupportedOperationException("ReviewService#insertReview 아직 구현하지 않음 :)");
+	private final StoreService storeService;
+	private final ReviewRepository reviewRepository;
+
+	@Transactional
+	public void insertReview(ReviewInsertRequest request) {
+		Long findStoreId = request.getStoreId();
+		storeService.findById(findStoreId);
+
+		Review newReview = new Review(request.getStoreId(),
+			new ReviewContent(request.getReviewContent()),
+			new ReviewScore(request.getReviewScore()),
+			ReviewVisibility.create(request.getReviewVisibility()),
+			new ReviewVisitedDate(request.getVisitedDate()),
+			request.getTags(),
+			request.getImages());
+
+		reviewRepository.save(newReview);
 	}
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/service/ReviewService.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/service/ReviewService.java
@@ -2,15 +2,12 @@ package com.jjikmuk.sikdorak.review.service;
 
 import com.jjikmuk.sikdorak.review.controller.request.ReviewInsertRequest;
 import com.jjikmuk.sikdorak.review.domain.Review;
-import com.jjikmuk.sikdorak.review.domain.ReviewContent;
-import com.jjikmuk.sikdorak.review.domain.ReviewScore;
-import com.jjikmuk.sikdorak.review.domain.ReviewVisibility;
-import com.jjikmuk.sikdorak.review.domain.ReviewVisitedDate;
 import com.jjikmuk.sikdorak.review.repository.ReviewRepository;
 import com.jjikmuk.sikdorak.store.service.StoreService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
 
 @Service
 @RequiredArgsConstructor
@@ -25,10 +22,10 @@ public class ReviewService {
 		storeService.findById(findStoreId);
 
 		Review newReview = new Review(request.getStoreId(),
-			new ReviewContent(request.getReviewContent()),
-			new ReviewScore(request.getReviewScore()),
-			ReviewVisibility.create(request.getReviewVisibility()),
-			new ReviewVisitedDate(request.getVisitedDate()),
+			request.getReviewContent(),
+			request.getReviewScore(),
+			request.getReviewVisibility(),
+			request.getVisitedDate(),
 			request.getTags(),
 			request.getImages());
 

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/domain/Store.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/domain/Store.java
@@ -10,6 +10,7 @@ import javax.persistence.Id;
 
 @Entity
 @Getter
+
 public class Store {
 
     @Id

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/domain/Store.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/domain/Store.java
@@ -1,5 +1,6 @@
 package com.jjikmuk.sikdorak.store.domain;
 
+import com.jjikmuk.sikdorak.common.domain.BaseTimeEntity;
 import lombok.Getter;
 
 import javax.persistence.Column;
@@ -11,7 +12,7 @@ import javax.persistence.Id;
 @Entity
 @Getter
 
-public class Store {
+public class Store extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/domain/Store.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/domain/Store.java
@@ -1,0 +1,19 @@
+package com.jjikmuk.sikdorak.store.domain;
+
+import lombok.Getter;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+@Getter
+public class Store {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "storeId")
+    private Long id;
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/exception/StoreNotFoundException.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/exception/StoreNotFoundException.java
@@ -1,0 +1,12 @@
+package com.jjikmuk.sikdorak.store.exception;
+
+import com.jjikmuk.sikdorak.common.exception.SikdorakRuntimeException;
+import org.springframework.http.HttpStatus;
+
+public class StoreNotFoundException extends SikdorakRuntimeException {
+
+	@Override
+	public HttpStatus getHttpStatus() {
+		return HttpStatus.NOT_FOUND;
+	}
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/repository/StoreRepository.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/repository/StoreRepository.java
@@ -1,0 +1,8 @@
+package com.jjikmuk.sikdorak.store.repository;
+
+import com.jjikmuk.sikdorak.store.domain.Store;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+public interface StoreRepository extends JpaRepository<Store, Long> {
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/service/StoreService.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/service/StoreService.java
@@ -1,9 +1,12 @@
 package com.jjikmuk.sikdorak.store.service;
 
 import com.jjikmuk.sikdorak.store.domain.Store;
+import com.jjikmuk.sikdorak.store.exception.StoreNotFoundException;
 import com.jjikmuk.sikdorak.store.repository.StoreRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -11,7 +14,11 @@ public class StoreService {
 
     private final StoreRepository storeRepository;
 
-    public boolean existsById(Long storeId) {
-        return storeRepository.existsById(storeId);
-    }
+	public Store findById(Long storeId) {
+		if (Objects.isNull(storeId)) {
+			throw new StoreNotFoundException();
+		}
+		return storeRepository.findById(storeId).orElseThrow(StoreNotFoundException::new);
+	}
+
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/service/StoreService.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/service/StoreService.java
@@ -1,0 +1,17 @@
+package com.jjikmuk.sikdorak.store.service;
+
+import com.jjikmuk.sikdorak.store.domain.Store;
+import com.jjikmuk.sikdorak.store.repository.StoreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class StoreService {
+
+    private final StoreRepository storeRepository;
+
+    public boolean existsById(Long storeId) {
+        return storeRepository.existsById(storeId);
+    }
+}

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/InitAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/InitAcceptanceTest.java
@@ -1,0 +1,20 @@
+package com.jjikmuk.sikdorak.acceptance;
+
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+public class InitAcceptanceTest {
+
+	@LocalServerPort
+	int port;
+
+	@BeforeEach
+	void setUp() {
+		RestAssured.port = port;
+	}
+
+}

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/InitAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/InitAcceptanceTest.java
@@ -1,20 +1,36 @@
 package com.jjikmuk.sikdorak.acceptance;
 
+import com.jjikmuk.sikdorak.store.domain.Store;
+import com.jjikmuk.sikdorak.store.repository.StoreRepository;
 import io.restassured.RestAssured;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
 
+import java.util.List;
+
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 public class InitAcceptanceTest {
+
+	@Autowired
+	StoreRepository storeRepository;
 
 	@LocalServerPort
 	int port;
 
+	Store savedStore;
+
 	@BeforeEach
 	void setUp() {
 		RestAssured.port = port;
+		savedStore = storeRepository.save(new Store());
 	}
 
+	@AfterEach
+	void tearDown() {
+		storeRepository.deleteAll();
+	}
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/ReviewAccecptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/ReviewAccecptanceTest.java
@@ -22,7 +22,7 @@ import org.springframework.http.MediaType;
  *  [x] 요청 식당 id가 유효하지 않은 경우(null, 0, -1, 등록되지 않은 값)
  *  [x] 요청 방문일이 유효하지 않은 경우(미래 날짜, 유효하지 않은 날짜 형식)
  *  [x] 요청 평점이 유효하지 않은 경우(1,2,3,4,5 가 아닌 경우)
- *  [ ] 요청 태그들이 유효하지 않은 경우(공백 포함, 한글 영어 숫자 이외의 값, 50자 초과, 개수 30개 초과)
+ *  [x] 요청 태그들이 유효하지 않은 경우(공백 포함, 한글 영어 숫자 이외의 값, 50자 초과, 개수 30개 초과)
  *  [ ] 요청 공개 범위가 유효하지 않은 경우(public, protected, private 이외의 값, null, empty)
  */
 public class ReviewAccecptanceTest extends InitAcceptanceTest {
@@ -221,8 +221,8 @@ public class ReviewAccecptanceTest extends InitAcceptanceTest {
 		return Stream.of(
 			Arguments.of(List.of("맛집", "")),
 			Arguments.of(List.of("맛집", "중간   공백")),
-			Arguments.of(List.of("맛집", "중간\\t공백")),
-			Arguments.of(List.of("맛집", "중간\\n공백")),
+			Arguments.of(List.of("맛집", "중간\t공백")),
+			Arguments.of(List.of("맛집", "중간\n공백")),
 			Arguments.of(List.of("맛집", "특수문자#")),
 			Arguments.of(List.of("맛집", "특수문자!")),
 			Arguments.of(List.of("맛집", "특수문자*")),

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/ReviewAccecptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/ReviewAccecptanceTest.java
@@ -2,21 +2,23 @@ package com.jjikmuk.sikdorak.acceptance;
 
 import static io.restassured.RestAssured.given;
 
+import java.util.stream.Stream;
 import net.minidev.json.JSONObject;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
 /**
- *  요청이 정상적인 경우 정상 상태 코드를 반환한다
- *  요청의 필수 데이터가 빠진경우(텍스트, 식당, 방문일, 평점, 공개 범위) 실패 상태 코드를 반환한다.
- *  요청 텍스트가 유효하지 않은 경우(null, empty, 500자 넘는 경우)
- *  요청 식당 id가 유효하지 않은 경우(null, 0, -1, 등록되지 않은 값)
- *  요청 방문일이 유효하지 않은 경우(미래 날짜, 유효하지 않은 날짜 형식)
- *  요청 평점이 유효하지 않은 경우(1,2,3,4,5 가 아닌 경우)
- *  요청 태그들이 유효하지 않은 경우(공백 포함, 한글 영어 숫자 이외의 값, 50자 초과, 개수 30개 초과)
- *  요청 공개 범위가 유효하지 않은 경우(public, protected, private 이외의 값, null, empty)
+ *  [x] 요청 텍스트가 유효하지 않은 경우(null, empty, 500자 넘는 경우)
+ *  [ ] 요청 식당 id가 유효하지 않은 경우(null, 0, -1, 등록되지 않은 값)
+ *  [ ] 요청 방문일이 유효하지 않은 경우(미래 날짜, 유효하지 않은 날짜 형식)
+ *  [ ] 요청 평점이 유효하지 않은 경우(1,2,3,4,5 가 아닌 경우)
+ *  [ ] 요청 태그들이 유효하지 않은 경우(공백 포함, 한글 영어 숫자 이외의 값, 50자 초과, 개수 30개 초과)
+ *  [ ] 요청 공개 범위가 유효하지 않은 경우(public, protected, private 이외의 값, null, empty)
  */
 public class ReviewAccecptanceTest extends InitAcceptanceTest {
 
@@ -29,6 +31,7 @@ public class ReviewAccecptanceTest extends InitAcceptanceTest {
 		requestBody.put("reviewScore", 4);
 		requestBody.put("reviewVisibility", "public");
 		requestBody.put("tags", new String[]{"맛집", "꿀맛"});
+		requestBody.put("images", new String[]{"https://s3.ap-northeast-2.amazonaws.com/sikdorak/test.jpg"});
 
 		given()
 			.accept(MediaType.APPLICATION_JSON_VALUE)
@@ -42,4 +45,39 @@ public class ReviewAccecptanceTest extends InitAcceptanceTest {
 			.statusCode(HttpStatus.CREATED.value());
 	}
 
+	@ParameterizedTest
+	@MethodSource("provideStringsForIsNullAndEmptyAnd500char")
+	@DisplayName("리뷰 생성 요청에서 컨텐츠가 유효하지 않은 경우라면 에러 상태 코드를 반환한다")
+	void create_review_content_invalid_failed(String content, int expectedStatusCode) {
+		JSONObject requestBody = new JSONObject();
+		requestBody.put("reviewContent", content);
+		requestBody.put("storeId", 1);
+		requestBody.put("reviewScore", 4);
+		requestBody.put("reviewVisibility", "public");
+		requestBody.put("tags", new String[]{"맛집", "꿀맛"});
+		requestBody.put("images", new String[]{"https://s3.ap-northeast-2.amazonaws.com/sikdorak/test.jpg"});
+
+		given()
+			.accept(MediaType.APPLICATION_JSON_VALUE)
+			.header("Content-type", "application/json")
+			.body(requestBody)
+
+			.when()
+			.post("/api/reviews")
+
+			.then()
+			.statusCode(expectedStatusCode);
+	}
+
+	private static Stream<Arguments> provideStringsForIsNullAndEmptyAnd500char() {
+		String content = "a";
+		return Stream.of(
+			Arguments.of(null, HttpStatus.BAD_REQUEST.value()),
+			Arguments.of("", HttpStatus.BAD_REQUEST.value()),
+			Arguments.of(" ", HttpStatus.BAD_REQUEST.value()),
+			Arguments.of("\\t", HttpStatus.BAD_REQUEST.value()),
+			Arguments.of("\\n", HttpStatus.BAD_REQUEST.value()),
+			Arguments.of(content.repeat(500), HttpStatus.BAD_REQUEST.value())
+		);
+	}
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/ReviewAccecptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/ReviewAccecptanceTest.java
@@ -22,7 +22,7 @@ import org.springframework.http.MediaType;
 /**
  *  [x] 요청 텍스트가 유효하지 않은 경우(null, empty, 500자 넘는 경우)
  *  [x] 요청 식당 id가 유효하지 않은 경우(null, 0, -1, 등록되지 않은 값)
- *  [ ] 요청 방문일이 유효하지 않은 경우(미래 날짜, 유효하지 않은 날짜 형식)
+ *  [x] 요청 방문일이 유효하지 않은 경우(미래 날짜, 유효하지 않은 날짜 형식)
  *  [ ] 요청 평점이 유효하지 않은 경우(1,2,3,4,5 가 아닌 경우)
  *  [ ] 요청 태그들이 유효하지 않은 경우(공백 포함, 한글 영어 숫자 이외의 값, 50자 초과, 개수 30개 초과)
  *  [ ] 요청 공개 범위가 유효하지 않은 경우(public, protected, private 이외의 값, null, empty)
@@ -145,7 +145,7 @@ public class ReviewAccecptanceTest extends InitAcceptanceTest {
 			Arguments.of(" ", HttpStatus.BAD_REQUEST.value()),
 			Arguments.of("\t", HttpStatus.BAD_REQUEST.value()),
 			Arguments.of("\n", HttpStatus.BAD_REQUEST.value()),
-			Arguments.of(content.repeat(500), HttpStatus.BAD_REQUEST.value())
+			Arguments.of(content.repeat(501), HttpStatus.BAD_REQUEST.value())
 		);
 	}
 
@@ -153,10 +153,10 @@ public class ReviewAccecptanceTest extends InitAcceptanceTest {
 		long unregisteredStoreId = Long.MAX_VALUE;
 
 		return Stream.of(
-			Arguments.of(null, HttpStatus.BAD_REQUEST.value()),
-			Arguments.of(0L, HttpStatus.BAD_REQUEST.value()),
-			Arguments.of(-1L, HttpStatus.BAD_REQUEST.value()),
-			Arguments.of(unregisteredStoreId, HttpStatus.BAD_REQUEST.value())
+			Arguments.of(null, HttpStatus.NOT_FOUND.value()),
+			Arguments.of(0L, HttpStatus.NOT_FOUND.value()),
+			Arguments.of(-1L, HttpStatus.NOT_FOUND.value()),
+			Arguments.of(unregisteredStoreId, HttpStatus.NOT_FOUND.value())
 		);
 	}
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/ReviewAccecptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/ReviewAccecptanceTest.java
@@ -1,0 +1,45 @@
+package com.jjikmuk.sikdorak.acceptance;
+
+import static io.restassured.RestAssured.given;
+
+import net.minidev.json.JSONObject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+/**
+ *  요청이 정상적인 경우 정상 상태 코드를 반환한다
+ *  요청의 필수 데이터가 빠진경우(텍스트, 식당, 방문일, 평점, 공개 범위) 실패 상태 코드를 반환한다.
+ *  요청 텍스트가 유효하지 않은 경우(null, empty, 500자 넘는 경우)
+ *  요청 식당 id가 유효하지 않은 경우(null, 0, -1, 등록되지 않은 값)
+ *  요청 방문일이 유효하지 않은 경우(미래 날짜, 유효하지 않은 날짜 형식)
+ *  요청 평점이 유효하지 않은 경우(1,2,3,4,5 가 아닌 경우)
+ *  요청 태그들이 유효하지 않은 경우(공백 포함, 한글 영어 숫자 이외의 값, 50자 초과, 개수 30개 초과)
+ *  요청 공개 범위가 유효하지 않은 경우(public, protected, private 이외의 값, null, empty)
+ */
+public class ReviewAccecptanceTest extends InitAcceptanceTest {
+
+	@Test
+	@DisplayName("리뷰 생성 요청이 정상적인 경우라면 리뷰 생성 후 정상 상태 코드를 반환한다")
+	void create_review_success() {
+		JSONObject requestBody = new JSONObject();
+		requestBody.put("reviewContent", "찐맛집입니다.");
+		requestBody.put("storeId", 1);
+		requestBody.put("reviewScore", 4);
+		requestBody.put("reviewVisibility", "public");
+		requestBody.put("tags", new String[]{"맛집", "꿀맛"});
+
+		given()
+			.accept(MediaType.APPLICATION_JSON_VALUE)
+			.header("Content-type", "application/json")
+			.body(requestBody)
+
+		.when()
+			.post("/api/reviews")
+
+		.then()
+			.statusCode(HttpStatus.CREATED.value());
+	}
+
+}

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/ReviewAccecptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/ReviewAccecptanceTest.java
@@ -27,7 +27,8 @@ import static org.hamcrest.Matchers.equalTo;
  *  [x] 요청 평점이 유효하지 않은 경우(1,2,3,4,5 가 아닌 경우)
  *  [x] 요청 태그들이 유효하지 않은 경우(공백 포함, 한글 영어 숫자 이외의 값, 50자 초과, 개수 30개 초과)
  *  [x] 요청 공개 범위가 유효하지 않은 경우(public, protected, private 이외의 값, null, empty)
- *  [ ]
+ *  TODO
+ *  [ ] 요청 이미지가 유효하지 않은 경우(유효하지 않은 image 경로 (유효하지 않은 URL포맷, 관리하고 있는 s3 주소))
  */
 public class ReviewAccecptanceTest extends InitAcceptanceTest {
 

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/ReviewAccecptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/ReviewAccecptanceTest.java
@@ -2,6 +2,8 @@ package com.jjikmuk.sikdorak.acceptance;
 
 import static io.restassured.RestAssured.given;
 
+import com.jjikmuk.sikdorak.store.domain.Store;
+import com.jjikmuk.sikdorak.store.repository.StoreRepository;
 import java.util.stream.Stream;
 import net.minidev.json.JSONObject;
 import org.junit.jupiter.api.DisplayName;
@@ -9,12 +11,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
 /**
  *  [x] 요청 텍스트가 유효하지 않은 경우(null, empty, 500자 넘는 경우)
- *  [ ] 요청 식당 id가 유효하지 않은 경우(null, 0, -1, 등록되지 않은 값)
+ *  [x] 요청 식당 id가 유효하지 않은 경우(null, 0, -1, 등록되지 않은 값)
  *  [ ] 요청 방문일이 유효하지 않은 경우(미래 날짜, 유효하지 않은 날짜 형식)
  *  [ ] 요청 평점이 유효하지 않은 경우(1,2,3,4,5 가 아닌 경우)
  *  [ ] 요청 태그들이 유효하지 않은 경우(공백 포함, 한글 영어 숫자 이외의 값, 50자 초과, 개수 30개 초과)
@@ -22,12 +25,16 @@ import org.springframework.http.MediaType;
  */
 public class ReviewAccecptanceTest extends InitAcceptanceTest {
 
+	@Autowired
+	StoreRepository storeRepository;
+
 	@Test
 	@DisplayName("리뷰 생성 요청이 정상적인 경우라면 리뷰 생성 후 정상 상태 코드를 반환한다")
 	void create_review_success() {
+		Store saveStore = storeRepository.save(new Store());
 		JSONObject requestBody = new JSONObject();
 		requestBody.put("reviewContent", "찐맛집입니다.");
-		requestBody.put("storeId", 1);
+		requestBody.put("storeId", saveStore.getId());
 		requestBody.put("reviewScore", 4);
 		requestBody.put("reviewVisibility", "public");
 		requestBody.put("tags", new String[]{"맛집", "꿀맛"});
@@ -38,15 +45,15 @@ public class ReviewAccecptanceTest extends InitAcceptanceTest {
 			.header("Content-type", "application/json")
 			.body(requestBody)
 
-		.when()
+			.when()
 			.post("/api/reviews")
 
-		.then()
+			.then()
 			.statusCode(HttpStatus.CREATED.value());
 	}
 
 	@ParameterizedTest
-	@MethodSource("provideStringsForIsNullAndEmptyAnd500char")
+	@MethodSource("provideContentForIsNullAndEmptyAnd500char")
 	@DisplayName("리뷰 생성 요청에서 컨텐츠가 유효하지 않은 경우라면 에러 상태 코드를 반환한다")
 	void create_review_content_invalid_failed(String content, int expectedStatusCode) {
 		JSONObject requestBody = new JSONObject();
@@ -69,7 +76,32 @@ public class ReviewAccecptanceTest extends InitAcceptanceTest {
 			.statusCode(expectedStatusCode);
 	}
 
-	private static Stream<Arguments> provideStringsForIsNullAndEmptyAnd500char() {
+	@ParameterizedTest
+	@MethodSource("provideStoreIdForIsNullAndZeroAndMinusAndUnregistered")
+	@DisplayName("리뷰 생성 요청에서 식당 id가 유효하지 않은 경우 에러 상태코드를 반환한다")
+	void create_review_storeId_invalid_failed(Long storeId, int expectedStatusCode) {
+		JSONObject requestBody = new JSONObject();
+		requestBody.put("reviewContent", "찐맛집입니다.");
+		requestBody.put("storeId", storeId);
+		requestBody.put("reviewScore", 4);
+		requestBody.put("reviewVisibility", "public");
+		requestBody.put("tags", new String[]{"맛집", "꿀맛"});
+		requestBody.put("images", new String[]{"https://s3.ap-northeast-2.amazonaws.com/sikdorak/test.jpg"});
+
+		given()
+				.accept(MediaType.APPLICATION_JSON_VALUE)
+				.header("Content-type", "application/json")
+				.body(requestBody)
+
+				.when()
+				.post("/api/reviews")
+
+				.then()
+				.statusCode(expectedStatusCode);
+
+	}
+
+	private static Stream<Arguments> provideContentForIsNullAndEmptyAnd500char() {
 		String content = "a";
 		return Stream.of(
 			Arguments.of(null, HttpStatus.BAD_REQUEST.value()),
@@ -78,6 +110,17 @@ public class ReviewAccecptanceTest extends InitAcceptanceTest {
 			Arguments.of("\\t", HttpStatus.BAD_REQUEST.value()),
 			Arguments.of("\\n", HttpStatus.BAD_REQUEST.value()),
 			Arguments.of(content.repeat(500), HttpStatus.BAD_REQUEST.value())
+		);
+	}
+
+	private static Stream<Arguments> provideStoreIdForIsNullAndZeroAndMinusAndUnregistered() {
+		long unregisteredStoreId = Long.MAX_VALUE;
+
+		return Stream.of(
+			Arguments.of(null, HttpStatus.BAD_REQUEST.value()),
+			Arguments.of(0L, HttpStatus.BAD_REQUEST.value()),
+			Arguments.of(-1L, HttpStatus.BAD_REQUEST.value()),
+			Arguments.of(unregisteredStoreId, HttpStatus.BAD_REQUEST.value())
 		);
 	}
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/ReviewAccecptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/ReviewAccecptanceTest.java
@@ -1,12 +1,5 @@
 package com.jjikmuk.sikdorak.acceptance;
 
-import static io.restassured.RestAssured.given;
-
-import com.jjikmuk.sikdorak.store.domain.Store;
-import com.jjikmuk.sikdorak.store.repository.StoreRepository;
-
-import java.time.LocalDate;
-import java.util.stream.Stream;
 import net.minidev.json.JSONObject;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,16 +7,20 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+
+import java.util.stream.Stream;
+
+import static io.restassured.RestAssured.given;
 
 /**
  *  [x] 요청 텍스트가 유효하지 않은 경우(null, empty, 500자 넘는 경우)
  *  [x] 요청 식당 id가 유효하지 않은 경우(null, 0, -1, 등록되지 않은 값)
  *  [x] 요청 방문일이 유효하지 않은 경우(미래 날짜, 유효하지 않은 날짜 형식)
- *  [ ] 요청 평점이 유효하지 않은 경우(1,2,3,4,5 가 아닌 경우)
+ *  [x] 요청 평점이 유효하지 않은 경우(1,2,3,4,5 가 아닌 경우)
  *  [ ] 요청 태그들이 유효하지 않은 경우(공백 포함, 한글 영어 숫자 이외의 값, 50자 초과, 개수 30개 초과)
  *  [ ] 요청 공개 범위가 유효하지 않은 경우(public, protected, private 이외의 값, null, empty)
  */
@@ -111,7 +108,6 @@ public class ReviewAccecptanceTest extends InitAcceptanceTest {
 			"02-01, 400"
 	})
 	@DisplayName("리뷰 생성 요청에서 방문일이 유효하지 않은 경우 에러 상태코드를 반환한다")
-	// (미래 날짜, 유효하지 않은 날짜 형식)
 	void create_review_visitedDate_invalid_failed(String localDate, int expectedStatusCode) {
 		JSONObject requestBody = new JSONObject();
 		requestBody.put("reviewContent", "찐맛집입니다.");
@@ -135,6 +131,32 @@ public class ReviewAccecptanceTest extends InitAcceptanceTest {
 				.then()
 				.statusCode(expectedStatusCode);
 
+	}
+
+	@ParameterizedTest
+	@NullSource
+	@ValueSource(floats = {0f, -1f, 1.1f, 6f})
+	@DisplayName("리뷰 생성 요청에서 평점이 유효하지 않은 경우 에러 상태코드를 반환한다")
+	void create_review_reviewScore_invalid_failed(Float reviewScore) {
+		JSONObject requestBody = new JSONObject();
+		requestBody.put("reviewContent", "찐맛집입니다.");
+		requestBody.put("storeId", savedStore.getId());
+		requestBody.put("reviewScore", reviewScore);
+		requestBody.put("reviewVisibility", "public");
+		requestBody.put("visitedDate", "2022-01-01");
+		requestBody.put("tags", new String[]{"맛집", "꿀맛"});
+		requestBody.put("images", new String[]{"https://s3.ap-northeast-2.amazonaws.com/sikdorak/test.jpg"});
+
+		given()
+				.accept(MediaType.APPLICATION_JSON_VALUE)
+				.header("Content-type", "application/json")
+				.body(requestBody)
+
+				.when()
+				.post("/api/reviews")
+
+				.then()
+				.statusCode(HttpStatus.BAD_REQUEST.value());
 	}
 
 	private static Stream<Arguments> provideContentForIsNullAndEmptyAnd500char() {

--- a/be/src/test/java/com/jjikmuk/sikdorak/review/domain/ReviewContentTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/review/domain/ReviewContentTest.java
@@ -1,0 +1,67 @@
+package com.jjikmuk.sikdorak.review.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.jjikmuk.sikdorak.review.exception.InvalidReviewContentException;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@DisplayName("ReviewContentTest 클래스")
+class ReviewContentTest {
+
+	@Nested
+	@DisplayName("생성자")
+	class Describe_constructor {
+
+	    @Nested
+	    @DisplayName("만약 정상적인 1~500자 이하의 content가 주어진다면")
+	    class Context_with_valid_content {
+
+			@ParameterizedTest
+			@ValueSource(strings = {"1", "content"})
+			@DisplayName("ReviewContent 객체를반환한다")
+			void It_returns_a_object(String content) {
+				ReviewContent reviewContent = new ReviewContent(content);
+
+				assertThat(reviewContent.getReviewContent()).isEqualTo(content);
+			}
+	    }
+
+		@Nested
+		@DisplayName("만약 유효하지 않은 content가 주어진다면")
+		class Context_with_invalid_content {
+
+			@ParameterizedTest
+			@NullSource
+			@MethodSource("provideContentForIsNullAndEmptyAnd500char")
+			@DisplayName("예외를 발생시킨다.")
+			void It_throws_exception(String content) {
+				assertThatThrownBy(() -> new ReviewContent(content))
+					.isInstanceOf(InvalidReviewContentException.class);
+			}
+
+			private static Stream<Arguments> provideContentForIsNullAndEmptyAnd500char() {
+				String content = "a";
+				return Stream.of(
+					Arguments.of(""),
+					Arguments.of(" "),
+					Arguments.of("\t"),
+					Arguments.of("\n"),
+					Arguments.of(content.repeat(501))
+				);
+			}
+		}
+
+
+	}
+
+
+
+}

--- a/be/src/test/java/com/jjikmuk/sikdorak/review/domain/ReviewScoreTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/review/domain/ReviewScoreTest.java
@@ -1,0 +1,47 @@
+package com.jjikmuk.sikdorak.review.domain;
+
+import com.jjikmuk.sikdorak.review.exception.InvalidReviewScoreException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ReviewScoreTest {
+
+    @Nested
+    @DisplayName("생성자")
+    class Describe_constructor {
+
+        @Nested
+        @DisplayName("만약 reviewScore 가 1,2,3,4,5 중에서만 주어진다면 ")
+        class Context_with_valid_reviewScore {
+
+            @ParameterizedTest
+            @ValueSource(floats = {1,2,3,4,5})
+            @DisplayName("ReviewScore 객체를 반환한다")
+            void It_returns_a_object(Float score) {
+                ReviewScore reviewScore = new ReviewScore(score);
+
+                assertThat(reviewScore.getReviewScore()).isEqualTo(score);
+            }
+        }
+
+        @Nested
+        @DisplayName("만약 reviewScore 가 1,2,3,4,5 이외의 값이 주어진다면 ")
+        class Context_with_invalid_reviewScore {
+
+            @ParameterizedTest
+            @NullSource
+            @ValueSource(floats = {-1, 0, 1.1f, 6})
+            @DisplayName("예외를 발생시킨다")
+            void It_throws_exception(Float score) {
+                assertThatThrownBy(() -> new ReviewScore(score))
+                        .isInstanceOf(InvalidReviewScoreException.class);
+            }
+        }
+    }
+}

--- a/be/src/test/java/com/jjikmuk/sikdorak/review/domain/ReviewVisibilityTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/review/domain/ReviewVisibilityTest.java
@@ -1,0 +1,30 @@
+package com.jjikmuk.sikdorak.review.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ReviewVisibilityTest {
+
+    @Nested
+    @DisplayName("생성자")
+    class Describe_constructor {
+
+        @Nested
+        @DisplayName("만약 유효한 값이 들어온다면")
+        class Context_with_valid_reviewVisibility {
+
+            @ParameterizedTest
+            @ValueSource(strings = {"PUBLIC", "PROTECTED", "PRIVATE", "puBlic", "Protected", "privatE"})
+            @DisplayName("ReviewVisibility enum 을 반환한다")
+            void It_returns_a_object(String visibility) {
+                ReviewVisibility reviewVisibility = ReviewVisibility.create(visibility);
+
+                assertThat(reviewVisibility.name()).isEqualTo(visibility.toUpperCase());
+            }
+        }
+    }
+}

--- a/be/src/test/java/com/jjikmuk/sikdorak/review/domain/ReviewVisitedDateTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/review/domain/ReviewVisitedDateTest.java
@@ -1,0 +1,79 @@
+package com.jjikmuk.sikdorak.review.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.jjikmuk.sikdorak.review.exception.InvalidReviewVisitedDateException;
+import java.time.LocalDate;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@DisplayName("ReviewVisitedDateTest 클래스")
+class ReviewVisitedDateTest {
+
+	@Nested
+	@DisplayName("생성자")
+	class Describe_constructor {
+
+		@Nested
+		@DisplayName("만약 reviewVisitedDate가 현재 시간보다 이전 시간이 주어진다면 ")
+		class Context_with_valid_reviewVisitedDate {
+
+			@Test
+			@DisplayName("ReviewVisitedDate 객체를 반환한다")
+			void It_returns_a_object() {
+				ReviewVisitedDate reviewVisitedDate = new ReviewVisitedDate(
+					LocalDate.of(2022, 7, 20), LocalDate.of(2022, 7, 21));
+
+				assertThat(reviewVisitedDate.getReviewVisitedDate()).isEqualTo(
+					LocalDate.of(2022, 7, 20));
+			}
+		}
+
+		@Nested
+		@DisplayName("만약 reviewVisitedDate가 현재 시간과 동일한 시간이 주어진다면 ")
+		class Context_with_same_reviewVisitedDate {
+
+			@Test
+			@DisplayName("ReviewVisitedDate 객체를 반환한다")
+			void It_returns_a_object() {
+				ReviewVisitedDate reviewVisitedDate = new ReviewVisitedDate(
+					LocalDate.of(2022, 7, 21), LocalDate.of(2022, 7, 21));
+
+				assertThat(reviewVisitedDate.getReviewVisitedDate()).isEqualTo(
+					LocalDate.of(2022, 7, 21));
+			}
+		}
+
+		@Nested
+		@DisplayName("만약 reviewVisitedDate가 유효하지 않은 시간이 주어진다면 ")
+		class Context_with_invalid_reviewVisitedDate {
+
+			@ParameterizedTest
+			@MethodSource("provideLocalDates")
+			@DisplayName("예외를 발생시킨다")
+			void It_throws_exception(LocalDate reviewVisitedDate, LocalDate currentDate) {
+				assertThatThrownBy(() -> new ReviewVisitedDate(reviewVisitedDate, currentDate))
+					.isInstanceOf(InvalidReviewVisitedDateException.class);
+			}
+
+			private static Stream<Arguments> provideLocalDates() {
+				return Stream.of(
+					Arguments.of(null, LocalDate.of(2021,12,31)),
+					Arguments.of(LocalDate.of(2022,1,1), null),
+					Arguments.of(LocalDate.of(2022,1,1), LocalDate.of(2021,12,31))
+				);
+			}
+		}
+	}
+
+
+
+
+}
+

--- a/be/src/test/java/com/jjikmuk/sikdorak/review/domain/TagTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/review/domain/TagTest.java
@@ -1,0 +1,91 @@
+package com.jjikmuk.sikdorak.review.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.jjikmuk.sikdorak.review.exception.InvalidTagException;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@DisplayName("Tag 클래스")
+class TagTest {
+
+	@Nested
+	@DisplayName("생성자")
+	class Describe_constructor {
+
+		@Nested
+		@DisplayName("만약 태그가 0~50자 이하의 문자열로 주어진다면")
+		class Context_with_valid_Tag {
+
+			@ParameterizedTest
+			@MethodSource("provideValidTag")
+			@DisplayName("Tag 객체를 반환한다.")
+			void It_returns_a_object(String rawTag, String expected) {
+				Tag tag = new Tag(rawTag);
+
+				assertThat(tag.getText()).isEqualTo(expected);
+			}
+
+			private static Stream<Arguments> provideValidTag() {
+				String content = "a";
+				return Stream.of(
+					Arguments.of("맛집", "맛집"),
+					Arguments.of("꿀맛집", "꿀맛집"),
+					Arguments.of(content.repeat(50), content.repeat(50))
+				);
+			}
+		}
+
+		@Nested
+		@DisplayName("만약 태그가 대소문자 구분없는 문자열이 주어진다면")
+		class Context_with_upper_and_lower_Tag {
+
+			@ParameterizedTest
+			@ValueSource(strings = {"good", "Good", "GoOd"})
+			@DisplayName("소문자로 변환한 Tag 객체를 반환한다.")
+			void It_returns_a_object(String rawTag) {
+				Tag tag = new Tag(rawTag);
+
+				assertThat(tag.getText()).isEqualTo("good");
+			}
+		}
+
+		@Nested
+		@DisplayName("만약 유효하지 않은 태그가 주어진다면")
+		class Context_with_invalid_Tag {
+
+			@ParameterizedTest
+			@NullAndEmptySource
+			@MethodSource("provideInvalidTag")
+			@DisplayName("예외를 발생시킨다.")
+			void It_throws_exception(String rawTag) {
+				assertThatThrownBy(() -> new Tag(rawTag))
+					.isInstanceOf(InvalidTagException.class);
+			}
+
+
+			private static Stream<Arguments> provideInvalidTag() {
+				String content = "a";
+				return Stream.of(
+					Arguments.of("중간 공백"),
+					Arguments.of(" 공 백"),
+					Arguments.of("중간\t공백"),
+					Arguments.of(content.repeat(51)),
+					Arguments.of("특수문자#"),
+					Arguments.of("특수문자!"),
+					Arguments.of("특수문자%$"),
+					Arguments.of("특수문자()"),
+					Arguments.of("특수문자+")
+				);
+			}
+		}
+	}
+
+}

--- a/be/src/test/java/com/jjikmuk/sikdorak/review/domain/TagsTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/review/domain/TagsTest.java
@@ -1,0 +1,74 @@
+package com.jjikmuk.sikdorak.review.domain;
+
+import com.jjikmuk.sikdorak.review.exception.InvalidTagsException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("Tags 클래스")
+class TagsTest {
+
+    @Nested
+    @DisplayName("생성자")
+    class Describe_constructor {
+        @Nested
+        @DisplayName("만약 태그 개수가 0개 ~ 30개 이하로 주어진다면")
+        class Context_with_valid_Tags {
+
+            @ParameterizedTest
+            @ValueSource(ints = {0, 15, 30})
+            @DisplayName("Tags 객체를 반환한다.")
+            void It_returns_a_object(int length) {
+                List<String> limitTags = new ArrayList<>();
+                for (int i = 0; i < length; i++) {
+                    limitTags.add("tag" + i);
+                }
+
+                Tags tags = new Tags(limitTags);
+
+                assertThat(tags.size()).isEqualTo(length);
+            }
+        }
+
+        @Nested
+        @DisplayName("만약 태그 개수가 30개 초과로 주어진다면")
+        class Context_with_invalid_Tags {
+
+            @Test
+            @DisplayName("예외를 발생시킨다.")
+            void It_throws_exception() {
+                List<String> limitTags = new ArrayList<>();
+
+                for (int i = 0; i < 32; i++) {
+                    limitTags.add("tag" + i);
+                }
+
+                assertThatThrownBy(()-> new Tags(limitTags))
+                        .isInstanceOf(InvalidTagsException.class);
+            }
+        }
+
+        @Nested
+        @DisplayName("만약 태그 중 중복된 태그가 있다면")
+        class Context_with_duplicated_Tags {
+
+            @Test
+            @DisplayName("중복된 항목을 제거한 Tags 객체를 반환한다.")
+            void It_throws_exception() {
+                List<String> duplicatedTags = List.of("맛집", "맛집", "맛집", "꿀맛");
+
+                Tags tags = new Tags(duplicatedTags);
+
+                assertThat(tags.size()).isEqualTo(2);
+            }
+        }
+    }
+}

--- a/be/src/test/resources/application.yml
+++ b/be/src/test/resources/application.yml
@@ -1,0 +1,21 @@
+spring:
+  datasource:
+    driver-class-name: org.h2.Driver
+  jpa:
+    hibernate:
+      ddl-auto: create
+      naming:
+        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+    properties:
+      hibernate:
+        format_sql: true
+        default_batch_fetch_size: 100
+    show-sql: true
+sql:
+  init:
+    mode: always
+    encoding: UTF-8
+
+logging:
+  level:
+    org.hibernate.SQL: debug


### PR DESCRIPTION
### ❗️ 이슈 번호

<strong>
Closes #5
</strong>

<br><br>

### 📝 구현 내용

- 리뷰 작성 API 구현
- `POST /api/reviews`
- 테스트(84개)
  - 인수 테스트 32개 작성
  - 단위 테스트 52개 작성(엔티티의 필드들을 객체로 구현)
- 예외 통합 처리를 위한 `GlobalExceptionHandler` 구현
- `@Valid` 사용하지 않고 각 도메인 객체에서 생성할 때 유효성 검증
- `Review` 엔티티 구현 시 연관관계 사용하지 않으려고 함 (컬렉션 값 매핑 또는, 외부 참조 엔티티(e.g. Store)의 경우 FK의 primitive type으로 관리)
 
<br><br>

### 💡 참고 자료

- [최범균님의 JPA 기초](https://www.youtube.com/playlist?list=PLwouWTPuIjUi9Sih9mEci4Rqhz1VqiQXX)
- [JPA에서의 일급 컬렉션 적용](https://gilssang97.tistory.com/76)
- [H2 테이블 대소문자 구분](https://velog.io/@gillog/JPA-Spring-Boot-JPA-Entity-Table-%EB%8C%80-%EC%86%8C%EB%AC%B8%EC%9E%90-%EA%B5%AC%EB%B6%84-%EB%AA%BB%ED%95%98%EB%8A%94-%EA%B2%BD%EC%9A%B0-%ED%95%B4%EA%B2%B0)