### PR TITLE
SDR-69 BE-dev 브랜치 push/PR 시 자동 테스트를 한다.

### DIFF
--- a/.github/workflows/CI-BE.yml
+++ b/.github/workflows/CI-BE.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
         with:
-          java-version: "11"
+          java-version: "17"
           distribution: "temurin"
           cache: gradle
 

--- a/.github/workflows/CI-BE.yml
+++ b/.github/workflows/CI-BE.yml
@@ -1,0 +1,66 @@
+name: CI - BE
+
+on:
+  push:
+    branches:
+      - BE-dev
+  pull_request:
+    branches:
+      - BE-dev
+permissions:
+  contents: read
+
+jobs:
+  be-test:
+    name: SpringBoot Test
+    runs-on: ubuntu-20.04
+    defaults:
+      run:
+        working-directory: ./be
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          java-version: "11"
+          distribution: "temurin"
+          cache: gradle
+
+      - name: Use gradle cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+            
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Test with Gradle
+        run: ./gradlew test
+      
+      # 참고 : https://github.com/marketplace/actions/discord-webhook-notify
+      - name: Noti Discord - Test Success
+        uses: rjstone/discord-webhook-notify@v1
+        if: success()
+        with:
+          severity: info
+          details: Test Succeeded!
+          webhookUrl: ${{ secrets.DISCORD_WEBHOOK }}
+      - name: Noti Discord - Test Failure
+        uses: rjstone/discord-webhook-notify@v1
+        if: failure()
+        with:
+          severity: error
+          details: Test Failed!
+          webhookUrl: ${{ secrets.DISCORD_WEBHOOK }}
+      - name: Noti Discord - Test Cancelled
+        uses: rjstone/discord-webhook-notify@v1
+        if: cancelled()
+        with:
+          severity: warn
+          details: Test Cancelled!
+          webhookUrl: ${{ secrets.DISCORD_WEBHOOK }}


### PR DESCRIPTION
### ❗️ 이슈 번호

<strong>
Closes #20
</strong>

<br><br>

### 📝 구현 내용

- GitHub Actions 활용
- ./gradlew test 으로 테스트 확인
- Discord 채널 테슽 통과 여부 자동 알림 기능

<br><br>

### 💡 참고 자료

- [discord-webhook-notify](https://github.com/marketplace/actions/discord-webhook-notify)