### PR TITLE
SDR-76 공통으로 사용할 통합테스트와 TestContainers 적용

### DIFF
--- a/be/build.gradle
+++ b/be/build.gradle
@@ -55,6 +55,7 @@ dependencies {
 	// Database
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	runtimeOnly 'com.h2database:h2'
+	runtimeOnly 'mysql:mysql-connector-java'
 
 	// Dev
 	compileOnly 'org.projectlombok:lombok'
@@ -67,6 +68,10 @@ dependencies {
 	// API Docs
 	testImplementation "com.epages:restdocs-api-spec-restassured:${epagesRestdocsVersion}"
 	swaggerUI 'org.webjars:swagger-ui:4.11.1'
+
+	// TestContainers
+	testImplementation "org.testcontainers:junit-jupiter:1.17.2"
+	testImplementation "org.testcontainers:mysql:1.17.2"
 }
 
 tasks.named('test') {

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/controller/request/ReviewInsertRequest.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/controller/request/ReviewInsertRequest.java
@@ -1,10 +1,9 @@
 package com.jjikmuk.sikdorak.review.controller.request;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
 import java.time.LocalDate;
 import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
@@ -23,4 +22,16 @@ public class ReviewInsertRequest {
 	private List<String> tags;
 
 	private List<String> images;
+
+	public ReviewInsertRequest(String reviewContent, Long storeId, Float reviewScore,
+		String reviewVisibility, LocalDate visitedDate, List<String> tags,
+		List<String> images) {
+		this.reviewContent = reviewContent;
+		this.storeId = storeId;
+		this.reviewScore = reviewScore;
+		this.reviewVisibility = reviewVisibility;
+		this.visitedDate = visitedDate;
+		this.tags = tags;
+		this.images = images;
+	}
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/domain/Review.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/domain/Review.java
@@ -62,4 +62,8 @@ public class Review extends BaseTimeEntity {
 		this(null, storeId, reviewContent, reviewScore, reviewVisibility, visitedDate, tags,
 			images);
 	}
+
+	public Long getId() {
+		return id;
+	}
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/domain/ReviewVisitedDate.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/domain/ReviewVisitedDate.java
@@ -5,6 +5,7 @@ import java.time.LocalDate;
 import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
+import javax.persistence.Transient;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,6 +17,8 @@ public class ReviewVisitedDate {
 
 	@Column
 	private LocalDate reviewVisitedDate;
+
+	@Transient
 	private LocalDate currentDate;
 
 

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/service/ReviewService.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/service/ReviewService.java
@@ -17,7 +17,7 @@ public class ReviewService {
 	private final ReviewRepository reviewRepository;
 
 	@Transactional
-	public void insertReview(ReviewInsertRequest request) {
+	public Long insertReview(ReviewInsertRequest request) {
 		Long findStoreId = request.getStoreId();
 		storeService.findById(findStoreId);
 
@@ -29,6 +29,7 @@ public class ReviewService {
 			request.getTags(),
 			request.getImages());
 
-		reviewRepository.save(newReview);
+		Review saveReview = reviewRepository.save(newReview);
+		return saveReview.getId();
 	}
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/common/DatabaseConfigurator.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/common/DatabaseConfigurator.java
@@ -1,0 +1,66 @@
+package com.jjikmuk.sikdorak.common;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import org.hibernate.Session;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DatabaseConfigurator implements InitializingBean {
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	private List<String> tableNames;
+
+	@Override
+	public void afterPropertiesSet() {
+		entityManager.unwrap(Session.class).doWork(this::extractTableNames);
+	}
+
+	// reference : https://www.baeldung.com/jdbc-database-metadata
+	private void extractTableNames(Connection connection) throws SQLException {
+		List<String> tableNames = new ArrayList<>();
+
+		ResultSet tables = connection
+			.getMetaData()
+			.getTables(connection.getCatalog(), null, "%", new String[]{"TABLE"});
+
+		try (tables) {
+			while (tables.next()) {
+				tableNames.add(tables.getString("table_name"));
+			}
+
+			this.tableNames = tableNames;
+		}
+	}
+
+	public void clear() {
+		entityManager.unwrap(Session.class).doWork(this::cleanUpDatabase);
+	}
+
+	private void cleanUpDatabase(Connection connection) throws SQLException {
+		try (Statement statement = connection.createStatement()) {
+
+			statement.executeUpdate("SET FOREIGN_KEY_CHECKS = 0"); // MySQL 참조무결성 off
+
+			for (String tableName : tableNames) {
+
+				statement.executeUpdate("TRUNCATE TABLE " + tableName);
+				// Mysql 8에서 auto_increment 초기화 지원 X
+//				statement
+//					.executeUpdate("ALTER TABLE " + tableName + " ALTER AUTO_INCREMENT = 1");
+			}
+
+			statement.executeUpdate("SET FOREIGN_KEY_CHECKS = 1");
+		}
+	}
+
+}

--- a/be/src/test/java/com/jjikmuk/sikdorak/common/MysqlTestContainer.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/common/MysqlTestContainer.java
@@ -1,0 +1,17 @@
+package com.jjikmuk.sikdorak.common;
+
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Testcontainers
+public abstract class MysqlTestContainer {
+
+	private static final String MYSQL_VERSION = "mysql:8";
+	private static final String DATABASE_NAME = "testDB";
+
+	@Container
+	static final MySQLContainer MYSQL_CONTAINER = new MySQLContainer(MYSQL_VERSION)
+		.withDatabaseName(DATABASE_NAME);
+
+}

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/InitIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/InitIntegrationTest.java
@@ -1,0 +1,20 @@
+package com.jjikmuk.sikdorak.integration;
+
+import com.jjikmuk.sikdorak.common.DatabaseConfigurator;
+import com.jjikmuk.sikdorak.common.MysqlTestContainer;
+import org.junit.jupiter.api.AfterEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+
+@SpringBootTest
+public abstract class InitIntegrationTest extends MysqlTestContainer {
+
+	@Autowired
+	private DatabaseConfigurator databaseConfigurator;
+
+	@AfterEach
+	void tearDown() {
+		databaseConfigurator.clear();
+	}
+}

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/review/ReviewInsertIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/review/ReviewInsertIntegrationTest.java
@@ -1,0 +1,59 @@
+package com.jjikmuk.sikdorak.integration.review;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.jjikmuk.sikdorak.integration.InitIntegrationTest;
+import com.jjikmuk.sikdorak.review.controller.request.ReviewInsertRequest;
+import com.jjikmuk.sikdorak.review.service.ReviewService;
+import com.jjikmuk.sikdorak.store.domain.Store;
+import com.jjikmuk.sikdorak.store.exception.StoreNotFoundException;
+import com.jjikmuk.sikdorak.store.repository.StoreRepository;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * TODO
+ * - [ ] 유저 도메인 객체 생성 후 통합 테스트 추가
+ */
+@DisplayName("ReviewInsert 통합테스트")
+public class ReviewInsertIntegrationTest extends InitIntegrationTest {
+
+	@Autowired
+	ReviewService reviewService;
+
+	@Autowired
+	private StoreRepository storeRepository;
+
+	@Test
+	@DisplayName("만약 정상적인 리뷰 요청이 주어진다면 리뷰를 등록할 수 있다.")
+	void create_review_Success() {
+		Store saveStore = storeRepository.save(new Store());
+		ReviewInsertRequest reviewInsertRequest = new ReviewInsertRequest("Test review contents",
+			saveStore.getId(), 3.f, "public", LocalDate.of(2022, 1, 1),
+			List.of("tag1", "tag2"),
+			List.of("https://s3.ap-northeast-2.amazonaws.com/sikdorak/test.jpg"));
+
+		Long saveId = reviewService.insertReview(reviewInsertRequest);
+
+		assertThat(saveId).isNotNull();
+	}
+
+	@Test
+	@DisplayName("만약 존재하지 않은 상점 id의 리뷰 요청이 주어진다면 예외를 발생시킨다.")
+	void create_review_failed() {
+		Long invalidStoreId = Long.MAX_VALUE;
+		ReviewInsertRequest reviewInsertRequest = new ReviewInsertRequest("Test review contents",
+			invalidStoreId, 3.f, "public", LocalDate.of(2022, 1, 1),
+			List.of("tag1", "tag2"),
+			List.of("https://s3.ap-northeast-2.amazonaws.com/sikdorak/test.jpg"));
+
+		assertThatThrownBy(() -> reviewService.insertReview(reviewInsertRequest))
+			.isInstanceOf(StoreNotFoundException.class);
+	}
+
+}
+

--- a/be/src/test/resources/application.yml
+++ b/be/src/test/resources/application.yml
@@ -1,16 +1,18 @@
 spring:
   datasource:
-    driver-class-name: org.h2.Driver
+    driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
+    url: jdbc:tc:mysql:8://testDB
   jpa:
     hibernate:
       ddl-auto: create
-      naming:
-        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
     properties:
       hibernate:
         format_sql: true
         default_batch_fetch_size: 100
+    defer-datasource-initialization: true
     show-sql: true
+
+
 sql:
   init:
     mode: always
@@ -19,3 +21,4 @@ sql:
 logging:
   level:
     org.hibernate.SQL: debug
+

--- a/be/src/test/resources/logback-test.xml
+++ b/be/src/test/resources/logback-test.xml
@@ -1,0 +1,14 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="info">
+    <appender-ref ref="STDOUT"/>
+  </root>
+
+  <logger name="org.testcontainers" level="INFO"/>
+  <logger name="com.github.dockerjava" level="WARN"/>
+</configuration>


### PR DESCRIPTION
### ❗️ 이슈 번호

<strong>
refs #28
</strong>

<br><br>

### 📝 구현 내용

- 통합 테스트(서비스 계층) 생성
- TestContainers 적용하여 MySQL 8 버전 사용

### 🙇🏻‍♂️ 리뷰어에게 부탁합니다!

#### 통합 테스트에 관하여
통합 테스트를 서비스 계층 테스트를 합니다.
통합 테스트의 테스트 케이스들을 도메인 객체의 단위테스트와 공통된 부분은 테스트 하지 않습니다.
예를 들어 reviewContent 가 500자가 넘는 경우 invalidReviewContent 예외가 발생하는 테스트는 ReviewContent 도메인 객체의 단위 테스트에서 이미 테스트하고 있습니다. 따라서 통합 테스트에서 중복되게 테스트할 필요가 없다고 생각합니다.

통합테스트의 범주는 단위테스트가 커버하지 못하는 부분, 외부 의존성(DB, OAuth server 등)을 테스트하면 좋을 거 같아요.
위 예의 경우 리뷰를 생성하기위해 storeId가 필요합니다. storeId가 유효한지 체크하기 위해서는 Store DB를 거쳐 확인해야 하기 때문에 통합 테스트 범주에 포함됩니다. 또는 User가 존재하는지 여부도 될 수 있겠군요.

+a) 유저와 스토어 객체 구현이 완료되면 테스트코드가 수정될 예정입니다.

통합테스트 구현할 때 `InitIntegrationTest`를 상속받아 구현하면 매 테스트마다 DB를 cleanUP 하고 동일한 TestContainers에서 테스트하게 됩니다.

`ReviewInsertIntegrationTest`를 참고하여 통합테스트하면 좋을 거 같습니다. :D

#### TestContainers 적용

- TestContainers 사용은  위경도 (Point object) 지원 여부와 추후 실 서버의 통일성을 맞추기 위해 MySQL 8 TestContainers를 적용하게 되었습니다. 
- GitHub Actions 에서 도커가 기본으로 실행되기 때문에 테스트 환경이 깨지지 않습니다. :) 
- ⚠️ 주의 : 해당 테스트를 실행하려면 실행할 테스트 환경에 Docker가 실행중이어야 합니다.
