### PR TITLE
SDR-116 가게 수정 API 구현

### DIFF
--- a/be/src/docs/asciidoc/index.adoc
+++ b/be/src/docs/asciidoc/index.adoc
@@ -16,7 +16,7 @@ notification-api-docs
 include::{docdir}/review/review.adoc[]
 
 
-== 음식점 API
+== 가게 API
 
 include::{docdir}/store/store.adoc[]
 

--- a/be/src/docs/asciidoc/store/store.adoc
+++ b/be/src/docs/asciidoc/store/store.adoc
@@ -34,7 +34,7 @@ API : `PUT /api/stores`
 
 ==== `Request`
 
-operation::store_modify_acceptance_test/modify_store_success[snippets='http-request,request-body']
+operation::store_modify_acceptance_test/modify_store_success[snippets='http-request,path-parameters,request-body']
 
 ==== `Response`
 

--- a/be/src/docs/asciidoc/store/store.adoc
+++ b/be/src/docs/asciidoc/store/store.adoc
@@ -1,4 +1,4 @@
-=== 이름으로 음식점 조회
+=== 가게 이름으로 가게 조회
 
 API : `GET /api/stores`
 
@@ -6,8 +6,36 @@ API : `GET /api/stores`
 
 ==== `Request`
 
-operation::store_acceptance_test/find_store_by_name_containing_success[snippets='http-request,request-parameters']
+operation::store_search_acceptance_test/search_store_by_name_containing_success[snippets='http-request,request-parameters']
 
 ==== `Response`
 
-operation::store_acceptance_test/find_store_by_name_containing_success[snippets='http-response,response-fields']
+operation::store_search_acceptance_test/search_store_by_name_containing_success[snippets='http-response,response-fields']
+
+=== 가게 추가
+
+API : `POST /api/stores`
+
+=== `201 CREATED`
+
+==== `Request`
+
+operation::store_create_acceptance_test/create_store_success[snippets='http-request,request-body']
+
+==== `Response`
+
+operation::store_create_acceptance_test/create_store_success[snippets='http-response,response-fields']
+
+=== 가게 수정
+
+API : `PUT /api/stores`
+
+=== `200 SUCCESS`
+
+==== `Request`
+
+operation::store_modify_acceptance_test/modify_store_success[snippets='http-request,request-body']
+
+==== `Response`
+
+operation::store_modify_acceptance_test/modify_store_success[snippets='http-response,response-fields']

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/ResponseCodeAndMessages.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/ResponseCodeAndMessages.java
@@ -10,7 +10,7 @@ public enum ResponseCodeAndMessages implements CodeAndMessages {
 
     // Store
     STORE_SEARCH_SUCCESS("T-S001", "가게 목록 조회에 성공했습니다."),
-    STORE_INSERT_SUCCESS("T-S002", "가게 등록에 성공했습니다."),
+    STORE_CREATE_SUCCESS("T-S002", "가게 등록에 성공했습니다."),
     STORE_MODIFY_SUCCESS("T-S003", "가게 수정에 성공했습니다.");
 
     private final String code;

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/ResponseCodeAndMessages.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/ResponseCodeAndMessages.java
@@ -10,7 +10,8 @@ public enum ResponseCodeAndMessages implements CodeAndMessages {
 
     // Store
     STORE_SEARCH_SUCCESS("T-S001", "가게 목록 조회에 성공했습니다."),
-    STORE_INSERT_SUCCESS("T-S002", "가게 등록에 성공했습니다.");
+    STORE_INSERT_SUCCESS("T-S002", "가게 등록에 성공했습니다."),
+    STORE_MODIFY_SUCCESS("T-S003", "가게 수정에 성공했습니다.");
 
     private final String code;
     private final String message;

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/response/CommonResponseEntity.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/response/CommonResponseEntity.java
@@ -7,9 +7,13 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.util.MultiValueMap;
 
 public class CommonResponseEntity<T> extends ResponseEntity<BaseResponse<T>> {
+
+    public CommonResponseEntity(CodeAndMessages codeAndMessages, HttpStatus httpStatus) {
+        this(codeAndMessages, null, httpStatus);
+    }
+
     public CommonResponseEntity(CodeAndMessages codeAndMessages, T data, HttpStatus httpStatus) {
         this(codeAndMessages, data, null, httpStatus);
-
     }
 
     public CommonResponseEntity(CodeAndMessages codeAndMessages, T data, MultiValueMap<String, String> headers,HttpStatus httpStatus) {

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/controller/StoreController.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/controller/StoreController.java
@@ -13,6 +13,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -43,9 +44,9 @@ public class StoreController {
 		return new CommonResponseEntity<>(STORE_CREATE_SUCCESS, null, HttpStatus.CREATED);
 	}
 
-	@PutMapping()
-	public CommonResponseEntity<Void> modifyStore(@RequestBody StoreModifyRequest modifyRequest) {
-		storeService.modifyStore(modifyRequest);
+	@PutMapping("/{storeId}")
+	public CommonResponseEntity<Void> modifyStore(@PathVariable("storeId") Long storeId, @RequestBody StoreModifyRequest modifyRequest) {
+		storeService.modifyStore(storeId, modifyRequest);
 
 		return new CommonResponseEntity<>(STORE_MODIFY_SUCCESS, HttpStatus.OK);
 	}

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/controller/StoreController.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/controller/StoreController.java
@@ -1,10 +1,12 @@
 package com.jjikmuk.sikdorak.store.controller;
 
 import static com.jjikmuk.sikdorak.common.ResponseCodeAndMessages.STORE_INSERT_SUCCESS;
+import static com.jjikmuk.sikdorak.common.ResponseCodeAndMessages.STORE_MODIFY_SUCCESS;
 import static com.jjikmuk.sikdorak.common.ResponseCodeAndMessages.STORE_SEARCH_SUCCESS;
 
 import com.jjikmuk.sikdorak.common.response.CommonResponseEntity;
 import com.jjikmuk.sikdorak.store.controller.request.StoreInsertRequest;
+import com.jjikmuk.sikdorak.store.controller.request.StoreModifyRequest;
 import com.jjikmuk.sikdorak.store.controller.response.StoreSearchResponse;
 import com.jjikmuk.sikdorak.store.service.StoreService;
 import java.util.List;
@@ -12,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -34,9 +37,14 @@ public class StoreController {
 	}
 
 	@PostMapping()
-	public CommonResponseEntity<Void> insertStor(@RequestBody StoreInsertRequest insertRequest) {
+	public CommonResponseEntity<Void> insertStore(@RequestBody StoreInsertRequest insertRequest) {
 		storeService.insertStore(insertRequest);
 
 		return new CommonResponseEntity<>(STORE_INSERT_SUCCESS, null, HttpStatus.CREATED);
+	}
+
+	@PutMapping()
+	public CommonResponseEntity<Void> modifyStore(@RequestBody StoreModifyRequest modifyRequest) {
+		return new CommonResponseEntity<>(STORE_MODIFY_SUCCESS, HttpStatus.OK);
 	}
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/controller/StoreController.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/controller/StoreController.java
@@ -1,11 +1,11 @@
 package com.jjikmuk.sikdorak.store.controller;
 
-import static com.jjikmuk.sikdorak.common.ResponseCodeAndMessages.STORE_INSERT_SUCCESS;
+import static com.jjikmuk.sikdorak.common.ResponseCodeAndMessages.STORE_CREATE_SUCCESS;
 import static com.jjikmuk.sikdorak.common.ResponseCodeAndMessages.STORE_MODIFY_SUCCESS;
 import static com.jjikmuk.sikdorak.common.ResponseCodeAndMessages.STORE_SEARCH_SUCCESS;
 
 import com.jjikmuk.sikdorak.common.response.CommonResponseEntity;
-import com.jjikmuk.sikdorak.store.controller.request.StoreInsertRequest;
+import com.jjikmuk.sikdorak.store.controller.request.StoreCreateRequest;
 import com.jjikmuk.sikdorak.store.controller.request.StoreModifyRequest;
 import com.jjikmuk.sikdorak.store.controller.response.StoreSearchResponse;
 import com.jjikmuk.sikdorak.store.service.StoreService;
@@ -37,10 +37,10 @@ public class StoreController {
 	}
 
 	@PostMapping()
-	public CommonResponseEntity<Void> insertStore(@RequestBody StoreInsertRequest insertRequest) {
-		storeService.insertStore(insertRequest);
+	public CommonResponseEntity<Void> createStore(@RequestBody StoreCreateRequest createRequest) {
+		storeService.createStore(createRequest);
 
-		return new CommonResponseEntity<>(STORE_INSERT_SUCCESS, null, HttpStatus.CREATED);
+		return new CommonResponseEntity<>(STORE_CREATE_SUCCESS, null, HttpStatus.CREATED);
 	}
 
 	@PutMapping()

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/controller/StoreController.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/controller/StoreController.java
@@ -45,6 +45,8 @@ public class StoreController {
 
 	@PutMapping()
 	public CommonResponseEntity<Void> modifyStore(@RequestBody StoreModifyRequest modifyRequest) {
+		storeService.modifyStore(modifyRequest);
+
 		return new CommonResponseEntity<>(STORE_MODIFY_SUCCESS, HttpStatus.OK);
 	}
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/controller/request/StoreCreateRequest.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/controller/request/StoreCreateRequest.java
@@ -9,7 +9,7 @@ import org.hibernate.validator.constraints.Length;
 
 @Getter
 @NoArgsConstructor
-public class StoreInsertRequest {
+public class StoreCreateRequest {
 
 	@NotBlank
 	@Length(min = 50)
@@ -33,7 +33,7 @@ public class StoreInsertRequest {
 	@Max(180)
 	private Double longitude;
 
-	public StoreInsertRequest(String storeName, String contactNumber, String baseAddress,
+	public StoreCreateRequest(String storeName, String contactNumber, String baseAddress,
 		String detailAddress, Double latitude, Double longitude) {
 		this.storeName = storeName;
 		this.contactNumber = contactNumber;

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/controller/request/StoreModifyRequest.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/controller/request/StoreModifyRequest.java
@@ -3,7 +3,6 @@ package com.jjikmuk.sikdorak.store.controller.request;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.validator.constraints.Length;
@@ -11,9 +10,6 @@ import org.hibernate.validator.constraints.Length;
 @Getter
 @NoArgsConstructor
 public class StoreModifyRequest {
-
-	@NotNull
-	private Long id;
 
 	@NotBlank
 	@Length(min = 50)
@@ -37,9 +33,8 @@ public class StoreModifyRequest {
 	@Max(180)
 	private Double longitude;
 
-	public StoreModifyRequest(Long id, String storeName, String contactNumber, String baseAddress,
+	public StoreModifyRequest(String storeName, String contactNumber, String baseAddress,
 		String detailAddress, Double latitude, Double longitude) {
-		this.id = id;
 		this.storeName = storeName;
 		this.contactNumber = contactNumber;
 		this.baseAddress = baseAddress;

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/controller/request/StoreModifyRequest.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/controller/request/StoreModifyRequest.java
@@ -1,0 +1,50 @@
+package com.jjikmuk.sikdorak.store.controller.request;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+
+@Getter
+@NoArgsConstructor
+public class StoreModifyRequest {
+
+	@NotNull
+	private Long id;
+
+	@NotBlank
+	@Length(min = 50)
+	private String storeName;
+
+	@NotBlank
+	private String contactNumber;
+
+	@NotBlank
+	@Length(max = 255)
+	private String baseAddress;
+
+	@Length(max = 50)
+	private String detailAddress;
+
+	@Min(-90)
+	@Max(90)
+	private Double latitude;
+
+	@Min(-180)
+	@Max(180)
+	private Double longitude;
+
+	public StoreModifyRequest(Long id, String storeName, String contactNumber, String baseAddress,
+		String detailAddress, Double latitude, Double longitude) {
+		this.id = id;
+		this.storeName = storeName;
+		this.contactNumber = contactNumber;
+		this.baseAddress = baseAddress;
+		this.detailAddress = detailAddress;
+		this.latitude = latitude;
+		this.longitude = longitude;
+	}
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/domain/Store.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/domain/Store.java
@@ -31,22 +31,11 @@ public class Store extends BaseTimeEntity {
     @Embedded
     private StoreLocation location; // Float latitude, Float longitude
 
-    public Store(Long id, String storeName, String contactNumber, String baseAddress, String detailAddress, Double latitude, Double longitude) {
-        this.id = id;
+    public Store(String storeName, String contactNumber, String baseAddress, String detailAddress, Double latitude, Double longitude) {
         this.storeName = new StoreName(storeName);
         this.contactNumber = new ContactNumber(contactNumber);
         this.address = new Address(baseAddress, detailAddress);
         this.location = new StoreLocation(latitude, longitude);
-    }
-
-    public Store(String storeName, String contactNumber, String baseAddress, String detailAddress, Double latitude, Double longitude) {
-        this(null,
-            storeName,
-            contactNumber,
-            baseAddress,
-            detailAddress,
-            latitude,
-            longitude);
     }
 
     public Long getId() {
@@ -75,5 +64,12 @@ public class Store extends BaseTimeEntity {
 
     public double getLongitude() {
         return location.longitude();
+    }
+
+    public void editAll(String storeName, String contactNumber, String baseAddress, String detailAddress, Double latitude, Double longitude) {
+        this.storeName = new StoreName(storeName);
+        this.contactNumber = new ContactNumber(contactNumber);
+        this.address = new Address(baseAddress, detailAddress);
+        this.location = new StoreLocation(latitude, longitude);
     }
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/domain/Store.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/domain/Store.java
@@ -31,11 +31,22 @@ public class Store extends BaseTimeEntity {
     @Embedded
     private StoreLocation location; // Float latitude, Float longitude
 
-    public Store(String storeName, String contactNumber, String baseAddress, String detailAddress, Double latitude, Double longitude) {
+    public Store(Long id, String storeName, String contactNumber, String baseAddress, String detailAddress, Double latitude, Double longitude) {
+        this.id = id;
         this.storeName = new StoreName(storeName);
         this.contactNumber = new ContactNumber(contactNumber);
         this.address = new Address(baseAddress, detailAddress);
         this.location = new StoreLocation(latitude, longitude);
+    }
+
+    public Store(String storeName, String contactNumber, String baseAddress, String detailAddress, Double latitude, Double longitude) {
+        this(null,
+            storeName,
+            contactNumber,
+            baseAddress,
+            detailAddress,
+            latitude,
+            longitude);
     }
 
     public Long getId() {

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/service/StoreService.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/service/StoreService.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -18,6 +19,7 @@ public class StoreService {
 
 	private final StoreRepository storeRepository;
 
+	@Transactional(readOnly = true)
 	public Store searchById(Long storeId) {
 		if (Objects.isNull(storeId)) {
 			throw new StoreNotFoundException();
@@ -25,6 +27,7 @@ public class StoreService {
 		return storeRepository.findById(storeId).orElseThrow(StoreNotFoundException::new);
 	}
 
+	@Transactional(readOnly = true)
 	public List<StoreSearchResponse> searchStoresByStoreNameContaining(String storeName) {
 		if (storeName == null) {
 			return Collections.emptyList();
@@ -36,6 +39,7 @@ public class StoreService {
 			.toList();
 	}
 
+	@Transactional
 	public Long createStore(StoreCreateRequest createRequest) {
 		Store store = new Store(
 			createRequest.getStoreName(),
@@ -50,6 +54,7 @@ public class StoreService {
 			.getId();
 	}
 
+	@Transactional
 	public Long modifyStore(StoreModifyRequest modifyRequest) {
 		Store savedStore = searchById(modifyRequest.getId());
 

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/service/StoreService.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/service/StoreService.java
@@ -1,6 +1,6 @@
 package com.jjikmuk.sikdorak.store.service;
 
-import com.jjikmuk.sikdorak.store.controller.request.StoreInsertRequest;
+import com.jjikmuk.sikdorak.store.controller.request.StoreCreateRequest;
 import com.jjikmuk.sikdorak.store.controller.request.StoreModifyRequest;
 import com.jjikmuk.sikdorak.store.controller.response.StoreSearchResponse;
 import com.jjikmuk.sikdorak.store.domain.Store;
@@ -36,14 +36,14 @@ public class StoreService {
 			.toList();
 	}
 
-	public Long insertStore(StoreInsertRequest insertRequest) {
+	public Long createStore(StoreCreateRequest createRequest) {
 		Store store = new Store(
-			insertRequest.getStoreName(),
-			insertRequest.getContactNumber(),
-			insertRequest.getBaseAddress(),
-			insertRequest.getDetailAddress(),
-			insertRequest.getLatitude(),
-			insertRequest.getLongitude()
+			createRequest.getStoreName(),
+			createRequest.getContactNumber(),
+			createRequest.getBaseAddress(),
+			createRequest.getDetailAddress(),
+			createRequest.getLatitude(),
+			createRequest.getLongitude()
 		);
 
 		return storeRepository.save(store)
@@ -51,7 +51,7 @@ public class StoreService {
 	}
 
 	public Long modifyStore(StoreModifyRequest modifyRequest) {
-		Store savedStore = findById(modifyRequest.getId());
+		Store savedStore = searchById(modifyRequest.getId());
 
 		Store modifiedStore = new Store(
 			savedStore.getId(),

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/service/StoreService.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/service/StoreService.java
@@ -1,6 +1,7 @@
 package com.jjikmuk.sikdorak.store.service;
 
 import com.jjikmuk.sikdorak.store.controller.request.StoreInsertRequest;
+import com.jjikmuk.sikdorak.store.controller.request.StoreModifyRequest;
 import com.jjikmuk.sikdorak.store.controller.response.StoreSearchResponse;
 import com.jjikmuk.sikdorak.store.domain.Store;
 import com.jjikmuk.sikdorak.store.exception.StoreNotFoundException;
@@ -47,5 +48,21 @@ public class StoreService {
 
 		return storeRepository.save(store)
 			.getId();
+	}
+
+	public Long modifyStore(StoreModifyRequest modifyRequest) {
+		Store savedStore = findById(modifyRequest.getId());
+
+		Store modifiedStore = new Store(
+			savedStore.getId(),
+			modifyRequest.getStoreName(),
+			modifyRequest.getContactNumber(),
+			modifyRequest.getBaseAddress(),
+			modifyRequest.getDetailAddress(),
+			modifyRequest.getLatitude(),
+			modifyRequest.getLongitude()
+		);
+
+		return storeRepository.save(modifiedStore).getId();
 	}
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/service/StoreService.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/service/StoreService.java
@@ -24,6 +24,7 @@ public class StoreService {
 		if (Objects.isNull(storeId)) {
 			throw new StoreNotFoundException();
 		}
+
 		return storeRepository.findById(storeId).orElseThrow(StoreNotFoundException::new);
 	}
 
@@ -55,11 +56,11 @@ public class StoreService {
 	}
 
 	@Transactional
-	public Long modifyStore(StoreModifyRequest modifyRequest) {
-		Store savedStore = searchById(modifyRequest.getId());
+	public Long modifyStore(Long storeId, StoreModifyRequest modifyRequest) {
+		Store store = storeRepository.findById(storeId)
+			.orElseThrow(StoreNotFoundException::new);
 
-		Store modifiedStore = new Store(
-			savedStore.getId(),
+		store.editAll(
 			modifyRequest.getStoreName(),
 			modifyRequest.getContactNumber(),
 			modifyRequest.getBaseAddress(),
@@ -68,6 +69,6 @@ public class StoreService {
 			modifyRequest.getLongitude()
 		);
 
-		return storeRepository.save(modifiedStore).getId();
+		return store.getId();
 	}
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/store/StoreCreateAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/store/StoreCreateAcceptanceTest.java
@@ -1,13 +1,13 @@
 package com.jjikmuk.sikdorak.acceptance.store;
 
-import static com.jjikmuk.sikdorak.acceptance.store.StoreSnippet.STORE_INSERT_REQUEST_SNIPPET;
-import static com.jjikmuk.sikdorak.acceptance.store.StoreSnippet.STORE_INSERT_RESPONSE_SNIPPET;
+import static com.jjikmuk.sikdorak.acceptance.store.StoreSnippet.STORE_CREATE_REQUEST_SNIPPET;
+import static com.jjikmuk.sikdorak.acceptance.store.StoreSnippet.STORE_CREATE_RESPONSE_SNIPPET;
 import static io.restassured.RestAssured.given;
 import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
 
 import com.jjikmuk.sikdorak.acceptance.InitAcceptanceTest;
 import com.jjikmuk.sikdorak.common.ResponseCodeAndMessages;
-import com.jjikmuk.sikdorak.store.controller.request.StoreInsertRequest;
+import com.jjikmuk.sikdorak.store.controller.request.StoreCreateRequest;
 import io.restassured.http.ContentType;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.DisplayName;
@@ -15,14 +15,14 @@ import org.junit.jupiter.api.Test;
 import org.springframework.cloud.contract.spec.internal.HttpStatus;
 import org.springframework.http.MediaType;
 
-@DisplayName("StoreInsert 인수 테스트")
-public class StoreInsertAcceptanceTest extends InitAcceptanceTest {
+@DisplayName("StoreCreate 인수 테스트")
+public class StoreCreateAcceptanceTest extends InitAcceptanceTest {
 
 	@Test
 	@DisplayName("가게 생성 요청이 정상적인 경우라면, 리뷰 생성 후 정상 상태 코드를 반환한다.")
 	void create_store_success() {
 
-		StoreInsertRequest storeInsertRequest = new StoreInsertRequest(
+		StoreCreateRequest storeCreateRequest = new StoreCreateRequest(
 			"새로 생긴 가게",
 			"02-0000-0000",
 			"서울시 어쩌구 00길 00",
@@ -31,16 +31,16 @@ public class StoreInsertAcceptanceTest extends InitAcceptanceTest {
 			127.033417
 		);
 
-		ResponseCodeAndMessages expectedCodeAndMessage = ResponseCodeAndMessages.STORE_INSERT_SUCCESS;
+		ResponseCodeAndMessages expectedCodeAndMessage = ResponseCodeAndMessages.STORE_CREATE_SUCCESS;
 
 		given(this.spec)
 			.filter(document(DEFAULT_RESTDOC_PATH,
-				STORE_INSERT_REQUEST_SNIPPET,
-				STORE_INSERT_RESPONSE_SNIPPET))
+				STORE_CREATE_REQUEST_SNIPPET,
+				STORE_CREATE_RESPONSE_SNIPPET))
 			.accept(MediaType.APPLICATION_JSON_VALUE)
 			.header("Authorization", testData.userValidAuthorizationHeader)
 			.contentType(ContentType.JSON)
-			.body(storeInsertRequest)
+			.body(storeCreateRequest)
 
 		.when()
 			.post("/api/stores")

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/store/StoreCreateAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/store/StoreCreateAcceptanceTest.java
@@ -16,7 +16,7 @@ import org.springframework.cloud.contract.spec.internal.HttpStatus;
 import org.springframework.http.MediaType;
 
 @DisplayName("StoreCreate 인수 테스트")
-public class StoreCreateAcceptanceTest extends InitAcceptanceTest {
+class StoreCreateAcceptanceTest extends InitAcceptanceTest {
 
 	@Test
 	@DisplayName("가게 생성 요청이 정상적인 경우라면, 리뷰 생성 후 정상 상태 코드를 반환한다.")

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/store/StoreModifyAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/store/StoreModifyAcceptanceTest.java
@@ -17,7 +17,7 @@ import org.springframework.cloud.contract.spec.internal.HttpStatus;
 import org.springframework.http.MediaType;
 
 @DisplayName("StoreModify 인수 테스트")
-public class StoreModifyAcceptanceTest extends InitAcceptanceTest {
+class StoreModifyAcceptanceTest extends InitAcceptanceTest {
 
 	@Test
 	@DisplayName("가게 수정 요청이 정상적인 경우라면, 리뷰 생성 후 정상 상태 코드를 반환한다.")

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/store/StoreModifyAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/store/StoreModifyAcceptanceTest.java
@@ -49,7 +49,7 @@ public class StoreModifyAcceptanceTest extends InitAcceptanceTest {
 			.put("/api/stores")
 
 		.then()
-			.statusCode(HttpStatus.NO_CONTENT)
+			.statusCode(HttpStatus.OK)
 			.body("code", Matchers.equalTo(expectedCodeAndMessage.getCode()))
 			.body("message", Matchers.equalTo(expectedCodeAndMessage.getMessage()));
 	}

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/store/StoreModifyAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/store/StoreModifyAcceptanceTest.java
@@ -1,5 +1,6 @@
 package com.jjikmuk.sikdorak.acceptance.store;
 
+import static com.jjikmuk.sikdorak.acceptance.store.StoreSnippet.STORE_MODIFY_REQUEST_PARAM_SNIPPET;
 import static com.jjikmuk.sikdorak.acceptance.store.StoreSnippet.STORE_MODIFY_REQUEST_SNIPPET;
 import static com.jjikmuk.sikdorak.acceptance.store.StoreSnippet.STORE_MODIFY_RESPONSE_SNIPPET;
 import static io.restassured.RestAssured.given;
@@ -22,10 +23,9 @@ class StoreModifyAcceptanceTest extends InitAcceptanceTest {
 	@Test
 	@DisplayName("가게 수정 요청이 정상적인 경우라면, 리뷰 생성 후 정상 상태 코드를 반환한다.")
 	void modify_store_success() {
-		Store savedStore = testData.store;
+		Long savedStoreId = testData.store.getId();
 
 		StoreModifyRequest storeModifyRequest = new StoreModifyRequest(
-			savedStore.getId(),
 			"업데이트된 가게 이름",
 			"02-9999-9999",
 			"서울시 어쩌구 00길 00",
@@ -36,8 +36,9 @@ class StoreModifyAcceptanceTest extends InitAcceptanceTest {
 
 		ResponseCodeAndMessages expectedCodeAndMessage = ResponseCodeAndMessages.STORE_MODIFY_SUCCESS;
 
-		given(this.spec)
+		given(this.spec).log().all()
 			.filter(document(DEFAULT_RESTDOC_PATH,
+				STORE_MODIFY_REQUEST_PARAM_SNIPPET,
 				STORE_MODIFY_REQUEST_SNIPPET,
 				STORE_MODIFY_RESPONSE_SNIPPET))
 			.accept(MediaType.APPLICATION_JSON_VALUE)
@@ -46,7 +47,7 @@ class StoreModifyAcceptanceTest extends InitAcceptanceTest {
 			.body(storeModifyRequest)
 
 		.when()
-			.put("/api/stores")
+			.put("/api/stores/{storeId}", savedStoreId)
 
 		.then()
 			.statusCode(HttpStatus.OK)

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/store/StoreModifyAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/store/StoreModifyAcceptanceTest.java
@@ -1,0 +1,56 @@
+package com.jjikmuk.sikdorak.acceptance.store;
+
+import static com.jjikmuk.sikdorak.acceptance.store.StoreSnippet.STORE_MODIFY_REQUEST_SNIPPET;
+import static com.jjikmuk.sikdorak.acceptance.store.StoreSnippet.STORE_MODIFY_RESPONSE_SNIPPET;
+import static io.restassured.RestAssured.given;
+import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
+
+import com.jjikmuk.sikdorak.acceptance.InitAcceptanceTest;
+import com.jjikmuk.sikdorak.common.ResponseCodeAndMessages;
+import com.jjikmuk.sikdorak.store.controller.request.StoreModifyRequest;
+import com.jjikmuk.sikdorak.store.domain.Store;
+import io.restassured.http.ContentType;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.cloud.contract.spec.internal.HttpStatus;
+import org.springframework.http.MediaType;
+
+@DisplayName("StoreModify 인수 테스트")
+public class StoreModifyAcceptanceTest extends InitAcceptanceTest {
+
+	@Test
+	@DisplayName("가게 수정 요청이 정상적인 경우라면, 리뷰 생성 후 정상 상태 코드를 반환한다.")
+	void modify_store_success() {
+		Store savedStore = testData.store;
+
+		StoreModifyRequest storeModifyRequest = new StoreModifyRequest(
+			savedStore.getId(),
+			"업데이트된 가게 이름",
+			"02-9999-9999",
+			"서울시 어쩌구 00길 00",
+			null,
+			37.49082,
+			127.033417
+		);
+
+		ResponseCodeAndMessages expectedCodeAndMessage = ResponseCodeAndMessages.STORE_MODIFY_SUCCESS;
+
+		given(this.spec)
+			.filter(document(DEFAULT_RESTDOC_PATH,
+				STORE_MODIFY_REQUEST_SNIPPET,
+				STORE_MODIFY_RESPONSE_SNIPPET))
+			.accept(MediaType.APPLICATION_JSON_VALUE)
+			.header("Authorization", testData.userValidAuthorizationHeader)
+			.contentType(ContentType.JSON)
+			.body(storeModifyRequest)
+
+		.when()
+			.put("/api/stores")
+
+		.then()
+			.statusCode(HttpStatus.NO_CONTENT)
+			.body("code", Matchers.equalTo(expectedCodeAndMessage.getCode()))
+			.body("message", Matchers.equalTo(expectedCodeAndMessage.getMessage()));
+	}
+}

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/store/StoreSnippet.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/store/StoreSnippet.java
@@ -39,6 +39,17 @@ public interface StoreSnippet {
 
 	Snippet STORE_INSERT_RESPONSE_SNIPPET = commonResponseNonFields();
 
+	Snippet STORE_MODIFY_REQUEST_SNIPPET = requestFields(
+		fieldWithPath("storeName").type(JsonFieldType.STRING).description(Constants.STORENAME_DESCRIPTION),
+		fieldWithPath("contactNumber").type(JsonFieldType.STRING).description(Constants.CONTACTNUMBER_DESCRIPTION),
+		fieldWithPath("baseAddress").type(JsonFieldType.STRING).description(Constants.BASEADDRESS_DESCRIPTION),
+		fieldWithPath("detailAddress").type(JsonFieldType.STRING).description(Constants.DETAILADDRESS_DESCRIPTION).optional(),
+		fieldWithPath("latitude").type(JsonFieldType.NUMBER).description(Constants.LATITUDE_DESCRIPTION),
+		fieldWithPath("longitude").type(JsonFieldType.NUMBER).description(Constants.LONGITUDE_DESCRIPTION)
+	);
+
+	Snippet STORE_MODIFY_RESPONSE_SNIPPET = commonResponseNonFields();
+
 	class Constants {
 		private static final String ID_DESCRIPTION = "가게 아이디";
 		private static final String STORENAME_DESCRIPTION = "가게 이름";

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/store/StoreSnippet.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/store/StoreSnippet.java
@@ -40,6 +40,7 @@ public interface StoreSnippet {
 	Snippet STORE_INSERT_RESPONSE_SNIPPET = commonResponseNonFields();
 
 	Snippet STORE_MODIFY_REQUEST_SNIPPET = requestFields(
+		fieldWithPath("id").type(JsonFieldType.NUMBER).description(Constants.ID_DESCRIPTION),
 		fieldWithPath("storeName").type(JsonFieldType.STRING).description(Constants.STORENAME_DESCRIPTION),
 		fieldWithPath("contactNumber").type(JsonFieldType.STRING).description(Constants.CONTACTNUMBER_DESCRIPTION),
 		fieldWithPath("baseAddress").type(JsonFieldType.STRING).description(Constants.BASEADDRESS_DESCRIPTION),

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/store/StoreSnippet.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/store/StoreSnippet.java
@@ -28,7 +28,7 @@ public interface StoreSnippet {
 			fieldWithPath("longitude").type(JsonFieldType.NUMBER).description(Constants.LONGITUDE_DESCRIPTION)
 	);
 
-	Snippet STORE_INSERT_REQUEST_SNIPPET = requestFields(
+	Snippet STORE_CREATE_REQUEST_SNIPPET = requestFields(
 		fieldWithPath("storeName").type(JsonFieldType.STRING).description(Constants.STORENAME_DESCRIPTION),
 		fieldWithPath("contactNumber").type(JsonFieldType.STRING).description(Constants.CONTACTNUMBER_DESCRIPTION),
 		fieldWithPath("baseAddress").type(JsonFieldType.STRING).description(Constants.BASEADDRESS_DESCRIPTION),
@@ -37,7 +37,7 @@ public interface StoreSnippet {
 		fieldWithPath("longitude").type(JsonFieldType.NUMBER).description(Constants.LONGITUDE_DESCRIPTION)
 	);
 
-	Snippet STORE_INSERT_RESPONSE_SNIPPET = commonResponseNonFields();
+	Snippet STORE_CREATE_RESPONSE_SNIPPET = commonResponseNonFields();
 
 	Snippet STORE_MODIFY_REQUEST_SNIPPET = requestFields(
 		fieldWithPath("id").type(JsonFieldType.NUMBER).description(Constants.ID_DESCRIPTION),

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/store/StoreSnippet.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/store/StoreSnippet.java
@@ -1,15 +1,16 @@
 package com.jjikmuk.sikdorak.acceptance.store;
 
-import com.jjikmuk.sikdorak.store.controller.response.StoreSearchResponse;
-import org.springframework.restdocs.payload.JsonFieldType;
-import org.springframework.restdocs.snippet.Snippet;
-
 import static com.jjikmuk.sikdorak.acceptance.DocumentFormatGenerator.commonListResponseFieldsWithValidConstraints;
 import static com.jjikmuk.sikdorak.acceptance.DocumentFormatGenerator.commonResponseNonFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
+
+import com.jjikmuk.sikdorak.store.controller.response.StoreSearchResponse;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.restdocs.snippet.Snippet;
 
 public interface StoreSnippet {
 
@@ -39,8 +40,11 @@ public interface StoreSnippet {
 
 	Snippet STORE_CREATE_RESPONSE_SNIPPET = commonResponseNonFields();
 
+	Snippet STORE_MODIFY_REQUEST_PARAM_SNIPPET = pathParameters(
+		parameterWithName("storeId").description(Constants.ID_DESCRIPTION)
+	);
+
 	Snippet STORE_MODIFY_REQUEST_SNIPPET = requestFields(
-		fieldWithPath("id").type(JsonFieldType.NUMBER).description(Constants.ID_DESCRIPTION),
 		fieldWithPath("storeName").type(JsonFieldType.STRING).description(Constants.STORENAME_DESCRIPTION),
 		fieldWithPath("contactNumber").type(JsonFieldType.STRING).description(Constants.CONTACTNUMBER_DESCRIPTION),
 		fieldWithPath("baseAddress").type(JsonFieldType.STRING).description(Constants.BASEADDRESS_DESCRIPTION),

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/store/StoreCreateIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/store/StoreCreateIntegrationTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.jjikmuk.sikdorak.common.exception.SikdorakRuntimeException;
 import com.jjikmuk.sikdorak.integration.InitIntegrationTest;
-import com.jjikmuk.sikdorak.store.controller.request.StoreInsertRequest;
+import com.jjikmuk.sikdorak.store.controller.request.StoreCreateRequest;
 import com.jjikmuk.sikdorak.store.domain.Store;
 import com.jjikmuk.sikdorak.store.repository.StoreRepository;
 import com.jjikmuk.sikdorak.store.service.StoreService;
@@ -14,8 +14,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-@DisplayName("StoreInsert 통합테스트")
-public class StoreInsertIntegrationTest extends InitIntegrationTest {
+@DisplayName("StoreCreate 통합테스트")
+public class StoreCreateIntegrationTest extends InitIntegrationTest {
 
     @Autowired
     private StoreService storeService;
@@ -25,13 +25,13 @@ public class StoreInsertIntegrationTest extends InitIntegrationTest {
 
     @Nested
     @DisplayName("가게를 저장할 때")
-    class InsertStoreTest {
+    class CreateStoreTest {
 
         @Test
         @DisplayName("정상적인 가게 생성 요청이 주어진다면 가게를 등록할 수 있다")
         void create_store_success() {
             // given
-            StoreInsertRequest storeInsertRequest = new StoreInsertRequest(
+            StoreCreateRequest storeCreateRequest = new StoreCreateRequest(
                 "새로 생긴 가게",
                 "02-0000-0000",
                 "서울시 어쩌구 00길 00",
@@ -41,23 +41,23 @@ public class StoreInsertIntegrationTest extends InitIntegrationTest {
             );
 
             // when
-            Long savedStoreId = storeService.insertStore(storeInsertRequest);
+            Long savedStoreId = storeService.createStore(storeCreateRequest);
 
             // then
             Store savedStore = storeRepository.findById(savedStoreId).orElseThrow();
-            assertThat(storeInsertRequest.getStoreName()).isEqualTo(savedStore.getStoreName());
-            assertThat(storeInsertRequest.getContactNumber()).isEqualTo(savedStore.getContactNumber());
-            assertThat(storeInsertRequest.getBaseAddress()).isEqualTo(savedStore.getBaseAddress());
-            assertThat(storeInsertRequest.getDetailAddress()).isEqualTo(savedStore.getDetailAddress());
-            assertThat(storeInsertRequest.getLatitude()).isEqualTo(savedStore.getLatitude());
-            assertThat(storeInsertRequest.getLongitude()).isEqualTo(savedStore.getLongitude());
+            assertThat(storeCreateRequest.getStoreName()).isEqualTo(savedStore.getStoreName());
+            assertThat(storeCreateRequest.getContactNumber()).isEqualTo(savedStore.getContactNumber());
+            assertThat(storeCreateRequest.getBaseAddress()).isEqualTo(savedStore.getBaseAddress());
+            assertThat(storeCreateRequest.getDetailAddress()).isEqualTo(savedStore.getDetailAddress());
+            assertThat(storeCreateRequest.getLatitude()).isEqualTo(savedStore.getLatitude());
+            assertThat(storeCreateRequest.getLongitude()).isEqualTo(savedStore.getLongitude());
         }
 
         @Test
         @DisplayName("정상적이지 않은 가게 생성 요청이 주어진다면 예외를 발생시킨다")
         void create_store_failed() {
             // given
-            StoreInsertRequest invalidStoreInsertRequest = new StoreInsertRequest(
+            StoreCreateRequest invalidStoreCreateRequest = new StoreCreateRequest(
                 null,
                 "02-0000-0000",
                 "서울시 어쩌구 00길 00",
@@ -67,7 +67,7 @@ public class StoreInsertIntegrationTest extends InitIntegrationTest {
             );
 
             // then
-            assertThatThrownBy(() -> storeService.insertStore(invalidStoreInsertRequest))
+            assertThatThrownBy(() -> storeService.createStore(invalidStoreCreateRequest))
                 .isInstanceOf(SikdorakRuntimeException.class);
         }
     }

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/store/StoreModifyIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/store/StoreModifyIntegrationTest.java
@@ -1,0 +1,80 @@
+package com.jjikmuk.sikdorak.integration.store;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.jjikmuk.sikdorak.common.exception.SikdorakRuntimeException;
+import com.jjikmuk.sikdorak.integration.InitIntegrationTest;
+import com.jjikmuk.sikdorak.store.controller.request.StoreModifyRequest;
+import com.jjikmuk.sikdorak.store.domain.Store;
+import com.jjikmuk.sikdorak.store.repository.StoreRepository;
+import com.jjikmuk.sikdorak.store.service.StoreService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayName("StoreModify 통합테스트")
+public class StoreModifyIntegrationTest extends InitIntegrationTest {
+
+    @Autowired
+    private StoreService storeService;
+
+    @Autowired
+    private StoreRepository storeRepository;
+
+    @Nested
+    @DisplayName("가게를 수정할 때")
+    class ModifyStoreTest {
+
+        @Test
+        @DisplayName("존재하는 가게에 대한 수정 요청이라면 가게를 수정할 수 있다.")
+        void modify_store_success() {
+            // given
+            Store savedStore = testData.store;
+
+            StoreModifyRequest storeModifyRequest = new StoreModifyRequest(
+                savedStore.getId(),
+                "업데이트된 가게 이름",
+                "02-9999-9999",
+                "서울시 어쩌구 00길 00",
+                null,
+                37.49082,
+                127.033417
+            );
+
+            // when
+            Long savedStoreId = storeService.modifyStore(storeModifyRequest);
+
+            // then
+            Store updatedStore = storeRepository.findById(savedStoreId).orElseThrow();
+            assertThat(storeModifyRequest.getId()).isEqualTo(updatedStore.getId());
+            assertThat(storeModifyRequest.getStoreName()).isEqualTo(updatedStore.getStoreName());
+            assertThat(storeModifyRequest.getContactNumber()).isEqualTo(updatedStore.getContactNumber());
+            assertThat(storeModifyRequest.getBaseAddress()).isEqualTo(updatedStore.getBaseAddress());
+            assertThat(storeModifyRequest.getDetailAddress()).isEqualTo(updatedStore.getDetailAddress());
+            assertThat(storeModifyRequest.getLatitude()).isEqualTo(updatedStore.getLatitude());
+            assertThat(storeModifyRequest.getLongitude()).isEqualTo(updatedStore.getLongitude());
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 가게에 대한 수정 요청이라면 예외를 발생시킨다.")
+        void create_store_failed() {
+            long notSavedStoreId = Long.MIN_VALUE;
+
+            StoreModifyRequest storeModifyRequest = new StoreModifyRequest(
+                notSavedStoreId,
+                "업데이트된 가게 이름",
+                "02-9999-9999",
+                "서울시 어쩌구 00길 00",
+                null,
+                37.49082,
+                127.033417
+            );
+
+            // then
+            assertThatThrownBy(() -> storeService.modifyStore(storeModifyRequest))
+                .isInstanceOf(SikdorakRuntimeException.class);
+        }
+    }
+}

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/store/StoreModifyIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/store/StoreModifyIntegrationTest.java
@@ -31,10 +31,9 @@ public class StoreModifyIntegrationTest extends InitIntegrationTest {
         @DisplayName("존재하는 가게에 대한 수정 요청이라면 가게를 수정할 수 있다.")
         void modify_store_success() {
             // given
-            Store savedStore = testData.store;
+            Long savedStoreId = testData.store.getId();
 
             StoreModifyRequest storeModifyRequest = new StoreModifyRequest(
-                savedStore.getId(),
                 "업데이트된 가게 이름",
                 "02-9999-9999",
                 "서울시 어쩌구 00길 00",
@@ -44,11 +43,10 @@ public class StoreModifyIntegrationTest extends InitIntegrationTest {
             );
 
             // when
-            Long savedStoreId = storeService.modifyStore(storeModifyRequest);
+            Long updatedStoreId = storeService.modifyStore(savedStoreId, storeModifyRequest);
 
             // then
-            Store updatedStore = storeRepository.findById(savedStoreId).orElseThrow();
-            assertThat(storeModifyRequest.getId()).isEqualTo(updatedStore.getId());
+            Store updatedStore = storeRepository.findById(updatedStoreId).orElseThrow();
             assertThat(storeModifyRequest.getStoreName()).isEqualTo(updatedStore.getStoreName());
             assertThat(storeModifyRequest.getContactNumber()).isEqualTo(updatedStore.getContactNumber());
             assertThat(storeModifyRequest.getBaseAddress()).isEqualTo(updatedStore.getBaseAddress());
@@ -63,7 +61,6 @@ public class StoreModifyIntegrationTest extends InitIntegrationTest {
             long notSavedStoreId = Long.MIN_VALUE;
 
             StoreModifyRequest storeModifyRequest = new StoreModifyRequest(
-                notSavedStoreId,
                 "업데이트된 가게 이름",
                 "02-9999-9999",
                 "서울시 어쩌구 00길 00",
@@ -73,7 +70,7 @@ public class StoreModifyIntegrationTest extends InitIntegrationTest {
             );
 
             // then
-            assertThatThrownBy(() -> storeService.modifyStore(storeModifyRequest))
+            assertThatThrownBy(() -> storeService.modifyStore(notSavedStoreId, storeModifyRequest))
                 .isInstanceOf(SikdorakRuntimeException.class);
         }
     }


### PR DESCRIPTION
### ❗️ 이슈 번호

[SDR-116]

<br><br>

### 📝 구현 내용

- 가게 수정 API 구현
- `Insert` -> `Create` 로 명칭 변경
- Service 계층 Transactional 적용
- API 문서 추가(등록, 수정)

<br><br>

### 🙇🏻‍♂️ 리뷰어에게 부탁합니다!

- 가게 수정 API 는 전체를 받고 전체를 수정하는 방식으로 동작합니다.
- CommonResponseEntity 에서 ResponseBody(data) 를 넣지 않는 경우를 위해, 생성자를 추가했습니다.


[SDR-116]: https://jjikmuk.atlassian.net/browse/SDR-116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ