### PR TITLE
SDR-75 Restdoc 테스트가 특정 상황에 실패하는 이슈 수정

### DIFF
--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/InitAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/InitAcceptanceTest.java
@@ -50,14 +50,6 @@ public class InitAcceptanceTest {
 				.build();
 	}
 
-//	private void setUpRestAssured() {
-//		Jackson2Mapper jackson2Mapper = new Jackson2Mapper((type, charset) -> objectMapper);
-//		ObjectMapperConfig jackson2ObjectMapperConfig = new ObjectMapperConfig(jackson2Mapper);
-//
-//		RestAssured.config = RestAssuredConfig.config()
-//				.objectMapperConfig(jackson2ObjectMapperConfig);
-//	}
-
 	@AfterEach
 	void tearDown() {
 		storeRepository.deleteAll();

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/InitAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/InitAcceptanceTest.java
@@ -43,6 +43,7 @@ public class InitAcceptanceTest {
 	@BeforeEach
 	void setUpRestDocs(RestDocumentationContextProvider restDocumentation) {
 		this.spec = new RequestSpecBuilder()
+				.setPort(port)
 				.addFilter(documentationConfiguration(restDocumentation)
 						.operationPreprocessors()
 						.withRequestDefaults(prettyPrint())


### PR DESCRIPTION
### ❗️ 이슈 번호

<strong>
Closes #36
</strong>

<br><br>

### 📝 구현 내용

- 불필요한 주석 제거
- Rest Assured 에서 API specification 추가시 port 정보 추가

<br><br>

### 💡 참고 자료

#### 단독 테스트 실행 시 성공 (Tests passed 1 of 1 test)

![image](https://user-images.githubusercontent.com/45728407/182032505-6568b079-a817-437b-b188-2cfe5a3ffc08.png)

#### 전체 테스트 실행 시 성공 (Tests passed 84 of 84 tests)

![image](https://user-images.githubusercontent.com/45728407/182032523-38c9414e-c3e6-4cb5-bf84-aab9690bf8a9.png)
