### PR TITLE
[BE/feat] 액세스 토큰 재발급 API

### DIFF
--- a/be/src/docs/asciidoc/auth/auth.adoc
+++ b/be/src/docs/asciidoc/auth/auth.adoc
@@ -50,8 +50,18 @@ operation::o_auth_update_token_acceptance_test/update_access_token_success[snipp
 
 ==== `Request`
 
-operation::o_auth_update_token_acceptance_test/update_access_token_fail[snippets='http-request,request-headers']
+operation::o_auth_update_token_acceptance_test/update_access_token_fail_expired_token[snippets='http-request,request-headers']
 
 ==== `Response`
 
-operation::o_auth_update_token_acceptance_test/update_access_token_fail[snippets='http-response,response-fields']
+operation::o_auth_update_token_acceptance_test/update_access_token_fail_expired_token[snippets='http-response,response-fields']
+
+=== `404 NOT_FOUND`
+
+==== `Request`
+
+operation::o_auth_update_token_acceptance_test/update_access_token_fail_user_not_found[snippets='http-request,request-headers']
+
+==== `Response`
+
+operation::o_auth_update_token_acceptance_test/update_access_token_fail_user_not_found[snippets='http-response,response-fields']

--- a/be/src/docs/asciidoc/auth/auth.adoc
+++ b/be/src/docs/asciidoc/auth/auth.adoc
@@ -39,8 +39,19 @@ API : `GET /api/oauth/refresh`
 
 ==== `Request`
 
-operation::o_auth_update_token_acceptance_test/update_access_token[snippets='http-request,request-headers']
+operation::o_auth_update_token_acceptance_test/update_access_token_success[snippets='http-request,request-headers']
 
 ==== `Response`
 
-operation::o_auth_update_token_acceptance_test/update_access_token[snippets='http-response,response-fields']
+operation::o_auth_update_token_acceptance_test/update_access_token_success[snippets='http-response,response-fields']
+
+
+=== `400 BAD_REQUEST`
+
+==== `Request`
+
+operation::o_auth_update_token_acceptance_test/update_access_token_fail[snippets='http-request,request-headers']
+
+==== `Response`
+
+operation::o_auth_update_token_acceptance_test/update_access_token_fail[snippets='http-response,response-fields']

--- a/be/src/docs/asciidoc/auth/auth.adoc
+++ b/be/src/docs/asciidoc/auth/auth.adoc
@@ -7,11 +7,11 @@ API : `GET /api/oauth/login`
 
 ==== `Request`
 
-operation::login_acceptance_test/redirect_to_social_login_page[snippets='http-request']
+operation::o_auth_acceptance_test/redirect_to_social_login_page[snippets='http-request']
 
 ==== `Response`
 
-operation::login_acceptance_test/redirect_to_social_login_page[snippets='http-response']
+operation::o_auth_acceptance_test/redirect_to_social_login_page[snippets='http-response']
 
 
 === 유저 로그인 콜백
@@ -23,8 +23,24 @@ API : `GET /api/oauth/callback`
 
 ==== `Request`
 
-operation::login_acceptance_test/user_login_success[snippets='http-request,request-parameters']
+operation::o_auth_acceptance_test/user_login_success[snippets='http-request,request-parameters']
 
 ==== `Response`
 
-operation::login_acceptance_test/user_login_success[snippets='http-response,response-fields']
+operation::o_auth_acceptance_test/user_login_success[snippets='http-response,response-fields']
+
+
+=== 액세스 토큰 갱신
+
+API : `GET /api/oauth/refresh`
+
+
+=== `200 OK`
+
+==== `Request`
+
+operation::o_auth_update_token_acceptance_test/update_access_token[snippets='http-request,request-headers']
+
+==== `Response`
+
+operation::o_auth_update_token_acceptance_test/update_access_token[snippets='http-response,response-fields']

--- a/be/src/main/java/com/jjikmuk/sikdorak/auth/controller/OAuthController.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/auth/controller/OAuthController.java
@@ -1,12 +1,15 @@
 package com.jjikmuk.sikdorak.auth.controller;
 
 import com.jjikmuk.sikdorak.auth.controller.response.JwtTokenResponse;
+import com.jjikmuk.sikdorak.auth.controller.response.SikdorakAccessToken;
 import com.jjikmuk.sikdorak.auth.service.OAuthService;
 import com.jjikmuk.sikdorak.common.ResponseCodeAndMessages;
 import com.jjikmuk.sikdorak.common.response.CommonResponseEntity;
+import javax.servlet.http.Cookie;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -20,13 +23,25 @@ public class OAuthController {
     @GetMapping("/api/oauth/login")
     public ResponseEntity<Void> loginPageUrl() {
         return ResponseEntity.status(HttpStatus.MOVED_PERMANENTLY)
-                .header("Location",oAuthService.getLoginPageUrl())
-                .build();
+            .header("Location", oAuthService.getLoginPageUrl())
+            .build();
     }
 
     @GetMapping("/api/oauth/callback")
     public CommonResponseEntity<JwtTokenResponse> loginCallback(@RequestParam String code) {
-        return new CommonResponseEntity<>(ResponseCodeAndMessages.LOGIN_SUCCESS, oAuthService.login(code), HttpStatus.OK);
+        return new CommonResponseEntity<>(ResponseCodeAndMessages.LOGIN_SUCCESS,
+            oAuthService.login(code), HttpStatus.OK);
+    }
+
+    @GetMapping("/api/oauth/refresh")
+    public CommonResponseEntity<SikdorakAccessToken> updateAccessToken(
+        @CookieValue("refreshToken") Cookie cookie) {
+
+        String refreshToken = cookie.getValue();
+
+        return new CommonResponseEntity<>(ResponseCodeAndMessages.UPDATE_ACCESS_TOKEN_SUCCESS,
+            oAuthService.updateAccessToken(refreshToken),
+            HttpStatus.OK);
 
     }
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/auth/controller/response/SikdorakAccessToken.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/auth/controller/response/SikdorakAccessToken.java
@@ -1,0 +1,15 @@
+package com.jjikmuk.sikdorak.auth.controller.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SikdorakAccessToken {
+
+    private String accessToken;
+
+    public SikdorakAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/auth/domain/JwtProvider.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/auth/domain/JwtProvider.java
@@ -1,63 +1,76 @@
 package com.jjikmuk.sikdorak.auth.domain;
 
 import com.jjikmuk.sikdorak.auth.controller.response.JwtTokenResponse;
+import com.jjikmuk.sikdorak.auth.exception.InvalidTokenException;
 import com.jjikmuk.sikdorak.common.properties.JwtProperties;
 import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
-import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
 import java.util.Date;
-import java.util.Objects;
 
 @Component
-@RequiredArgsConstructor
 public class JwtProvider {
 
     private final JwtProperties jwtProperties;
+    private final SecretKey secretKey;
+
+    public JwtProvider(JwtProperties jwtProperties) {
+        this.jwtProperties = jwtProperties;
+        this.secretKey = Keys.hmacShaKeyFor(jwtProperties.getSecretKey());
+    }
 
     public JwtTokenResponse createTokenResponse(String payload) {
-        SecretKey secretKey = Keys.hmacShaKeyFor(jwtProperties.getSecretKey());
-
-        Date accessTokeExpiredDate = new Date(new Date().getTime() + jwtProperties.getAccessTokenExpiredMillisecond());
-        Date refreshTokeExpiredDate = new Date(new Date().getTime() + jwtProperties.getRefreshTokenExpiredMillisecond());
-
-        String accessToken = creatToken(payload, secretKey, accessTokeExpiredDate);
-        String refreshToken = creatToken(payload, secretKey, refreshTokeExpiredDate);
+        String accessToken = createAccessToken(payload);
+        String refreshToken = createRefreshToken(payload);
 
         return new JwtTokenResponse(accessToken, refreshToken);
     }
 
+    public String createAccessToken(String payload) {
+        Date accessTokenExpiredDate = new Date(
+            new Date().getTime() + jwtProperties.getAccessTokenExpiredMillisecond());
 
-    public boolean validateToken(String token) {
-        SecretKey secretKey = Keys.hmacShaKeyFor(jwtProperties.getSecretKey());
+        return buildToken(payload, accessTokenExpiredDate);
+    }
 
-        if (Objects.isNull(token) || token.isEmpty()) {
-//            throw new InvalidTokenException();
-        }
+    public String createRefreshToken(String payload) {
+        Date refreshTokeExpiredDate = new Date(
+            new Date().getTime() + jwtProperties.getRefreshTokenExpiredMillisecond());
 
+        return buildToken(payload, refreshTokeExpiredDate);
+    }
+
+    // INFO: token값에 대한 null 예외처리는 parseClaimsJws에서 모두 하기 때문에 별도로 작성하지 않았습니다.
+    public void validateToken(String token) {
         try {
-            Jws<Claims> claimsJws = Jwts.parserBuilder()
-                    .setSigningKey(secretKey)
-                    .build()
-                    .parseClaimsJws(token);
-            return claimsJws.getBody().getExpiration().after(new Date());
-        } catch (JwtException e) {
-            return false;
+            Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token);
+        }catch (JwtException e) {
+            throw new InvalidTokenException();
         }
     }
 
-    private static String creatToken(String payload, SecretKey secretKey, Date tokenExpiredDate) {
-        return Jwts.builder()
-                .claim("id", payload)
-                .setExpiration(tokenExpiredDate)
-                .signWith(secretKey)
-                .compact();
+    public String decodeToken(String refreshToken) {
+        Claims claim = Jwts.parserBuilder()
+            .setSigningKey(secretKey)
+            .build()
+            .parseClaimsJws(refreshToken)
+            .getBody();
+
+        return claim.get("id", String.class);
     }
 
-
+    private String buildToken(String payload, Date expiredDate) {
+        return Jwts.builder()
+            .claim("id", payload)
+            .setExpiration(expiredDate)
+            .signWith(secretKey)
+            .compact();
+    }
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/auth/exception/InvalidTokenException.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/auth/exception/InvalidTokenException.java
@@ -1,0 +1,12 @@
+package com.jjikmuk.sikdorak.auth.exception;
+
+import com.jjikmuk.sikdorak.common.exception.SikdorakRuntimeException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidTokenException extends SikdorakRuntimeException {
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HttpStatus.BAD_REQUEST;
+    }
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/ResponseCodeAndMessages.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/ResponseCodeAndMessages.java
@@ -3,7 +3,10 @@ package com.jjikmuk.sikdorak.common;
 public enum ResponseCodeAndMessages implements CodeAndMessages {
 
     REVIEW_CREATED("T-R001", "리뷰 생성 성공했습니다."),
-    LOGIN_SUCCESS("T-L001", "로그인에 성공했습니다."),
+
+    // Auth
+    LOGIN_SUCCESS("T-A001", "로그인에 성공했습니다."),
+    UPDATE_ACCESS_TOKEN_SUCCESS("T-A002", "액세스 토큰 재발급에 성공했습니다."),
 
     // Store
     STORE_FIND_SUCCESS("T-S001", "가게 목록 조회에 성공했습니다.");

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/ResponseCodeAndMessages.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/ResponseCodeAndMessages.java
@@ -4,9 +4,9 @@ public enum ResponseCodeAndMessages implements CodeAndMessages {
 
     REVIEW_CREATED("T-R001", "리뷰 생성 성공했습니다."),
 
-    // Auth
-    LOGIN_SUCCESS("T-A001", "로그인에 성공했습니다."),
-    UPDATE_ACCESS_TOKEN_SUCCESS("T-A002", "액세스 토큰 재발급에 성공했습니다."),
+    // OAuth
+    LOGIN_SUCCESS("T-O001", "로그인에 성공했습니다."),
+    UPDATE_ACCESS_TOKEN_SUCCESS("T-O002", "액세스 토큰 재발급에 성공했습니다."),
 
     // Store
     STORE_FIND_SUCCESS("T-S001", "가게 목록 조회에 성공했습니다.");

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/exception/ExceptionCodeAndMessages.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/exception/ExceptionCodeAndMessages.java
@@ -51,7 +51,7 @@ public enum ExceptionCodeAndMessages implements CodeAndMessages {
 
     //OAuth
     FAILED_CONNECTION_WITH_KAKAO_API("F-O001", "카카오 서버와의 통신이 원할하지 않습니다.", KakaoApiException.class),
-    EXPIRED_TOKEN("F-O003", "유효하지 않은 토큰입니다.", InvalidTokenException.class);
+    EXPIRED_TOKEN("F-O002", "유효하지 않은 토큰입니다.", InvalidTokenException.class);
 
     private final String code;
 

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/exception/ExceptionCodeAndMessages.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/exception/ExceptionCodeAndMessages.java
@@ -1,7 +1,8 @@
 package com.jjikmuk.sikdorak.common.exception;
 
-import com.jjikmuk.sikdorak.auth.exception.InvalidUserNicknameException;
-import com.jjikmuk.sikdorak.auth.exception.InvalidUserProfileImageUrlException;
+import com.jjikmuk.sikdorak.auth.exception.InvalidTokenException;
+import com.jjikmuk.sikdorak.user.exception.InvalidUserNicknameException;
+import com.jjikmuk.sikdorak.user.exception.InvalidUserProfileImageUrlException;
 import com.jjikmuk.sikdorak.auth.exception.KakaoApiException;
 import com.jjikmuk.sikdorak.common.CodeAndMessages;
 import com.jjikmuk.sikdorak.review.exception.InvalidReviewContentException;
@@ -17,6 +18,7 @@ import com.jjikmuk.sikdorak.store.exception.InvalidStoreNameException;
 import com.jjikmuk.sikdorak.store.exception.StoreNotFoundException;
 import com.jjikmuk.sikdorak.user.exception.DuplicateUserException;
 import com.jjikmuk.sikdorak.user.exception.InvalidUserEmailException;
+import com.jjikmuk.sikdorak.user.exception.UserNotFoundException;
 import lombok.Getter;
 
 import java.util.Arrays;
@@ -45,10 +47,11 @@ public enum ExceptionCodeAndMessages implements CodeAndMessages {
     INVALID_USER_NIKCNAME("F-U002", "유효하지 않은 닉네임 입니다.", InvalidUserNicknameException.class),
     INVALID_USER_PROFILE_IMAGE("F-U003", "유효하지 않은 프로필 이미지 url의 형식입니다.", InvalidUserProfileImageUrlException.class),
     INVALID_USER_EMAIL("F-U004", "유효하지 않은 이메일 형식입니다.", InvalidUserEmailException.class),
+    USER_NOT_FOUND("F-U005", "존재하지 않는 유저입니다.", UserNotFoundException.class),
 
-    //Third Party
-    FAILED_CONNECTION_WITH_KAKAO_API("F-K001", "카카오 서버와의 통신이 원할하지 않습니다.", KakaoApiException.class);
-
+    //OAuth
+    FAILED_CONNECTION_WITH_KAKAO_API("F-O001", "카카오 서버와의 통신이 원할하지 않습니다.", KakaoApiException.class),
+    EXPIRED_TOKEN("F-O003", "유효하지 않은 토큰입니다.", InvalidTokenException.class);
 
     private final String code;
 

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/response/CommonResponseEntity.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/response/CommonResponseEntity.java
@@ -4,9 +4,17 @@ import com.jjikmuk.sikdorak.common.BaseResponse;
 import com.jjikmuk.sikdorak.common.CodeAndMessages;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.MultiValueMap;
 
 public class CommonResponseEntity<T> extends ResponseEntity<BaseResponse<T>> {
     public CommonResponseEntity(CodeAndMessages codeAndMessages, T data, HttpStatus httpStatus) {
-        super(new BaseResponse<>(codeAndMessages.getCode(), codeAndMessages.getMessage(), data), httpStatus);
+        this(codeAndMessages, data, null, httpStatus);
+
     }
+
+    public CommonResponseEntity(CodeAndMessages codeAndMessages, T data, MultiValueMap<String, String> headers,HttpStatus httpStatus) {
+        super(new BaseResponse<>(codeAndMessages.getCode(), codeAndMessages.getMessage(), data),
+            headers, httpStatus);
+    }
+
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/domain/Nickname.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/domain/Nickname.java
@@ -1,6 +1,6 @@
 package com.jjikmuk.sikdorak.user.domain;
 
-import com.jjikmuk.sikdorak.auth.exception.InvalidUserNicknameException;
+import com.jjikmuk.sikdorak.user.exception.InvalidUserNicknameException;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/domain/ProfileImage.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/domain/ProfileImage.java
@@ -1,6 +1,6 @@
 package com.jjikmuk.sikdorak.user.domain;
 
-import com.jjikmuk.sikdorak.auth.exception.InvalidUserProfileImageUrlException;
+import com.jjikmuk.sikdorak.user.exception.InvalidUserProfileImageUrlException;
 import java.util.Objects;
 import java.util.regex.Pattern;
 import javax.persistence.Embeddable;

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/exception/InvalidUserNicknameException.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/exception/InvalidUserNicknameException.java
@@ -1,0 +1,11 @@
+package com.jjikmuk.sikdorak.user.exception;
+
+import com.jjikmuk.sikdorak.common.exception.SikdorakRuntimeException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidUserNicknameException extends SikdorakRuntimeException {
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HttpStatus.BAD_REQUEST;
+    }
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/exception/InvalidUserProfileImageUrlException.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/exception/InvalidUserProfileImageUrlException.java
@@ -1,4 +1,4 @@
-package com.jjikmuk.sikdorak.auth.exception;
+package com.jjikmuk.sikdorak.user.exception;
 
 import com.jjikmuk.sikdorak.common.exception.SikdorakRuntimeException;
 import org.springframework.http.HttpStatus;

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/exception/UserNotFoundException.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/exception/UserNotFoundException.java
@@ -1,11 +1,13 @@
-package com.jjikmuk.sikdorak.auth.exception;
+package com.jjikmuk.sikdorak.user.exception;
 
 import com.jjikmuk.sikdorak.common.exception.SikdorakRuntimeException;
 import org.springframework.http.HttpStatus;
 
-public class InvalidUserNicknameException extends SikdorakRuntimeException {
+public class UserNotFoundException extends SikdorakRuntimeException {
+
+
     @Override
     public HttpStatus getHttpStatus() {
-        return HttpStatus.BAD_REQUEST;
+        return HttpStatus.NOT_FOUND;
     }
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/auth/OAuthAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/auth/OAuthAcceptanceTest.java
@@ -23,7 +23,7 @@ import org.springframework.test.context.TestPropertySource;
     "oauth.kakao.service.token_url=http://localhost:${wiremock.server.port}",
     "oauth.kakao.service.api_url=http://localhost:${wiremock.server.port}"
 })
-@DisplayName("OAuth 인수테스트")
+@DisplayName("OAuth 로그인 인수테스트")
 class OAuthAcceptanceTest extends InitAcceptanceTest {
 
     @BeforeAll

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/auth/OAuthSnippet.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/auth/OAuthSnippet.java
@@ -1,5 +1,6 @@
 package com.jjikmuk.sikdorak.acceptance.auth;
 
+import static com.jjikmuk.sikdorak.acceptance.DocumentFormatGenerator.commonResponseNonFields;
 import static com.jjikmuk.sikdorak.acceptance.DocumentFormatGenerator.commonSingleResponseFieldsWithValidConstraints;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
@@ -29,8 +30,10 @@ public interface OAuthSnippet {
     );
 
 
-    Snippet UPDATE_ACCESS_TOKEN_RESPONSE_SNIPPET = commonSingleResponseFieldsWithValidConstraints(
+    Snippet UPDATE_ACCESS_TOKEN_SUCCESS_RESPONSE_SNIPPET = commonSingleResponseFieldsWithValidConstraints(
         SikdorakAccessToken.class,
         fieldWithPath("accessToken").type(JsonFieldType.STRING).description("액세스 토큰")
     );
+
+    Snippet UPDATE_ACCESS_TOKEN_FAIL_RESPONSE_SNIPPET = commonResponseNonFields();
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/auth/OAuthSnippet.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/auth/OAuthSnippet.java
@@ -1,13 +1,16 @@
 package com.jjikmuk.sikdorak.acceptance.auth;
 
-import com.jjikmuk.sikdorak.auth.controller.response.JwtTokenResponse;
-import org.springframework.restdocs.payload.JsonFieldType;
-import org.springframework.restdocs.snippet.Snippet;
-
 import static com.jjikmuk.sikdorak.acceptance.DocumentFormatGenerator.commonSingleResponseFieldsWithValidConstraints;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
+
+import com.jjikmuk.sikdorak.auth.controller.response.JwtTokenResponse;
+import com.jjikmuk.sikdorak.auth.controller.response.SikdorakAccessToken;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.restdocs.snippet.Snippet;
 
 public interface OAuthSnippet {
 
@@ -21,4 +24,13 @@ public interface OAuthSnippet {
             fieldWithPath("refreshToken").type(JsonFieldType.STRING).description("리프레쉬 토큰")
     );
 
+    Snippet UPDATE_ACCESS_TOKEN_REQUEST_SNIPPET = requestHeaders(
+        headerWithName("Cookie").description("리프레쉬 토큰")
+    );
+
+
+    Snippet UPDATE_ACCESS_TOKEN_RESPONSE_SNIPPET = commonSingleResponseFieldsWithValidConstraints(
+        SikdorakAccessToken.class,
+        fieldWithPath("accessToken").type(JsonFieldType.STRING).description("액세스 토큰")
+    );
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/auth/OAuthUpdateTokenAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/auth/OAuthUpdateTokenAcceptanceTest.java
@@ -7,22 +7,32 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
 
 import com.jjikmuk.sikdorak.acceptance.InitAcceptanceTest;
+import com.jjikmuk.sikdorak.auth.controller.response.JwtTokenResponse;
+import com.jjikmuk.sikdorak.auth.domain.JwtProvider;
+import com.jjikmuk.sikdorak.common.exception.ExceptionCodeAndMessages;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
 @DisplayName("OAuth 토큰 재발급 인수테스트")
 public class OAuthUpdateTokenAcceptanceTest extends InitAcceptanceTest {
 
+    @Autowired
+    private JwtProvider jwtProvider;
     @Test
     @DisplayName("유저로부터 액세스 토큰 갱신 요청이 올 경우 새로운 액세스 토큰을 발급한다")
-    void update_access_token() {
+    void update_access_token_success() {
+
+
+        JwtTokenResponse tokenResponse = jwtProvider.createTokenResponse(testData.user.getUniqueId().toString());
+
         given(this.spec)
             .filter(document(DEFAULT_RESTDOC_PATH,
                 UPDATE_ACCESS_TOKEN_REQUEST_SNIPPET,
                 UPDATE_ACCESS_TOKEN_RESPONSE_SNIPPET))
-            .header("Cookie", "RefreshToken=refreshToken")
+            .header("Cookie", "RefreshToken=" + tokenResponse.getRefreshToken())
             .accept(MediaType.APPLICATION_JSON_VALUE)
 
         .when()
@@ -31,6 +41,24 @@ public class OAuthUpdateTokenAcceptanceTest extends InitAcceptanceTest {
         .then()
             .statusCode(HttpStatus.OK.value())
             .body("data.accessToken", notNullValue());
+    }
+
+    @Test
+    @DisplayName("유저로부터 액세스 토큰 갱신 요청의 리프레쉬 토큰이 유효하지 않을 경우 실패 메세지를 전송한다.")
+    void update_access_token_fail() {
+        given(this.spec)
+            .filter(document(DEFAULT_RESTDOC_PATH,
+                UPDATE_ACCESS_TOKEN_REQUEST_SNIPPET,
+                UPDATE_ACCESS_TOKEN_RESPONSE_SNIPPET))
+            .header("Cookie", "RefreshToken=InvalidToken")
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+
+        .when()
+            .get("/api/oauth/refresh")
+
+        .then()
+            .statusCode(HttpStatus.BAD_REQUEST.value());
+//            .body("code", ExceptionCodeAndMessages.);
     }
 
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/auth/OAuthUpdateTokenAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/auth/OAuthUpdateTokenAcceptanceTest.java
@@ -1,13 +1,14 @@
 package com.jjikmuk.sikdorak.acceptance.auth;
 
+import static com.jjikmuk.sikdorak.acceptance.auth.OAuthSnippet.UPDATE_ACCESS_TOKEN_FAIL_RESPONSE_SNIPPET;
 import static com.jjikmuk.sikdorak.acceptance.auth.OAuthSnippet.UPDATE_ACCESS_TOKEN_REQUEST_SNIPPET;
-import static com.jjikmuk.sikdorak.acceptance.auth.OAuthSnippet.UPDATE_ACCESS_TOKEN_RESPONSE_SNIPPET;
+import static com.jjikmuk.sikdorak.acceptance.auth.OAuthSnippet.UPDATE_ACCESS_TOKEN_SUCCESS_RESPONSE_SNIPPET;
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
 
 import com.jjikmuk.sikdorak.acceptance.InitAcceptanceTest;
-import com.jjikmuk.sikdorak.auth.controller.response.JwtTokenResponse;
 import com.jjikmuk.sikdorak.auth.domain.JwtProvider;
 import com.jjikmuk.sikdorak.common.exception.ExceptionCodeAndMessages;
 import org.junit.jupiter.api.DisplayName;
@@ -21,18 +22,19 @@ public class OAuthUpdateTokenAcceptanceTest extends InitAcceptanceTest {
 
     @Autowired
     private JwtProvider jwtProvider;
+
     @Test
     @DisplayName("유저로부터 액세스 토큰 갱신 요청이 올 경우 새로운 액세스 토큰을 발급한다")
     void update_access_token_success() {
 
-
-        JwtTokenResponse tokenResponse = jwtProvider.createTokenResponse(testData.user.getUniqueId().toString());
+        String refreshToken = jwtProvider.createRefreshToken(
+            testData.user.getUniqueId().toString());
 
         given(this.spec)
             .filter(document(DEFAULT_RESTDOC_PATH,
                 UPDATE_ACCESS_TOKEN_REQUEST_SNIPPET,
-                UPDATE_ACCESS_TOKEN_RESPONSE_SNIPPET))
-            .header("Cookie", "RefreshToken=" + tokenResponse.getRefreshToken())
+                UPDATE_ACCESS_TOKEN_SUCCESS_RESPONSE_SNIPPET))
+            .header("Cookie", "refreshToken=" + refreshToken)
             .accept(MediaType.APPLICATION_JSON_VALUE)
 
         .when()
@@ -45,20 +47,46 @@ public class OAuthUpdateTokenAcceptanceTest extends InitAcceptanceTest {
 
     @Test
     @DisplayName("유저로부터 액세스 토큰 갱신 요청의 리프레쉬 토큰이 유효하지 않을 경우 실패 메세지를 전송한다.")
-    void update_access_token_fail() {
+    void update_access_token_fail_expired_token() {
+
+        String invalidToken = "eyJhbGciOiJIUzI1NiJ9.eyJpZCI6IjIzNjgyMjM2MzgiLCJleHAiOjE2MzA2MzkzNTF9.SnT_Nxgspg3cUomCieDyBRH9TowtWh21YIfAKntuguA";
+
         given(this.spec)
             .filter(document(DEFAULT_RESTDOC_PATH,
                 UPDATE_ACCESS_TOKEN_REQUEST_SNIPPET,
-                UPDATE_ACCESS_TOKEN_RESPONSE_SNIPPET))
-            .header("Cookie", "RefreshToken=InvalidToken")
+                UPDATE_ACCESS_TOKEN_FAIL_RESPONSE_SNIPPET))
+            .header("Cookie", "refreshToken=" + invalidToken)
             .accept(MediaType.APPLICATION_JSON_VALUE)
 
         .when()
             .get("/api/oauth/refresh")
 
         .then()
-            .statusCode(HttpStatus.BAD_REQUEST.value());
-//            .body("code", ExceptionCodeAndMessages.);
+            .statusCode(HttpStatus.BAD_REQUEST.value())
+            .body("code", equalTo(ExceptionCodeAndMessages.EXPIRED_TOKEN.getCode()))
+            .body("message", equalTo(ExceptionCodeAndMessages.EXPIRED_TOKEN.getMessage()));
+    }
+
+    @Test
+    @DisplayName("유저로부터 액세스 토큰 갱신 요청의 리프레쉬 토큰에 담긴 유저의 id가 유효하지 않을 경우 실패 메세지를 전송한다.")
+    void update_access_token_fail_user_not_found() {
+
+        String invalidToken = "eyJhbGciOiJIUzI1NiJ9.eyJpZCI6IjIzNjgyMjM2MzIiLCJleHAiOjE3MjA2MzkzNTF9.PB7YOSEJqmwnrHddE0ZbGXlUWlK_NG0hmQjBv8d_9cE";
+
+        given(this.spec)
+            .filter(document(DEFAULT_RESTDOC_PATH,
+                UPDATE_ACCESS_TOKEN_REQUEST_SNIPPET,
+                UPDATE_ACCESS_TOKEN_FAIL_RESPONSE_SNIPPET))
+            .header("Cookie", "refreshToken=" + invalidToken)
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+
+        .when()
+            .get("/api/oauth/refresh")
+
+        .then()
+            .statusCode(HttpStatus.NOT_FOUND.value())
+            .body("code", equalTo(ExceptionCodeAndMessages.USER_NOT_FOUND.getCode()))
+            .body("message", equalTo(ExceptionCodeAndMessages.USER_NOT_FOUND.getMessage()));
     }
 
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/auth/OAuthUpdateTokenAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/auth/OAuthUpdateTokenAcceptanceTest.java
@@ -1,0 +1,36 @@
+package com.jjikmuk.sikdorak.acceptance.auth;
+
+import static com.jjikmuk.sikdorak.acceptance.auth.OAuthSnippet.UPDATE_ACCESS_TOKEN_REQUEST_SNIPPET;
+import static com.jjikmuk.sikdorak.acceptance.auth.OAuthSnippet.UPDATE_ACCESS_TOKEN_RESPONSE_SNIPPET;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
+
+import com.jjikmuk.sikdorak.acceptance.InitAcceptanceTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+@DisplayName("OAuth 토큰 재발급 인수테스트")
+public class OAuthUpdateTokenAcceptanceTest extends InitAcceptanceTest {
+
+    @Test
+    @DisplayName("유저로부터 액세스 토큰 갱신 요청이 올 경우 새로운 액세스 토큰을 발급한다")
+    void update_access_token() {
+        given(this.spec)
+            .filter(document(DEFAULT_RESTDOC_PATH,
+                UPDATE_ACCESS_TOKEN_REQUEST_SNIPPET,
+                UPDATE_ACCESS_TOKEN_RESPONSE_SNIPPET))
+            .header("Cookie", "RefreshToken=refreshToken")
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+
+        .when()
+            .get("/api/oauth/refresh")
+
+        .then()
+            .statusCode(HttpStatus.OK.value())
+            .body("data.accessToken", notNullValue());
+    }
+
+}

--- a/be/src/test/java/com/jjikmuk/sikdorak/user/domain/NicknameTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/user/domain/NicknameTest.java
@@ -1,6 +1,6 @@
 package com.jjikmuk.sikdorak.user.domain;
 
-import com.jjikmuk.sikdorak.auth.exception.InvalidUserNicknameException;
+import com.jjikmuk.sikdorak.user.exception.InvalidUserNicknameException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/be/src/test/java/com/jjikmuk/sikdorak/user/domain/ProfileImageTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/user/domain/ProfileImageTest.java
@@ -1,6 +1,6 @@
 package com.jjikmuk.sikdorak.user.domain;
 
-import com.jjikmuk.sikdorak.auth.exception.InvalidUserProfileImageUrlException;
+import com.jjikmuk.sikdorak.user.exception.InvalidUserProfileImageUrlException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.params.ParameterizedTest;


### PR DESCRIPTION
### ❗️ 이슈 번호

<strong>
Closes #32 #51 
</strong>

<br><br>

### 📝 구현 내용

- 액세스 토큰 재발급에 대한 인수테스트 작성
  - 성공 케이스
  - 실패 케이스 : 토큰 만료 / 존재하지 않는 유저
- 재발급 로직 구현
- 기존 Body로 제공하던 RefreshToken을 쿠키로 제공하도록 설정

<br><br>

### 🙇🏻‍♂️ 리뷰어에게 부탁합니다!

 - 솔직하고 과감한 리뷰는 저를 춤추게 합니다.
