### PR TITLE
SDR-74 API 문서 관련 설정 및 리뷰 작성 API 문서 추가

### DIFF
--- a/be/.gitignore
+++ b/be/.gitignore
@@ -48,6 +48,9 @@ gradle-app.setting
 # # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
 # gradle/wrapper/gradle-wrapper.properties
 
+### SwaggerUI docs
+**/static/docs/
+
 ### Windows template
 # Windows thumbnail cache files
 Thumbs.db

--- a/be/build.gradle
+++ b/be/build.gradle
@@ -1,6 +1,17 @@
+import org.hidetake.gradle.swagger.generator.GenerateSwaggerUI
+import org.springframework.boot.gradle.tasks.bundling.BootJar
+
+buildscript {
+	ext {
+		epagesRestdocsVersion = '0.16.2'
+	}
+}
+
 plugins {
 	id 'org.springframework.boot' version '2.7.1'
 	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+	id 'com.epages.restdocs-api-spec' version "${epagesRestdocsVersion}"
+	id 'org.hidetake.swagger.generator' version '2.18.2'
 	id 'java'
 }
 
@@ -16,6 +27,20 @@ configurations {
 
 repositories {
 	mavenCentral()
+}
+
+openapi3 {
+	setServer("http://localhost:8080")
+	title = "Sikdorak Service API"
+	description = "An API providing greetings to users."
+	version = "1.0.0"
+	format = "yaml"
+}
+
+swaggerSources {
+	register("sikdorak").configure {
+		setInputFile(file("${project.buildDir}/api-spec/openapi3.yaml"))
+	}
 }
 
 dependencies {
@@ -35,14 +60,47 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'io.rest-assured:rest-assured'
 
+	// API Docs
+	testImplementation "com.epages:restdocs-api-spec-restassured:${epagesRestdocsVersion}"
+	swaggerUI 'org.webjars:swagger-ui:4.11.1'
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
 }
 
+//-- Git submodule 관련 task -------------------------------------------------------
 task copyGitSubmodule(type: Copy) {
 	from './config'
 	include '*.yml'
 	into './src/main/resources'
+}
+
+//-- API 문서 관련 task -------------------------------------------------------
+// API Spec 을 HTML 로 변환
+tasks.withType(GenerateSwaggerUI) {
+	dependsOn 'openapi3'
+}
+
+def generateSwaggerUISikdorakTask = tasks.named('generateSwaggerUISikdorak', GenerateSwaggerUI).get()
+
+// API 문서 HTML 을 build resources 로 복사
+tasks.register('copySwaggerUI', Copy) {
+	dependsOn 'generateSwaggerUISikdorak'
+
+	from("${generateSwaggerUISikdorakTask.outputDir}")
+	into("${project.buildDir}/resources/main/static/docs")
+}
+
+// API 문서 HTML 을 main resources 로 복사
+tasks.register('copySwaggerUI2MainResources', Copy) {
+	dependsOn 'generateSwaggerUISikdorak'
+
+	from("${generateSwaggerUISikdorakTask.outputDir}")
+	into("${project.projectDir}/src/main/resources/static/docs")
+}
+
+// bootJar 실행 전, copySwaggerUI 를 실행하도록 설정
+tasks.withType(BootJar) {
+	dependsOn 'copySwaggerUI'
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/InitAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/InitAcceptanceTest.java
@@ -3,17 +3,28 @@ package com.jjikmuk.sikdorak.acceptance;
 import com.jjikmuk.sikdorak.store.domain.Store;
 import com.jjikmuk.sikdorak.store.repository.StoreRepository;
 import io.restassured.RestAssured;
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.specification.RequestSpecification;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
 
-import java.util.List;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.documentationConfiguration;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@ExtendWith(RestDocumentationExtension.class)
 public class InitAcceptanceTest {
+
+	protected static final String DEFAULT_RESTDOC_PATH = "{class_name}/{method_name}/";
+
+	protected RequestSpecification spec;
 
 	@Autowired
 	StoreRepository storeRepository;
@@ -28,6 +39,24 @@ public class InitAcceptanceTest {
 		RestAssured.port = port;
 		savedStore = storeRepository.save(new Store());
 	}
+
+	@BeforeEach
+	void setUpRestDocs(RestDocumentationContextProvider restDocumentation) {
+		this.spec = new RequestSpecBuilder()
+				.addFilter(documentationConfiguration(restDocumentation)
+						.operationPreprocessors()
+						.withRequestDefaults(prettyPrint())
+						.withResponseDefaults(prettyPrint()))
+				.build();
+	}
+
+//	private void setUpRestAssured() {
+//		Jackson2Mapper jackson2Mapper = new Jackson2Mapper((type, charset) -> objectMapper);
+//		ObjectMapperConfig jackson2ObjectMapperConfig = new ObjectMapperConfig(jackson2Mapper);
+//
+//		RestAssured.config = RestAssuredConfig.config()
+//				.objectMapperConfig(jackson2ObjectMapperConfig);
+//	}
 
 	@AfterEach
 	void tearDown() {

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/ReviewAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/ReviewAcceptanceTest.java
@@ -12,13 +12,18 @@ import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.restdocs.snippet.Snippet;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
+import static com.epages.restdocs.apispec.RestAssuredRestDocumentationWrapper.document;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 
 /**
  *  [x] 요청 텍스트가 유효하지 않은 경우(null, empty, 500자 넘는 경우)
@@ -30,7 +35,17 @@ import static org.hamcrest.Matchers.equalTo;
  *  TODO
  *  [ ] 요청 이미지가 유효하지 않은 경우(유효하지 않은 image 경로 (유효하지 않은 URL포맷, 관리하고 있는 s3 주소))
  */
-public class ReviewAccecptanceTest extends InitAcceptanceTest {
+public class ReviewAcceptanceTest extends InitAcceptanceTest {
+
+	private static final Snippet REVIEW_INSERT_REQUEST = requestFields(
+			fieldWithPath("reviewContent").type(JsonFieldType.STRING).description("리뷰 내용"),
+			fieldWithPath("storeId").type(JsonFieldType.NUMBER).description("가게 아이디"),
+			fieldWithPath("reviewScore").type(JsonFieldType.NUMBER).description(""),
+			fieldWithPath("reviewVisibility").type(JsonFieldType.STRING).description(""),
+			fieldWithPath("visitedDate").type(JsonFieldType.STRING).description(""),
+			fieldWithPath("tags").type(JsonFieldType.ARRAY).description(""),
+			fieldWithPath("images").type(JsonFieldType.ARRAY).description("")
+	);
 
 	@Test
 	@DisplayName("리뷰 생성 요청이 정상적인 경우라면 리뷰 생성 후 정상 상태 코드를 반환한다")
@@ -44,16 +59,16 @@ public class ReviewAccecptanceTest extends InitAcceptanceTest {
 		requestBody.put("tags", new String[]{"맛집", "꿀맛"});
 		requestBody.put("images", new String[]{"https://s3.ap-northeast-2.amazonaws.com/sikdorak/test.jpg"});
 
-		given()
+		given(this.spec)
+			.filter(document(DEFAULT_RESTDOC_PATH, REVIEW_INSERT_REQUEST))
 			.accept(MediaType.APPLICATION_JSON_VALUE)
 			.header("Content-type", "application/json")
 			.body(requestBody)
-			.log().all()
 
-			.when()
+		.when()
 			.post("/api/reviews")
 
-			.then()
+		.then()
 			.statusCode(HttpStatus.CREATED.value());
 	}
 
@@ -75,7 +90,7 @@ public class ReviewAccecptanceTest extends InitAcceptanceTest {
 			.header("Content-type", "application/json")
 			.body(requestBody)
 
-			.when()
+		.when()
 			.post("/api/reviews")
 
 			.then()


### PR DESCRIPTION
### ❗️ 이슈 번호

<strong>
Closes #19
</strong>

<br><br>

### 📝 구현 내용

#### 의존성 추가
- **plugin**
  - `com.epages.restdocs-api-spec`
      TestCode -> API Spec 변환
  - `org.hidetake.swagger.generator`
      API Spec -> HTML 변환
- **dependency**
  - `com.epages:restdocs-api-spec-restassured` 
      Rest Assured 로 작성된 테스트 코드에 API 스펙을 정의할 수 있는 API 제공
  - `org.webjars:swagger-ui`
      API 스펙을 SwaggerUI 로 변환하는데 사용되는 의존성(org.hidetake.swagger.generator 플러그인이 참조)

#### API 문서 작성

- InitAcceptanceTest : API 스펙 작성을 위한 기본 설정 추가
- ReviewAcceptanceTest : 리뷰 작성 성공 API 스펙 추가

<br><br>

### 🙇🏻‍♂️ 리뷰어에게 부탁합니다!

- SwaggerUI 로 생성된 API 문서 ignore 검토
  생성된 HTML, CSS, JS 는 굳이 버전 관리를 하지 않아도 될 것 같아, ignore 했는데 이에 대한 의견 요청
  예) `src/main/resources/static/docs/` 경로 아래의 SwaggerUI API 문서 

<br><br>

### 💡 참고 자료

- https://blog.jdriven.com/2021/10/generate-swagger-ui-from-spring-rest-docs/
- https://github.com/ePages-de/restdocs-api-spec
- https://github.com/int128/gradle-swagger-generator-plugin
