### PR TITLE
SDR-90 특정 음식점을 상세 조회할 수 있는 API 추가

### DIFF
--- a/be/src/docs/asciidoc/index.adoc
+++ b/be/src/docs/asciidoc/index.adoc
@@ -14,3 +14,7 @@ notification-api-docs
 == 이슈 API
 
 include::{docdir}/review/review.adoc[]
+
+== 음식점 API
+
+include::{docdir}/store/store.adoc[]

--- a/be/src/docs/asciidoc/store/store.adoc
+++ b/be/src/docs/asciidoc/store/store.adoc
@@ -1,0 +1,13 @@
+=== 이름으로 음식점 조회
+
+API : `GET /api/stores`
+
+=== `200 OK`
+
+==== `Request`
+
+operation::store_acceptance_test/find_store_by_name_containing_success[snippets='http-request,request-parameters']
+
+==== `Response`
+
+operation::store_acceptance_test/find_store_by_name_containing_success[snippets='http-response,response-fields']

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/ResponseCodeAndMessages.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/ResponseCodeAndMessages.java
@@ -3,7 +3,10 @@ package com.jjikmuk.sikdorak.common;
 public enum ResponseCodeAndMessages implements CodeAndMessages {
 
     REVIEW_CREATED("T-R001", "리뷰 생성 성공했습니다."),
-    LOGIN_SUCCESS("T-L001", "로그인에 성공했습니다.");
+    LOGIN_SUCCESS("T-L001", "로그인에 성공했습니다."),
+
+    // Store
+    STORE_FIND_SUCCESS("T-S001", "가게 목록 조회에 성공했습니다.");
 
     private final String code;
     private final String message;

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/exception/ExceptionCodeAndMessages.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/exception/ExceptionCodeAndMessages.java
@@ -10,6 +10,7 @@ import com.jjikmuk.sikdorak.review.exception.InvalidReviewVisibilityException;
 import com.jjikmuk.sikdorak.review.exception.InvalidReviewVisitedDateException;
 import com.jjikmuk.sikdorak.review.exception.InvalidTagException;
 import com.jjikmuk.sikdorak.review.exception.InvalidTagsException;
+import com.jjikmuk.sikdorak.store.exception.InvalidContactNumberException;
 import com.jjikmuk.sikdorak.store.exception.InvalidStoreNameException;
 import com.jjikmuk.sikdorak.store.exception.StoreNotFoundException;
 import com.jjikmuk.sikdorak.user.exception.DuplicateUserException;
@@ -33,6 +34,7 @@ public enum ExceptionCodeAndMessages implements CodeAndMessages {
     // Store
     NOT_FOUND_STORE("F-S001", "Store Id를 찾을 수 없습니다.", StoreNotFoundException.class),
     INVALID_STORE_NAME("F-S002", "유효하지 않은 가게이름 입니다.",InvalidStoreNameException.class),
+    INVALID_CONTACT_NUMER("F-S003", "유효하지 않은 연락처 입니다.", InvalidContactNumberException.class),
 
     // User
     DUPLICATE_USER("F-U001", "중복된 유저입니다.",DuplicateUserException.class),

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/exception/ExceptionCodeAndMessages.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/exception/ExceptionCodeAndMessages.java
@@ -12,6 +12,7 @@ import com.jjikmuk.sikdorak.review.exception.InvalidTagException;
 import com.jjikmuk.sikdorak.review.exception.InvalidTagsException;
 import com.jjikmuk.sikdorak.store.exception.InvalidAddressException;
 import com.jjikmuk.sikdorak.store.exception.InvalidContactNumberException;
+import com.jjikmuk.sikdorak.store.exception.InvalidStoreLocationException;
 import com.jjikmuk.sikdorak.store.exception.InvalidStoreNameException;
 import com.jjikmuk.sikdorak.store.exception.StoreNotFoundException;
 import com.jjikmuk.sikdorak.user.exception.DuplicateUserException;
@@ -37,6 +38,7 @@ public enum ExceptionCodeAndMessages implements CodeAndMessages {
     INVALID_STORE_NAME("F-S002", "유효하지 않은 가게이름 입니다.",InvalidStoreNameException.class),
     INVALID_CONTACT_NUMER("F-S003", "유효하지 않은 연락처 입니다.", InvalidContactNumberException.class),
     INVALID_ADDRESS("F-S004", "유효하지 않은 연락처 입니다.", InvalidAddressException.class),
+    INVALID_STORE_LOCATION("F-S005", "유효하지 않은 좌표 입니다.",InvalidStoreLocationException .class),
 
     // User
     DUPLICATE_USER("F-U001", "중복된 유저입니다.",DuplicateUserException.class),

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/exception/ExceptionCodeAndMessages.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/exception/ExceptionCodeAndMessages.java
@@ -10,6 +10,7 @@ import com.jjikmuk.sikdorak.review.exception.InvalidReviewVisibilityException;
 import com.jjikmuk.sikdorak.review.exception.InvalidReviewVisitedDateException;
 import com.jjikmuk.sikdorak.review.exception.InvalidTagException;
 import com.jjikmuk.sikdorak.review.exception.InvalidTagsException;
+import com.jjikmuk.sikdorak.store.exception.InvalidStoreNameException;
 import com.jjikmuk.sikdorak.store.exception.StoreNotFoundException;
 import com.jjikmuk.sikdorak.user.exception.DuplicateUserException;
 import com.jjikmuk.sikdorak.user.exception.InvalidUserEmailException;
@@ -31,6 +32,7 @@ public enum ExceptionCodeAndMessages implements CodeAndMessages {
 
     // Store
     NOT_FOUND_STORE("F-S001", "Store Id를 찾을 수 없습니다.", StoreNotFoundException.class),
+    INVALID_STORE_NAME("F-S002", "유효하지 않은 가게이름 입니다.",InvalidStoreNameException.class),
 
     // User
     DUPLICATE_USER("F-U001", "중복된 유저입니다.",DuplicateUserException.class),

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/exception/ExceptionCodeAndMessages.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/exception/ExceptionCodeAndMessages.java
@@ -10,6 +10,7 @@ import com.jjikmuk.sikdorak.review.exception.InvalidReviewVisibilityException;
 import com.jjikmuk.sikdorak.review.exception.InvalidReviewVisitedDateException;
 import com.jjikmuk.sikdorak.review.exception.InvalidTagException;
 import com.jjikmuk.sikdorak.review.exception.InvalidTagsException;
+import com.jjikmuk.sikdorak.store.exception.InvalidAddressException;
 import com.jjikmuk.sikdorak.store.exception.InvalidContactNumberException;
 import com.jjikmuk.sikdorak.store.exception.InvalidStoreNameException;
 import com.jjikmuk.sikdorak.store.exception.StoreNotFoundException;
@@ -35,6 +36,7 @@ public enum ExceptionCodeAndMessages implements CodeAndMessages {
     NOT_FOUND_STORE("F-S001", "Store Id를 찾을 수 없습니다.", StoreNotFoundException.class),
     INVALID_STORE_NAME("F-S002", "유효하지 않은 가게이름 입니다.",InvalidStoreNameException.class),
     INVALID_CONTACT_NUMER("F-S003", "유효하지 않은 연락처 입니다.", InvalidContactNumberException.class),
+    INVALID_ADDRESS("F-S004", "유효하지 않은 연락처 입니다.", InvalidAddressException.class),
 
     // User
     DUPLICATE_USER("F-U001", "중복된 유저입니다.",DuplicateUserException.class),

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/controller/StoreController.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/controller/StoreController.java
@@ -20,7 +20,7 @@ public class StoreController {
     private final StoreService storeService;
 
     @GetMapping("api/stores")
-    public CommonResponseEntity<List<StoreFindResponse>> findStore(@RequestParam("storeName") String storeName ) {
+    public CommonResponseEntity<List<StoreFindResponse>> findStoresByStoreName(@RequestParam("storeName") String storeName ) {
         List<StoreFindResponse> findResponseList = storeService.findStoresByStoreNameContaining(storeName);
 
         return new CommonResponseEntity<>(STORE_FIND_SUCCESS, findResponseList, HttpStatus.OK);

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/controller/StoreController.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/controller/StoreController.java
@@ -1,0 +1,29 @@
+package com.jjikmuk.sikdorak.store.controller;
+
+import com.jjikmuk.sikdorak.common.response.CommonResponseEntity;
+import com.jjikmuk.sikdorak.store.controller.response.StoreFindResponse;
+import com.jjikmuk.sikdorak.store.service.StoreService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+import static com.jjikmuk.sikdorak.common.ResponseCodeAndMessages.STORE_FIND_SUCCESS;
+
+@RestController
+@RequiredArgsConstructor
+public class StoreController {
+
+    private final StoreService storeService;
+
+    @GetMapping("api/stores")
+    public CommonResponseEntity<List<StoreFindResponse>> findStore(@RequestParam("storeName") String storeName ) {
+        List<StoreFindResponse> findResponseList = storeService.findStoresByStoreNameContaining(storeName);
+
+        return new CommonResponseEntity<>(STORE_FIND_SUCCESS, findResponseList, HttpStatus.OK);
+    }
+
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/controller/response/StoreFindResponse.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/controller/response/StoreFindResponse.java
@@ -1,0 +1,24 @@
+package com.jjikmuk.sikdorak.store.controller.response;
+
+import com.jjikmuk.sikdorak.store.domain.Store;
+
+public record StoreFindResponse(long id,
+                                String storeName,
+                                String contactNumber,
+                                String baseAddress,
+                                String detailAddress,
+                                double latitude,
+                                double longitude) {
+
+    public static StoreFindResponse from(Store store) {
+        return new StoreFindResponse(
+                store.getId(),
+                store.getStoreName(),
+                store.getContactNumber(),
+                store.getBaseAddress(),
+                store.getDetailAddress(),
+                store.getLatitude(),
+                store.getLongitude()
+        );
+    }
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/domain/Address.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/domain/Address.java
@@ -1,0 +1,60 @@
+package com.jjikmuk.sikdorak.store.domain;
+
+import com.jjikmuk.sikdorak.store.exception.InvalidAddressException;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Embeddable;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Address {
+
+    private static final int BASEADDRESS_LENGTH = 255;
+    private static final int DETAILADDRESS_LENGTH = 50;
+
+    private String baseAddress;
+
+    private String detailAddress;
+
+    public Address(String baseAddress) {
+        this(baseAddress, null);
+    }
+
+    public Address(String baseAddress, String detailAddress) {
+        validateBaseAddress(baseAddress);
+        validateDetailAddress(detailAddress);
+
+        this.baseAddress = baseAddress;
+        this.detailAddress = detailAddress;
+    }
+
+    private void validateBaseAddress(String baseAddress) {
+        // baseAddress 는 not null, not empty, 255자 제한, 한글 숫자만
+        if (Objects.isNull(baseAddress) ||
+                baseAddress.isBlank() ||
+                baseAddress.length() > BASEADDRESS_LENGTH ||
+                !isContainsOnlyKoreanAndNumber(baseAddress)) {
+            throw new InvalidAddressException();
+        }
+    }
+
+    private void validateDetailAddress(String detailAddress) {
+        // detailAddress 는 null 이 아닌 경우, not empty, 50자 제한, 한글 숫자만
+        if (Objects.nonNull(detailAddress) &&
+                (detailAddress.isBlank() ||
+                        detailAddress.length() > BASEADDRESS_LENGTH ||
+                        !isContainsOnlyKoreanAndNumber(detailAddress))
+        ) {
+            throw new InvalidAddressException();
+        }
+    }
+
+    private boolean isContainsOnlyKoreanAndNumber(String text) {
+        return Pattern.matches("^[가-힣 0-9]*$", text);
+    }
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/domain/Address.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/domain/Address.java
@@ -16,6 +16,7 @@ public class Address {
 
     private static final int BASEADDRESS_LENGTH = 255;
     private static final int DETAILADDRESS_LENGTH = 50;
+    private static final String REGEX_ONLY_KOREAN_AND_NUMBER = "^[가-힣 0-9]*$";
 
     private String baseAddress;
 
@@ -47,7 +48,7 @@ public class Address {
         // detailAddress 는 null 이 아닌 경우, not empty, 50자 제한, 한글 숫자만
         if (Objects.nonNull(detailAddress) &&
                 (detailAddress.isBlank() ||
-                        detailAddress.length() > BASEADDRESS_LENGTH ||
+                        detailAddress.length() > DETAILADDRESS_LENGTH ||
                         !isContainsOnlyKoreanAndNumber(detailAddress))
         ) {
             throw new InvalidAddressException();
@@ -55,6 +56,6 @@ public class Address {
     }
 
     private boolean isContainsOnlyKoreanAndNumber(String text) {
-        return Pattern.matches("^[가-힣 0-9]*$", text);
+        return Pattern.matches(REGEX_ONLY_KOREAN_AND_NUMBER, text);
     }
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/domain/ContactNumber.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/domain/ContactNumber.java
@@ -1,0 +1,46 @@
+package com.jjikmuk.sikdorak.store.domain;
+
+import com.jjikmuk.sikdorak.store.exception.InvalidContactNumberException;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class ContactNumber {
+
+    /**
+     * 허용되는 전화번호 형식 <br>
+     * - 00-000-0000 <br>
+     * - 00-0000-0000 <br>
+     * - 000-000-0000 <br>
+     * - 000-0000-0000
+     */
+
+    private static final int LIMIT_LENGTH = 13;
+    private static final Pattern numberPattern = Pattern.compile("\\d{2,3}-\\d{3,4}-\\d{4}");
+
+    @Column(length = LIMIT_LENGTH)
+    private String contactNumber;
+
+    public ContactNumber(String contactNumber) {
+        if (Objects.isNull(contactNumber) ||
+                contactNumber.isBlank() ||
+                contactNumber.length() > LIMIT_LENGTH ||
+                !isPatternMatches(contactNumber, numberPattern)) {
+            throw new InvalidContactNumberException();
+        }
+
+        this.contactNumber = contactNumber;
+    }
+
+    private boolean isPatternMatches(String contactNumber, Pattern pattern) {
+        return pattern.matcher(contactNumber).matches();
+    }
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/domain/Store.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/domain/Store.java
@@ -38,11 +38,31 @@ public class Store extends BaseTimeEntity {
         this.location = new StoreLocation(latitude, longitude);
     }
 
+    public Long getId() {
+        return id;
+    }
+
     public String getStoreName() {
         return storeName.getStoreName();
     }
 
-    public Long getId() {
-        return id;
+    public String getContactNumber() {
+        return contactNumber.getContactNumber();
+    }
+
+    public String getBaseAddress() {
+        return address.getBaseAddress();
+    }
+
+    public String getDetailAddress() {
+        return address.getDetailAddress();
+    }
+
+    public double getLatitude() {
+        return location.latitude();
+    }
+
+    public double getLongitude() {
+        return location.longitude();
     }
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/domain/Store.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/domain/Store.java
@@ -4,6 +4,7 @@ import com.jjikmuk.sikdorak.common.domain.BaseTimeEntity;
 import lombok.Getter;
 
 import javax.persistence.Column;
+import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -16,6 +17,19 @@ public class Store extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "storeId")
+    @Column(name = "store_id")
     private Long id;
+
+    @Embedded
+    private StoreName storeName;
+
+    @Embedded
+    private ContactNumber contactNumber;
+
+    @Embedded
+    private Address address; // baseAddress, detailAddress
+
+    @Embedded
+    private StoreLocation location; // Float latitude, Float longitude
+
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/domain/Store.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/domain/Store.java
@@ -1,7 +1,7 @@
 package com.jjikmuk.sikdorak.store.domain;
 
 import com.jjikmuk.sikdorak.common.domain.BaseTimeEntity;
-import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.Column;
 import javax.persistence.Embedded;
@@ -11,8 +11,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 
 @Entity
-@Getter
-
+@NoArgsConstructor // for @Entity
 public class Store extends BaseTimeEntity {
 
     @Id
@@ -32,4 +31,18 @@ public class Store extends BaseTimeEntity {
     @Embedded
     private StoreLocation location; // Float latitude, Float longitude
 
+    public Store(String storeName, String contactNumber, String baseAddress, String detailAddress, Double latitude, Double longitude) {
+        this.storeName = new StoreName(storeName);
+        this.contactNumber = new ContactNumber(contactNumber);
+        this.address = new Address(baseAddress, detailAddress);
+        this.location = new StoreLocation(latitude, longitude);
+    }
+
+    public String getStoreName() {
+        return storeName.getStoreName();
+    }
+
+    public Long getId() {
+        return id;
+    }
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/domain/StoreLocation.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/domain/StoreLocation.java
@@ -1,0 +1,45 @@
+package com.jjikmuk.sikdorak.store.domain;
+
+import com.jjikmuk.sikdorak.store.exception.InvalidStoreLocationException;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.data.geo.Point;
+
+import javax.persistence.Embeddable;
+import java.util.Objects;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StoreLocation {
+
+    private static final double LATITUDE_MIN = -90.0;
+    private static final double LATITUDE_MAX = 90.0;
+    private static final double LONGITUDE_MIN = -180.0;
+    private static final double LONGITUDE_MAX = 180.0;
+
+    private Point storePoint;
+
+    public StoreLocation(Double latitude, Double longitude) {
+        if (Objects.isNull(latitude) ||
+                Objects.isNull(longitude) ||
+                !isInRange(latitude, LATITUDE_MIN, LATITUDE_MAX) ||
+                !isInRange(longitude, LONGITUDE_MIN, LONGITUDE_MAX)) {
+            throw new InvalidStoreLocationException();
+        }
+
+        // longitude = X, latitude = Y
+        this.storePoint = new Point(longitude, latitude);
+    }
+
+    private boolean isInRange(double value, double min, double max) {
+        return min <= value && value <= max;
+    }
+
+    public double latitude() {
+        return storePoint.getY();
+    }
+
+    public double longitude() {
+        return storePoint.getX();
+    }
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/domain/StoreName.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/domain/StoreName.java
@@ -1,0 +1,31 @@
+package com.jjikmuk.sikdorak.store.domain;
+
+import com.jjikmuk.sikdorak.store.exception.InvalidStoreNameException;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import java.util.Objects;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class StoreName {
+
+    private static final int LIMIT_LENGTH = 50;
+
+    @Column(length = LIMIT_LENGTH)
+    private String storeName;
+
+    public StoreName(String storeName) {
+        if (Objects.isNull(storeName) ||
+                storeName.isBlank() ||
+                storeName.length() > LIMIT_LENGTH) {
+            throw new InvalidStoreNameException();
+        }
+
+        this.storeName = storeName;
+    }
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/exception/InvalidAddressException.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/exception/InvalidAddressException.java
@@ -1,0 +1,12 @@
+package com.jjikmuk.sikdorak.store.exception;
+
+import com.jjikmuk.sikdorak.common.exception.SikdorakRuntimeException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidAddressException extends SikdorakRuntimeException {
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HttpStatus.BAD_REQUEST;
+    }
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/exception/InvalidContactNumberException.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/exception/InvalidContactNumberException.java
@@ -1,0 +1,12 @@
+package com.jjikmuk.sikdorak.store.exception;
+
+import com.jjikmuk.sikdorak.common.exception.SikdorakRuntimeException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidContactNumberException extends SikdorakRuntimeException {
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HttpStatus.BAD_REQUEST;
+    }
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/exception/InvalidStoreLocationException.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/exception/InvalidStoreLocationException.java
@@ -1,0 +1,12 @@
+package com.jjikmuk.sikdorak.store.exception;
+
+import com.jjikmuk.sikdorak.common.exception.SikdorakRuntimeException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidStoreLocationException extends SikdorakRuntimeException {
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HttpStatus.BAD_REQUEST;
+    }
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/exception/InvalidStoreNameException.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/exception/InvalidStoreNameException.java
@@ -1,0 +1,12 @@
+package com.jjikmuk.sikdorak.store.exception;
+
+import com.jjikmuk.sikdorak.common.exception.SikdorakRuntimeException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidStoreNameException extends SikdorakRuntimeException {
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HttpStatus.BAD_REQUEST;
+    }
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/repository/StoreRepository.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/repository/StoreRepository.java
@@ -2,7 +2,13 @@ package com.jjikmuk.sikdorak.store.repository;
 
 import com.jjikmuk.sikdorak.store.domain.Store;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface StoreRepository extends JpaRepository<Store, Long> {
+
+    @Query("select s from Store s where s.storeName.storeName like %:storeName%")
+    List<Store> findStoresByStoreNameContaining(@Param("storeName") String storeName);
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/service/StoreService.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/service/StoreService.java
@@ -1,5 +1,6 @@
 package com.jjikmuk.sikdorak.store.service;
 
+import com.jjikmuk.sikdorak.store.controller.response.StoreFindResponse;
 import com.jjikmuk.sikdorak.store.domain.Store;
 import com.jjikmuk.sikdorak.store.exception.StoreNotFoundException;
 import com.jjikmuk.sikdorak.store.repository.StoreRepository;
@@ -23,11 +24,14 @@ public class StoreService {
 		return storeRepository.findById(storeId).orElseThrow(StoreNotFoundException::new);
 	}
 
-	public List<Store> findStoresByStoreNameContaining(String storeName) {
+	public List<StoreFindResponse> findStoresByStoreNameContaining(String storeName) {
 		if (storeName == null) {
 			return Collections.emptyList();
 		}
 
-		return storeRepository.findStoresByStoreNameContaining(storeName);
+		return storeRepository.findStoresByStoreNameContaining(storeName)
+				.stream()
+				.map(StoreFindResponse::from)
+				.toList();
 	}
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/service/StoreService.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/service/StoreService.java
@@ -6,6 +6,8 @@ import com.jjikmuk.sikdorak.store.repository.StoreRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 
 @Service
@@ -21,4 +23,11 @@ public class StoreService {
 		return storeRepository.findById(storeId).orElseThrow(StoreNotFoundException::new);
 	}
 
+	public List<Store> findStoresByStoreNameContaining(String storeName) {
+		if (storeName == null) {
+			return Collections.emptyList();
+		}
+
+		return storeRepository.findStoresByStoreNameContaining(storeName);
+	}
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/InitAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/InitAcceptanceTest.java
@@ -22,6 +22,18 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.operation.preprocess.OperationPreprocessor;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.restdocs.snippet.Snippet;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.modifyUris;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.documentationConfiguration;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @ExtendWith(RestDocumentationExtension.class)
@@ -46,10 +58,36 @@ public class InitAcceptanceTest extends MysqlTestContainer {
 		setUpRestAssured();
 	}
 
+	protected static Snippet commonResponseFields(FieldDescriptor ...responseFieldDescriptors) {
+		List<FieldDescriptor> commonResponseFieldDescriptors = new ArrayList<>();
+
+		commonResponseFieldDescriptors.add(fieldWithPath("code").type(JsonFieldType.STRING).description("결과 코드"));
+		commonResponseFieldDescriptors.add(fieldWithPath("message").type(JsonFieldType.STRING).description("메세지"));
+
+		final String dataPrefix = "data.[].";
+
+		for (FieldDescriptor responseField : responseFieldDescriptors) {
+			FieldDescriptor dataField = fieldWithPath(dataPrefix + responseField.getPath()).type(responseField.getType()).description(responseField.getDescription());
+
+			if (responseField.isOptional()) {
+				dataField.optional();
+			}
+
+			commonResponseFieldDescriptors.add(dataField);
+		}
+
+		return responseFields(commonResponseFieldDescriptors);
+	}
+
 	@BeforeEach
 	void setUpDataBase() {
 		testData.clear();
-		testData.initDataSource();
+		testData.initDataSource("맛있는가게",
+				"02-0000-0000",
+				"서울시 송파구 좋은길 1",
+				"1층 101호",
+				37.5093890,
+				127.105143);
 	}
 
 	@BeforeEach

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/InitAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/InitAcceptanceTest.java
@@ -1,9 +1,5 @@
 package com.jjikmuk.sikdorak.acceptance;
 
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.modifyUris;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
-import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.documentationConfiguration;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jjikmuk.sikdorak.common.DatabaseConfigurator;
 import com.jjikmuk.sikdorak.common.MysqlTestContainer;
@@ -22,17 +18,9 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.operation.preprocess.OperationPreprocessor;
-import org.springframework.restdocs.payload.FieldDescriptor;
-import org.springframework.restdocs.payload.JsonFieldType;
-import org.springframework.restdocs.snippet.Snippet;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.modifyUris;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.documentationConfiguration;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
@@ -58,36 +46,10 @@ public class InitAcceptanceTest extends MysqlTestContainer {
 		setUpRestAssured();
 	}
 
-	protected static Snippet commonResponseFields(FieldDescriptor ...responseFieldDescriptors) {
-		List<FieldDescriptor> commonResponseFieldDescriptors = new ArrayList<>();
-
-		commonResponseFieldDescriptors.add(fieldWithPath("code").type(JsonFieldType.STRING).description("결과 코드"));
-		commonResponseFieldDescriptors.add(fieldWithPath("message").type(JsonFieldType.STRING).description("메세지"));
-
-		final String dataPrefix = "data.[].";
-
-		for (FieldDescriptor responseField : responseFieldDescriptors) {
-			FieldDescriptor dataField = fieldWithPath(dataPrefix + responseField.getPath()).type(responseField.getType()).description(responseField.getDescription());
-
-			if (responseField.isOptional()) {
-				dataField.optional();
-			}
-
-			commonResponseFieldDescriptors.add(dataField);
-		}
-
-		return responseFields(commonResponseFieldDescriptors);
-	}
-
 	@BeforeEach
 	void setUpDataBase() {
 		testData.clear();
-		testData.initDataSource("맛있는가게",
-				"02-0000-0000",
-				"서울시 송파구 좋은길 1",
-				"1층 101호",
-				37.5093890,
-				127.105143);
+		testData.initDataSource();
 	}
 
 	@BeforeEach

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/StoreAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/StoreAcceptanceTest.java
@@ -1,62 +1,48 @@
 package com.jjikmuk.sikdorak.acceptance;
 
 import com.jjikmuk.sikdorak.common.ResponseCodeAndMessages;
+import com.jjikmuk.sikdorak.store.domain.Store;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.restdocs.payload.JsonFieldType;
-import org.springframework.restdocs.snippet.Snippet;
 
+import static com.jjikmuk.sikdorak.acceptance.store.StoreSnippet.STORE_FIND_REQUEST;
+import static com.jjikmuk.sikdorak.acceptance.store.StoreSnippet.STORE_FIND_RESPONSE;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.hasItem;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
 import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
 
 @DisplayName("Store 인수테스트")
 public class StoreAcceptanceTest extends InitAcceptanceTest {
 
-    private static final Snippet STORE_FIND_REQUEST = requestParameters(
-            parameterWithName("storeName").description("가게 이름 검색 키워드")
-    );
-
-    private static final Snippet STORE_FIND_RESPONSE = commonResponseFields(
-            fieldWithPath("id").type(JsonFieldType.NUMBER).description("가게 아이디"),
-            fieldWithPath("storeName").type(JsonFieldType.STRING).description("가게 이름"),
-            fieldWithPath("contactNumber").type(JsonFieldType.STRING).description("가게 연락처"),
-            fieldWithPath("baseAddress").type(JsonFieldType.STRING).description("주소"),
-            fieldWithPath("detailAddress").type(JsonFieldType.STRING).description("상세 주소").optional(),
-            fieldWithPath("latitude").type(JsonFieldType.NUMBER).description("위도"),
-            fieldWithPath("longitude").type(JsonFieldType.NUMBER).description("경도")
-    );
-
     @Test
     @DisplayName("가게를 이름으로 검색할때 조건에 맞는 가게가 있으면 가게 목록이 반환된다.")
     void find_store_by_name_containing_success() {
+        Store savedStore = testData.store;
+
         ResponseCodeAndMessages expectedCodeAndMessage = ResponseCodeAndMessages.STORE_FIND_SUCCESS;
         String storeNameSearchKeywork = "가게";
 
         given(this.spec)
-                .filter(document(DEFAULT_RESTDOC_PATH, STORE_FIND_REQUEST, STORE_FIND_RESPONSE))
-                .accept(MediaType.APPLICATION_JSON_VALUE)
-                .header("Content-type", "application/json")
-                .param("storeName", storeNameSearchKeywork)
+            .filter(document(DEFAULT_RESTDOC_PATH, STORE_FIND_REQUEST, STORE_FIND_RESPONSE))
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+            .header("Content-type", "application/json")
+            .param("storeName", storeNameSearchKeywork)
 
         .when()
-                .get("/api/stores")
+            .get("/api/stores")
 
-        .then().log().all()
-                .statusCode(HttpStatus.OK.value())
-                .body("code", equalTo(expectedCodeAndMessage.getCode()))
-                .body("message", equalTo(expectedCodeAndMessage.getMessage()))
-                .body("data.id", hasItem(savedStore.getId().intValue()))
-                .body("data.storeName", everyItem(containsString(savedStore.getStoreName())));
+        .then()
+            .statusCode(HttpStatus.OK.value())
+            .body("code", equalTo(expectedCodeAndMessage.getCode()))
+            .body("message", equalTo(expectedCodeAndMessage.getMessage()))
+            .body("data.id", hasItem(savedStore.getId().intValue()))
+            .body("data.storeName", everyItem(containsString(savedStore.getStoreName())));
     }
 
     @Test
@@ -66,17 +52,17 @@ public class StoreAcceptanceTest extends InitAcceptanceTest {
         String notExistStoreName = "존재하지않는가게이름테스트를위한가게이름";
 
         given()
-                .accept(MediaType.APPLICATION_JSON_VALUE)
-                .header("Content-type", "application/json")
-                .param("storeName", notExistStoreName)
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+            .header("Content-type", "application/json")
+            .param("storeName", notExistStoreName)
 
-                .when()
-                .get("/api/stores")
+        .when()
+            .get("/api/stores")
 
-                .then()
-                .statusCode(HttpStatus.OK.value())
-                .body("code", equalTo(expectedCodeAndMessage.getCode()))
-                .body("message", equalTo(expectedCodeAndMessage.getMessage()))
-                .body("data", empty());
+        .then()
+            .statusCode(HttpStatus.OK.value())
+            .body("code", equalTo(expectedCodeAndMessage.getCode()))
+            .body("message", equalTo(expectedCodeAndMessage.getMessage()))
+            .body("data", empty());
     }
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/StoreAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/StoreAcceptanceTest.java
@@ -1,0 +1,82 @@
+package com.jjikmuk.sikdorak.acceptance;
+
+import com.jjikmuk.sikdorak.common.ResponseCodeAndMessages;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.restdocs.snippet.Snippet;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.hasItem;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
+import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
+
+@DisplayName("Store 인수테스트")
+public class StoreAcceptanceTest extends InitAcceptanceTest {
+
+    private static final Snippet STORE_FIND_REQUEST = requestParameters(
+            parameterWithName("storeName").description("가게 이름 검색 키워드")
+    );
+
+    private static final Snippet STORE_FIND_RESPONSE = commonResponseFields(
+            fieldWithPath("id").type(JsonFieldType.NUMBER).description("가게 아이디"),
+            fieldWithPath("storeName").type(JsonFieldType.STRING).description("가게 이름"),
+            fieldWithPath("contactNumber").type(JsonFieldType.STRING).description("가게 연락처"),
+            fieldWithPath("baseAddress").type(JsonFieldType.STRING).description("주소"),
+            fieldWithPath("detailAddress").type(JsonFieldType.STRING).description("상세 주소").optional(),
+            fieldWithPath("latitude").type(JsonFieldType.NUMBER).description("위도"),
+            fieldWithPath("longitude").type(JsonFieldType.NUMBER).description("경도")
+    );
+
+    @Test
+    @DisplayName("가게를 이름으로 검색할때 조건에 맞는 가게가 있으면 가게 목록이 반환된다.")
+    void find_store_by_name_containing_success() {
+        ResponseCodeAndMessages expectedCodeAndMessage = ResponseCodeAndMessages.STORE_FIND_SUCCESS;
+        String storeNameSearchKeywork = "가게";
+
+        given(this.spec)
+                .filter(document(DEFAULT_RESTDOC_PATH, STORE_FIND_REQUEST, STORE_FIND_RESPONSE))
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .header("Content-type", "application/json")
+                .param("storeName", storeNameSearchKeywork)
+
+        .when()
+                .get("/api/stores")
+
+        .then().log().all()
+                .statusCode(HttpStatus.OK.value())
+                .body("code", equalTo(expectedCodeAndMessage.getCode()))
+                .body("message", equalTo(expectedCodeAndMessage.getMessage()))
+                .body("data.id", hasItem(savedStore.getId().intValue()))
+                .body("data.storeName", everyItem(containsString(savedStore.getStoreName())));
+    }
+
+    @Test
+    @DisplayName("가게를 이름으로 검색할때 조건에 맞는 가게가 없으면 빈 목록이 반환된다.")
+    void find_store_by_name_containing_failed() {
+        ResponseCodeAndMessages expectedCodeAndMessage = ResponseCodeAndMessages.STORE_FIND_SUCCESS;
+        String notExistStoreName = "존재하지않는가게이름테스트를위한가게이름";
+
+        given()
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .header("Content-type", "application/json")
+                .param("storeName", notExistStoreName)
+
+                .when()
+                .get("/api/stores")
+
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .body("code", equalTo(expectedCodeAndMessage.getCode()))
+                .body("message", equalTo(expectedCodeAndMessage.getMessage()))
+                .body("data", empty());
+    }
+}

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/StoreAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/StoreAcceptanceTest.java
@@ -26,7 +26,7 @@ public class StoreAcceptanceTest extends InitAcceptanceTest {
         Store savedStore = testData.store;
 
         ResponseCodeAndMessages expectedCodeAndMessage = ResponseCodeAndMessages.STORE_FIND_SUCCESS;
-        String storeNameSearchKeywork = "가게";
+        String storeNameSearchKeywork = savedStore.getStoreName();
 
         given(this.spec)
             .filter(document(DEFAULT_RESTDOC_PATH, STORE_FIND_REQUEST, STORE_FIND_RESPONSE))

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/store/StoreSnippet.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/store/StoreSnippet.java
@@ -1,0 +1,28 @@
+package com.jjikmuk.sikdorak.acceptance.store;
+
+import com.jjikmuk.sikdorak.store.controller.response.StoreFindResponse;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.restdocs.snippet.Snippet;
+
+import static com.jjikmuk.sikdorak.acceptance.DocumentFormatGenerator.commonResponseFieldsWithValidConstraints;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
+
+public interface StoreSnippet {
+
+	Snippet STORE_FIND_REQUEST = requestParameters(
+			parameterWithName("storeName").description("가게 이름 검색 키워드")
+	);
+
+	Snippet STORE_FIND_RESPONSE = commonResponseFieldsWithValidConstraints(
+			StoreFindResponse.class,
+			fieldWithPath("id").type(JsonFieldType.NUMBER).description("가게 아이디"),
+			fieldWithPath("storeName").type(JsonFieldType.STRING).description("가게 이름"),
+			fieldWithPath("contactNumber").type(JsonFieldType.STRING).description("가게 연락처"),
+			fieldWithPath("baseAddress").type(JsonFieldType.STRING).description("주소"),
+			fieldWithPath("detailAddress").type(JsonFieldType.STRING).description("상세 주소").optional(),
+			fieldWithPath("latitude").type(JsonFieldType.NUMBER).description("위도"),
+			fieldWithPath("longitude").type(JsonFieldType.NUMBER).description("경도")
+	);
+}

--- a/be/src/test/java/com/jjikmuk/sikdorak/common/DatabaseConfigurator.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/common/DatabaseConfigurator.java
@@ -28,7 +28,12 @@ public class DatabaseConfigurator implements InitializingBean {
 	public Store store;
 
 	public void initDataSource() {
-		this.store = storeRepository.save(new Store());
+		this.store = storeRepository.save(new Store("맛있는가게",
+				"02-0000-0000",
+				"서울시 송파구 좋은길 1",
+				"1층 101호",
+				37.5093890,
+				127.105143));
 	}
 
 	public void clear() {

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/store/StoreFindIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/store/StoreFindIntegrationTest.java
@@ -1,0 +1,114 @@
+package com.jjikmuk.sikdorak.integration.store;
+
+import com.jjikmuk.sikdorak.integration.InitIntegrationTest;
+import com.jjikmuk.sikdorak.store.domain.Store;
+import com.jjikmuk.sikdorak.store.repository.StoreRepository;
+import com.jjikmuk.sikdorak.store.service.StoreService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("StoreFind 통합테스트")
+public class StoreFindIntegrationTest extends InitIntegrationTest {
+
+    @Autowired
+    private StoreService storeService;
+
+    @Autowired
+    private StoreRepository storeRepository;
+
+    @Nested
+    @DisplayName("가게 이름으로 검색할 때")
+    class FindStoreByStoreName {
+
+        private static final String STORE_NAME = "맛있는가게";
+        private static final String CONTACT_NUMBER = "02-0000-0000";
+        private static final String BASE_ADDRESS = "서울시 송파구 좋은길 1";
+        private static final String DETAIL_ADDRESS = "1층 101호";
+        private static final double LATITUDE = 37.5093890;
+        private static final double LONGITUDE = 127.105143;
+
+        Store savedStore = null;
+
+        @BeforeEach
+        void setUp() {
+            storeRepository.deleteAll();
+            savedStore = storeRepository.save(new Store(
+                    STORE_NAME,
+                    CONTACT_NUMBER,
+                    BASE_ADDRESS,
+                    DETAIL_ADDRESS,
+                    LATITUDE,
+                    LONGITUDE
+            ));
+        }
+
+        @Test
+        @DisplayName("저장된 가게 이름과 일치하면 가게 목록이 반환된다.")
+        void exactly_same_store_name_returns_store_list() {
+            // given
+            String storeName = STORE_NAME;
+
+            // when
+            List<Store> stores = storeService.findStoresByStoreNameContaining(storeName);
+
+            // then
+            assertThat(stores).isNotNull();
+            assertThat(stores).isNotEmpty();
+            for (Store store : stores) {
+                assertThat(store.getStoreName()).contains(storeName);
+            }
+        }
+
+        @Test
+        @DisplayName("저장된 가게 이름과 일부분만 일치해도 가게 목록이 반환된다.")
+        void partially_same_store_name_returns_store_list() {
+            // given
+            String storeName = "가게";
+
+            // when
+            List<Store> stores = storeService.findStoresByStoreNameContaining(storeName);
+
+            // then
+            assertThat(stores).isNotNull();
+            assertThat(stores).isNotEmpty();
+            for (Store store : stores) {
+                assertThat(store.getStoreName()).contains(storeName);
+            }
+        }
+
+        @Test
+        @DisplayName("가게 이름이 null 이면 빈 목록이 반환된다.")
+        void null_store_name_returns_empty_list() {
+            // given
+            String storeName = null;
+
+            // when
+            List<Store> stores = storeService.findStoresByStoreNameContaining(storeName);
+
+            // then
+            assertThat(stores).isNotNull();
+            assertThat(stores).isEmpty();
+        }
+
+        @Test
+        @DisplayName("저장된 가게 이름과 일치하는 부분이 없으면 빈 목록이 반환된다.")
+        void not_same_store_name_returns_empty_list() {
+            // given
+            String storeName = "존재하지않는가게이름";
+
+            // when
+            List<Store> stores = storeService.findStoresByStoreNameContaining(storeName);
+
+            // then
+            assertThat(stores).isNotNull();
+            assertThat(stores).isEmpty();
+        }
+    }
+}

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/store/StoreFindIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/store/StoreFindIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.jjikmuk.sikdorak.integration.store;
 
 import com.jjikmuk.sikdorak.integration.InitIntegrationTest;
+import com.jjikmuk.sikdorak.store.controller.response.StoreFindResponse;
 import com.jjikmuk.sikdorak.store.domain.Store;
 import com.jjikmuk.sikdorak.store.repository.StoreRepository;
 import com.jjikmuk.sikdorak.store.service.StoreService;
@@ -56,13 +57,13 @@ public class StoreFindIntegrationTest extends InitIntegrationTest {
             String storeName = STORE_NAME;
 
             // when
-            List<Store> stores = storeService.findStoresByStoreNameContaining(storeName);
+            List<StoreFindResponse> stores = storeService.findStoresByStoreNameContaining(storeName);
 
             // then
             assertThat(stores).isNotNull();
             assertThat(stores).isNotEmpty();
-            for (Store store : stores) {
-                assertThat(store.getStoreName()).contains(storeName);
+            for (StoreFindResponse store : stores) {
+                assertThat(store.storeName()).contains(storeName);
             }
         }
 
@@ -73,13 +74,13 @@ public class StoreFindIntegrationTest extends InitIntegrationTest {
             String storeName = "가게";
 
             // when
-            List<Store> stores = storeService.findStoresByStoreNameContaining(storeName);
+            List<StoreFindResponse> stores = storeService.findStoresByStoreNameContaining(storeName);
 
             // then
             assertThat(stores).isNotNull();
             assertThat(stores).isNotEmpty();
-            for (Store store : stores) {
-                assertThat(store.getStoreName()).contains(storeName);
+            for (StoreFindResponse store : stores) {
+                assertThat(store.storeName()).contains(storeName);
             }
         }
 
@@ -90,7 +91,7 @@ public class StoreFindIntegrationTest extends InitIntegrationTest {
             String storeName = null;
 
             // when
-            List<Store> stores = storeService.findStoresByStoreNameContaining(storeName);
+            List<StoreFindResponse> stores = storeService.findStoresByStoreNameContaining(storeName);
 
             // then
             assertThat(stores).isNotNull();
@@ -104,7 +105,7 @@ public class StoreFindIntegrationTest extends InitIntegrationTest {
             String storeName = "존재하지않는가게이름";
 
             // when
-            List<Store> stores = storeService.findStoresByStoreNameContaining(storeName);
+            List<StoreFindResponse> stores = storeService.findStoresByStoreNameContaining(storeName);
 
             // then
             assertThat(stores).isNotNull();

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/store/StoreFindIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/store/StoreFindIntegrationTest.java
@@ -1,19 +1,15 @@
 package com.jjikmuk.sikdorak.integration.store;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.jjikmuk.sikdorak.integration.InitIntegrationTest;
 import com.jjikmuk.sikdorak.store.controller.response.StoreFindResponse;
-import com.jjikmuk.sikdorak.store.domain.Store;
-import com.jjikmuk.sikdorak.store.repository.StoreRepository;
 import com.jjikmuk.sikdorak.store.service.StoreService;
-import org.junit.jupiter.api.BeforeEach;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("StoreFind 통합테스트")
 public class StoreFindIntegrationTest extends InitIntegrationTest {
@@ -21,40 +17,15 @@ public class StoreFindIntegrationTest extends InitIntegrationTest {
     @Autowired
     private StoreService storeService;
 
-    @Autowired
-    private StoreRepository storeRepository;
-
     @Nested
     @DisplayName("가게 이름으로 검색할 때")
     class FindStoreByStoreName {
-
-        private static final String STORE_NAME = "맛있는가게";
-        private static final String CONTACT_NUMBER = "02-0000-0000";
-        private static final String BASE_ADDRESS = "서울시 송파구 좋은길 1";
-        private static final String DETAIL_ADDRESS = "1층 101호";
-        private static final double LATITUDE = 37.5093890;
-        private static final double LONGITUDE = 127.105143;
-
-        Store savedStore = null;
-
-        @BeforeEach
-        void setUp() {
-            storeRepository.deleteAll();
-            savedStore = storeRepository.save(new Store(
-                    STORE_NAME,
-                    CONTACT_NUMBER,
-                    BASE_ADDRESS,
-                    DETAIL_ADDRESS,
-                    LATITUDE,
-                    LONGITUDE
-            ));
-        }
 
         @Test
         @DisplayName("저장된 가게 이름과 일치하면 가게 목록이 반환된다.")
         void exactly_same_store_name_returns_store_list() {
             // given
-            String storeName = STORE_NAME;
+            String storeName = testData.store.getStoreName();
 
             // when
             List<StoreFindResponse> stores = storeService.findStoresByStoreNameContaining(storeName);
@@ -71,16 +42,17 @@ public class StoreFindIntegrationTest extends InitIntegrationTest {
         @DisplayName("저장된 가게 이름과 일부분만 일치해도 가게 목록이 반환된다.")
         void partially_same_store_name_returns_store_list() {
             // given
-            String storeName = "가게";
+            String storeFullName = testData.store.getStoreName();
+            String partOfStoreName = storeFullName.substring(0, storeFullName.length() / 2);
 
             // when
-            List<StoreFindResponse> stores = storeService.findStoresByStoreNameContaining(storeName);
+            List<StoreFindResponse> stores = storeService.findStoresByStoreNameContaining(partOfStoreName);
 
             // then
             assertThat(stores).isNotNull();
             assertThat(stores).isNotEmpty();
             for (StoreFindResponse store : stores) {
-                assertThat(store.storeName()).contains(storeName);
+                assertThat(store.storeName()).contains(partOfStoreName);
             }
         }
 

--- a/be/src/test/java/com/jjikmuk/sikdorak/store/domain/AddressTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/store/domain/AddressTest.java
@@ -1,0 +1,108 @@
+package com.jjikmuk.sikdorak.store.domain;
+
+import com.jjikmuk.sikdorak.store.exception.InvalidAddressException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("AddressTest 클래스")
+class AddressTest {
+
+    @Nested
+    @DisplayName("생성자")
+    class Describe_constructor {
+
+        @Nested
+        @DisplayName("만약 정상적인 1~255자 이하의 baseAddress 가 주어진다면")
+        class Context_with_vaild_baseAddress {
+
+            @ParameterizedTest
+            @ValueSource(strings = {"1", "서울 강남구 강남대로62길 23 4층"})
+            @DisplayName("Address 객체를 반환한다")
+            void It_returns_a_object(String baseAddress) {
+                Address address = new Address(baseAddress);
+
+                assertThat(address.getBaseAddress()).isEqualTo(baseAddress);
+            }
+        }
+
+        @Nested
+        @DisplayName("만약 정상적인 1~255자 이하의 baseAddress 와 1~50자 이하의 detailAddress 가 주어진다면")
+        class Context_with_vaild_baseAddress_detailAddress {
+
+            @ParameterizedTest
+            @CsvSource({
+                    "서울 강남구 강남대로62길 23, 4층",
+                    "서울 송파구 석촌호수로 262, 1층"
+            })
+            @DisplayName("Address 객체를 반환한다")
+            void It_returns_a_object(String baseAddress, String detailAddress) {
+                Address address = new Address(baseAddress, detailAddress);
+
+                assertThat(address.getBaseAddress()).isEqualTo(baseAddress);
+                assertThat(address.getDetailAddress()).isEqualTo(detailAddress);
+            }
+        }
+
+        @Nested
+        @DisplayName("만약 유효하지 않은 baseAddress 가 주어진다면")
+        class Context_with_invaild_baseAddress {
+
+            @ParameterizedTest
+            @NullSource
+            @MethodSource("provideAddressForIsNullAndEmptyAndOver255char")
+            @DisplayName("예외를 발생시킨다")
+            void It_throws_error(String baseAddress) {
+                assertThatThrownBy(() -> new Address(baseAddress))
+                        .isInstanceOf(InvalidAddressException.class);
+            }
+
+            private static Stream<Arguments> provideAddressForIsNullAndEmptyAndOver255char() {
+                String content = "a";
+                return Stream.of(
+                        Arguments.of(""),
+                        Arguments.of(" "),
+                        Arguments.of("\t"),
+                        Arguments.of("\n"),
+                        Arguments.of(content.repeat(255 + 1))
+                );
+            }
+        }
+
+        @Nested
+        @DisplayName("만약 유효하지 않은 baseAddress 와 detailAddress 가 주어진다면")
+        class Context_with_invaild_baseAddress_detailAddress {
+
+            @ParameterizedTest
+            @MethodSource("provideAddressForIsNullAndEmptyAndOver50char")
+            @DisplayName("예외를 발생시킨다")
+            void It_throws_error(String detailAddress) {
+                String baseAddress = "서울 강남구 강남대로62길 23";
+
+                assertThatThrownBy(() -> new Address(baseAddress, detailAddress))
+                        .isInstanceOf(InvalidAddressException.class);
+            }
+
+            private static Stream<Arguments> provideAddressForIsNullAndEmptyAndOver50char() {
+                String content = "a";
+                return Stream.of(
+                        Arguments.of(""),
+                        Arguments.of(" "),
+                        Arguments.of("\t"),
+                        Arguments.of("\n"),
+                        Arguments.of(content.repeat(50 + 1))
+                );
+            }
+        }
+    }
+}

--- a/be/src/test/java/com/jjikmuk/sikdorak/store/domain/ContactNumberTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/store/domain/ContactNumberTest.java
@@ -1,0 +1,50 @@
+package com.jjikmuk.sikdorak.store.domain;
+
+import com.jjikmuk.sikdorak.store.exception.InvalidContactNumberException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+
+@DisplayName("ContactNumberTest 클래스")
+class ContactNumberTest {
+
+    @Nested
+    @DisplayName("생성자")
+    class Describe_constructor {
+
+        @Nested
+        @DisplayName("만약 정상적인 9~13자 이하의 contactNumber 가 주어진다면")
+        class Context_with_vaild_storeName {
+
+
+            @ParameterizedTest
+            @ValueSource(strings = {"00-000-0000","00-0000-0000","000-000-0000","000-0000-0000"})
+            @DisplayName("ContactNumber 객체를 반환한다")
+            void It_returns_a_object(String number) {
+                ContactNumber contactNumber = new ContactNumber(number);
+
+                assertThat(contactNumber.getContactNumber()).isEqualTo(number);
+            }
+        }
+
+        @Nested
+        @DisplayName("만약 유효하지 않은 contactNumber 이 주어진다면")
+        class Context_with_invaild_storeName {
+
+            @ParameterizedTest
+            @NullSource
+            @ValueSource(strings = {"", "1234", "123456789_123456789_", "가나다라", "abc-abcd-abcd"})
+            @DisplayName("예외를 발생시킨다")
+            void It_returns_a_object(String number) {
+                assertThatThrownBy(() -> new ContactNumber(number))
+                        .isInstanceOf(InvalidContactNumberException.class);
+            }
+        }
+    }
+}

--- a/be/src/test/java/com/jjikmuk/sikdorak/store/domain/StoreLocationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/store/domain/StoreLocationTest.java
@@ -1,0 +1,58 @@
+package com.jjikmuk.sikdorak.store.domain;
+
+import com.jjikmuk.sikdorak.store.exception.InvalidStoreLocationException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("StoreLocation 클래스")
+class StoreLocationTest {
+
+    @Nested
+    @DisplayName("생성자")
+    class Describe_constructor {
+
+        @Nested
+        @DisplayName("만약 정상적인 latitude, longitude 가 들어온다면")
+        class Context_with_valid_storePoint {
+
+            @ParameterizedTest
+            @CsvSource({
+                    "37.4908786, 127.033406",
+                    "37.5093890, 127.105143",
+            })
+            @DisplayName("StorePoint 객체를 반환한다")
+            void It_returns_a_object(double latitude, double longitude) {
+                StoreLocation storePoint = new StoreLocation(latitude, longitude);
+
+                assertThat(storePoint.latitude()).isEqualTo(latitude);
+                assertThat(storePoint.longitude()).isEqualTo(longitude);
+            }
+        }
+
+        @Nested
+        @DisplayName("만약 유효하지 않은 latitude, longitude 가 들어온다면")
+        class Context_with_invalid_storePoint {
+
+            @ParameterizedTest
+            @CsvSource({
+                    "-91.0, -181.0",            // MIN 미만, MIN 미만
+                    "-91.0, 127.033406",        // MIN 미만, 정상
+                    "91.0, 181.0",              // MAX 초과, MAX 초과
+                    "91.0, 127.033406",         // MAX 초과, 정상
+                    "37.5093890, -181.0",       // 정상,     MIN 미만
+                    "91.0, 181.0",              // MAX 초과, MAX 초과
+                    "37.5093890, 181.0",        // 정상,     MAX 초과
+            })
+            @DisplayName("예외를 발생시킨다")
+            void It_throws_error(double latitude, double longitude) {
+                assertThatThrownBy(() -> new StoreLocation(latitude, longitude))
+                        .isInstanceOf(InvalidStoreLocationException.class);
+            }
+        }
+    }
+}

--- a/be/src/test/java/com/jjikmuk/sikdorak/store/domain/StoreLocationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/store/domain/StoreLocationTest.java
@@ -4,7 +4,11 @@ import com.jjikmuk.sikdorak.store.exception.InvalidStoreLocationException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -39,19 +43,26 @@ class StoreLocationTest {
         class Context_with_invalid_storePoint {
 
             @ParameterizedTest
-            @CsvSource({
-                    "-91.0, -181.0",            // MIN 미만, MIN 미만
-                    "-91.0, 127.033406",        // MIN 미만, 정상
-                    "91.0, 181.0",              // MAX 초과, MAX 초과
-                    "91.0, 127.033406",         // MAX 초과, 정상
-                    "37.5093890, -181.0",       // 정상,     MIN 미만
-                    "91.0, 181.0",              // MAX 초과, MAX 초과
-                    "37.5093890, 181.0",        // 정상,     MAX 초과
-            })
+            @MethodSource("providePointNullOrOutOfRange")
             @DisplayName("예외를 발생시킨다")
-            void It_throws_error(double latitude, double longitude) {
+            void It_throws_error(Double latitude, Double longitude) {
                 assertThatThrownBy(() -> new StoreLocation(latitude, longitude))
                         .isInstanceOf(InvalidStoreLocationException.class);
+            }
+
+            public static Stream<Arguments> providePointNullOrOutOfRange() {
+                return Stream.of(
+                        Arguments.of(null, null),
+                        Arguments.of(30.0, null),
+                        Arguments.of(null, 100.0),
+                        Arguments.of(-91.0, -181.0),
+                        Arguments.of(-91.0, 127.033406),
+                        Arguments.of(91.0, 181.0),
+                        Arguments.of(91.0, 127.033406),
+                        Arguments.of(37.5093890, -181.0),
+                        Arguments.of(91.0, 181.0),
+                        Arguments.of(37.5093890, 181.0)
+                );
             }
         }
     }

--- a/be/src/test/java/com/jjikmuk/sikdorak/store/domain/StoreNameTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/store/domain/StoreNameTest.java
@@ -1,0 +1,48 @@
+package com.jjikmuk.sikdorak.store.domain;
+
+import com.jjikmuk.sikdorak.store.exception.InvalidStoreNameException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("StoreNameTest 클래스")
+class StoreNameTest {
+
+    @Nested
+    @DisplayName("생성자")
+    class Describe_constructor {
+
+        @Nested
+        @DisplayName("만약 정상적인 1~50자 이하의 storeName 이 주어진다면")
+        class Context_with_vaild_storeName {
+
+            @ParameterizedTest
+            @ValueSource(strings = {"1", "123456789_123456789_123456789_123456789_123456789_"})
+            @DisplayName("StoreName 객체를 반환한다")
+            void It_returns_a_object(String name) {
+                StoreName storeName = new StoreName(name);
+
+                assertThat(storeName.getStoreName()).isEqualTo(name);
+            }
+        }
+
+        @Nested
+        @DisplayName("만약 유효하지 않은 storeName 이 주어진다면")
+        class Context_with_invaild_storeName {
+
+            @ParameterizedTest
+            @NullSource
+            @ValueSource(strings = {"", "123456789_123456789_123456789_123456789_123456789_123456789_"})
+            @DisplayName("예외를 발생시킨다")
+            void It_returns_a_object(String name) {
+                assertThatThrownBy(() -> new StoreName(name))
+                        .isInstanceOf(InvalidStoreNameException.class);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### ❗️ 이슈 번호

<strong>
Closes #8
</strong>

<br><br>

### 📝 구현 내용

- [x] 음식점 도메인 정의
- [x] 음식점 조회 API 구현
  - 인수테스트 작성
  - 서비스 통합테스트 작성
  - 도메인 단위테스트 작성
  - API 문서 작성

<br><br>

### 🙇🏻‍♂️ 리뷰어에게 부탁합니다!

1. `camel case` 와 `snake case` 중 택 1 하여, 통일 필요
  - `ReviewInsertRequest` : `camel case`
  - `OAuthTokenResponse` : `snake case`
  -> 일단 `StoreFindResponse` 는 `camel case` 로 작성하였음

2. Response DTO 에 record 적용 제안
  - record 클래스를 적용하면 Immutable class 를 손쉽게 만들 수 있는 장점이 있음
    - 소스코드가 깔끔해지는 장점이 있음
  - Jackson 라이브러리가 record 클래스의 직렬화/역직렬화를 지원함
  - 각 필드에 Annotation 도 붙일 수 있어서, 커스텀 가능
    - Validation, Json 관련 Annotation 등
  - ⚠ 주의할 점
    - `equals`, `hashcode`, `toString` 가 묵시적으로 override 되는것을 인지해야함
    - 라이브러리가 `getter`, `setter` 를 반드시 필요로 하는 경우 호환이 안될 수 있음
      - 사례 : [이 글](https://techblog.gccompany.co.kr/우리팀이-jdk-17을-도입한-이유-ced2b754cd7) 에서 `Record Data Class 추가` 부분 


<br><br>

### 💡 참고 자료

- [Oracle docs - Record](https://docs.oracle.com/en/java/javase/15/language/records.html)
