### PR TITLE
SDR-81 CI-BE 적용 범위 수정

### DIFF
--- a/.github/workflows/CI-BE.yml
+++ b/.github/workflows/CI-BE.yml
@@ -1,6 +1,8 @@
 name: CI - BE
 
 on:
+  push:
+    branches: [BE-dev]
   pull_request:
     branches: [BE-dev]
     paths: ["be/**"]


### PR DESCRIPTION
### ❗️ 이슈 번호

<strong>
Closes #45
</strong>

<br><br>

### 📝 구현 내용

- sonarcloud 적용을 위해 CI-BE 적용 범위를 수정합니다.
- BE-dev 브랜치 push 때 정적 분석 결과 문서 생성
- BE-dev 브랜치에 PR 때 해당 PR에 대한 정적 분석 결과 문서 생성
