### PR TITLE
SDR-122 리뷰 수정 API 구현

### DIFF
--- a/be/src/docs/asciidoc/review/review.adoc
+++ b/be/src/docs/asciidoc/review/review.adoc
@@ -12,3 +12,32 @@ operation::review_insert_acceptance_test/create_review_success[snippets='http-re
 ==== `Response`
 
 operation::review_insert_acceptance_test/create_review_success[snippets='http-response,response-fields']
+
+=== 리뷰 수정
+
+API : `PUT /api/reviews/{reviewId}`
+
+=== `200 OK`
+
+리뷰 작성자가 리뷰 수정한 경우
+
+==== `Request`
+
+operation::review_modify_acceptance_test/modify_review_success[snippets='http-request,path-parameters,request-fields']
+
+==== `Response`
+
+operation::review_modify_acceptance_test/modify_review_success[snippets='http-response,response-fields']
+
+=== `401 UNATHORIZED`
+
+리뷰 작성자가 아닌 유저가 수정 요청한 경우
+
+
+==== `Request`
+
+operation::review_modify_acceptance_test/modify_review_failed[snippets='http-request']
+
+==== `Response`
+
+operation::review_modify_acceptance_test/modify_review_failed[snippets='http-response,response-fields']

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/ResponseCodeAndMessages.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/ResponseCodeAndMessages.java
@@ -2,7 +2,7 @@ package com.jjikmuk.sikdorak.common;
 
 public enum ResponseCodeAndMessages implements CodeAndMessages {
 
-    REVIEW_CREATED("T-R001", "리뷰 생성 성공했습니다."),
+    REVIEW_CREATED_SUCCESS("T-R001", "리뷰 생성 성공했습니다."),
 
     // OAuth
     LOGIN_SUCCESS("T-O001", "로그인에 성공했습니다."),

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/ResponseCodeAndMessages.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/ResponseCodeAndMessages.java
@@ -2,7 +2,8 @@ package com.jjikmuk.sikdorak.common;
 
 public enum ResponseCodeAndMessages implements CodeAndMessages {
 
-    REVIEW_CREATED_SUCCESS("T-R001", "리뷰 생성 성공했습니다."),
+    REVIEW_CREATE_SUCCESS("T-R001", "리뷰 생성 성공했습니다."),
+    REVIEW_MODIFY_SUCCESS("T-R002", "리뷰 수정 성공했습니다."),
 
     // OAuth
     LOGIN_SUCCESS("T-O001", "로그인에 성공했습니다."),

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/exception/ExceptionCodeAndMessages.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/exception/ExceptionCodeAndMessages.java
@@ -7,11 +7,12 @@ import com.jjikmuk.sikdorak.review.exception.InvalidReviewVisibilityException;
 import com.jjikmuk.sikdorak.review.exception.InvalidReviewVisitedDateException;
 import com.jjikmuk.sikdorak.review.exception.InvalidTagException;
 import com.jjikmuk.sikdorak.review.exception.InvalidTagsException;
+import com.jjikmuk.sikdorak.review.exception.NotFoundReviewException;
 import com.jjikmuk.sikdorak.store.exception.InvalidAddressException;
 import com.jjikmuk.sikdorak.store.exception.InvalidContactNumberException;
 import com.jjikmuk.sikdorak.store.exception.InvalidStoreLocationException;
 import com.jjikmuk.sikdorak.store.exception.InvalidStoreNameException;
-import com.jjikmuk.sikdorak.store.exception.StoreNotFoundException;
+import com.jjikmuk.sikdorak.store.exception.NotFoundStoreException;
 import com.jjikmuk.sikdorak.user.auth.exception.InvalidTokenException;
 import com.jjikmuk.sikdorak.user.auth.exception.NeedLoginException;
 import com.jjikmuk.sikdorak.user.auth.exception.OAuthServerException;
@@ -19,8 +20,8 @@ import com.jjikmuk.sikdorak.user.user.exception.DuplicateUserException;
 import com.jjikmuk.sikdorak.user.user.exception.InvalidUserEmailException;
 import com.jjikmuk.sikdorak.user.user.exception.InvalidUserNicknameException;
 import com.jjikmuk.sikdorak.user.user.exception.InvalidUserProfileImageUrlException;
+import com.jjikmuk.sikdorak.user.user.exception.NotFoundUserException;
 import com.jjikmuk.sikdorak.user.user.exception.UnauthorizedUserException;
-import com.jjikmuk.sikdorak.user.user.exception.UserNotFoundException;
 import java.util.Arrays;
 import lombok.Getter;
 
@@ -35,9 +36,10 @@ public enum ExceptionCodeAndMessages implements CodeAndMessages {
     INVALID_REVIEW_VISITEDDATE("F-R004", "유효하지 않은 방문일자 입니다.", InvalidReviewVisitedDateException.class),
     INVALID_REVIEW_TAGS("F-R005", "유효하지 않은 태그들 입니다.", InvalidTagsException.class),
     INVALID_REVIEW_TAG("F-R006", "유효하지 않은 태그 입니다.", InvalidTagException.class),
+    NOT_FOUND_STROE("F-R007", "리뷰를 찾을 수 없습니다.", NotFoundReviewException.class),
 
     // Store
-    NOT_FOUND_STORE("F-S001", "Store Id를 찾을 수 없습니다.", StoreNotFoundException.class),
+    NOT_FOUND_STORE("F-S001", "Store Id를 찾을 수 없습니다.", NotFoundStoreException.class),
     INVALID_STORE_NAME("F-S002", "유효하지 않은 가게이름 입니다.",InvalidStoreNameException.class),
     INVALID_CONTACT_NUMER("F-S003", "유효하지 않은 연락처 입니다.", InvalidContactNumberException.class),
     INVALID_ADDRESS("F-S004", "유효하지 않은 연락처 입니다.", InvalidAddressException.class),
@@ -48,7 +50,7 @@ public enum ExceptionCodeAndMessages implements CodeAndMessages {
     INVALID_USER_NIKCNAME("F-U002", "유효하지 않은 닉네임 입니다.", InvalidUserNicknameException.class),
     INVALID_USER_PROFILE_IMAGE("F-U003", "유효하지 않은 프로필 이미지 url의 형식입니다.", InvalidUserProfileImageUrlException.class),
     INVALID_USER_EMAIL("F-U004", "유효하지 않은 이메일 형식입니다.", InvalidUserEmailException.class),
-    USER_NOT_FOUND("F-U005", "존재하지 않는 유저입니다.", UserNotFoundException.class),
+    NOT_FOUND_USER("F-U005", "존재하지 않는 유저입니다.", NotFoundUserException.class),
     UNAUTHORIZED_USER("F-U006", "권한이 없는 유저입니다.", UnauthorizedUserException.class),
 
     //OAuth

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/exception/ExceptionCodeAndMessages.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/exception/ExceptionCodeAndMessages.java
@@ -19,6 +19,7 @@ import com.jjikmuk.sikdorak.user.user.exception.DuplicateUserException;
 import com.jjikmuk.sikdorak.user.user.exception.InvalidUserEmailException;
 import com.jjikmuk.sikdorak.user.user.exception.InvalidUserNicknameException;
 import com.jjikmuk.sikdorak.user.user.exception.InvalidUserProfileImageUrlException;
+import com.jjikmuk.sikdorak.user.user.exception.UnauthorizedUserException;
 import com.jjikmuk.sikdorak.user.user.exception.UserNotFoundException;
 import java.util.Arrays;
 import lombok.Getter;
@@ -48,6 +49,7 @@ public enum ExceptionCodeAndMessages implements CodeAndMessages {
     INVALID_USER_PROFILE_IMAGE("F-U003", "유효하지 않은 프로필 이미지 url의 형식입니다.", InvalidUserProfileImageUrlException.class),
     INVALID_USER_EMAIL("F-U004", "유효하지 않은 이메일 형식입니다.", InvalidUserEmailException.class),
     USER_NOT_FOUND("F-U005", "존재하지 않는 유저입니다.", UserNotFoundException.class),
+    UNAUTHORIZED_USER("F-U006", "권한이 없는 유저입니다.", UnauthorizedUserException.class),
 
     //OAuth
     FAILED_CONNECTION_WITH_OAUTH_SERVER("F-O001", "OAuth 서버와의 통신이 원할하지 않습니다.", OAuthServerException.class),

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/exception/GlobalExceptionHandler.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/exception/GlobalExceptionHandler.java
@@ -9,7 +9,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(SikdorakRuntimeException.class)
     public CommonResponseEntity<Void> handle(SikdorakRuntimeException exception) {
-        return new CommonResponseEntity<>(exception.getCodeAndMessages(), null, exception.getHttpStatus());
+        return new CommonResponseEntity<>(exception.getCodeAndMessages(), exception.getHttpStatus());
     }
 
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/controller/ReviewController.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/controller/ReviewController.java
@@ -3,7 +3,7 @@ package com.jjikmuk.sikdorak.review.controller;
 import com.jjikmuk.sikdorak.common.ResponseCodeAndMessages;
 import com.jjikmuk.sikdorak.common.aop.UserOnly;
 import com.jjikmuk.sikdorak.common.response.CommonResponseEntity;
-import com.jjikmuk.sikdorak.review.controller.request.ReviewInsertRequest;
+import com.jjikmuk.sikdorak.review.controller.request.ReviewCreateRequest;
 import com.jjikmuk.sikdorak.review.service.ReviewService;
 import com.jjikmuk.sikdorak.user.auth.controller.LoginUser;
 import com.jjikmuk.sikdorak.user.auth.domain.AuthenticatedUser;
@@ -23,9 +23,9 @@ public class ReviewController {
     @PostMapping("/api/reviews")
     public CommonResponseEntity<Void> insertReview(
         @AuthenticatedUser LoginUser loginUser,
-        @RequestBody ReviewInsertRequest reviewInsertRequest) {
-        reviewService.insertReview(loginUser, reviewInsertRequest);
+        @RequestBody ReviewCreateRequest reviewCreateRequest) {
+        reviewService.createReview(loginUser, reviewCreateRequest);
 
-        return new CommonResponseEntity<>(ResponseCodeAndMessages.REVIEW_CREATED, null, HttpStatus.CREATED);
+        return new CommonResponseEntity<>(ResponseCodeAndMessages.REVIEW_CREATED_SUCCESS, HttpStatus.CREATED);
     }
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/controller/ReviewController.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/controller/ReviewController.java
@@ -4,12 +4,15 @@ import com.jjikmuk.sikdorak.common.ResponseCodeAndMessages;
 import com.jjikmuk.sikdorak.common.aop.UserOnly;
 import com.jjikmuk.sikdorak.common.response.CommonResponseEntity;
 import com.jjikmuk.sikdorak.review.controller.request.ReviewCreateRequest;
+import com.jjikmuk.sikdorak.review.controller.request.ReviewModifyRequest;
 import com.jjikmuk.sikdorak.review.service.ReviewService;
 import com.jjikmuk.sikdorak.user.auth.controller.LoginUser;
 import com.jjikmuk.sikdorak.user.auth.domain.AuthenticatedUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -17,15 +20,28 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class ReviewController {
 
-    private final ReviewService reviewService;
+	private final ReviewService reviewService;
 
-    @UserOnly
-    @PostMapping("/api/reviews")
-    public CommonResponseEntity<Void> insertReview(
-        @AuthenticatedUser LoginUser loginUser,
-        @RequestBody ReviewCreateRequest reviewCreateRequest) {
-        reviewService.createReview(loginUser, reviewCreateRequest);
+	@UserOnly
+	@PostMapping("/api/reviews")
+	public CommonResponseEntity<Void> createReview(
+		@AuthenticatedUser LoginUser loginUser,
+		@RequestBody ReviewCreateRequest reviewCreateRequest) {
+		reviewService.createReview(loginUser, reviewCreateRequest);
 
-        return new CommonResponseEntity<>(ResponseCodeAndMessages.REVIEW_CREATED_SUCCESS, HttpStatus.CREATED);
-    }
+		return new CommonResponseEntity<>(ResponseCodeAndMessages.REVIEW_CREATE_SUCCESS,
+			HttpStatus.CREATED);
+	}
+
+	@UserOnly
+	@PutMapping("/api/reviews/{reviewId}")
+	public CommonResponseEntity<Void> modifyReview(
+		@PathVariable Long reviewId,
+		@AuthenticatedUser LoginUser loginUser,
+		@RequestBody ReviewModifyRequest reviewModifyRequest) {
+		reviewService.modifyReview(loginUser, reviewId, reviewModifyRequest);
+
+		return new CommonResponseEntity<>(ResponseCodeAndMessages.REVIEW_MODIFY_SUCCESS,
+			HttpStatus.OK);
+	}
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/controller/request/ReviewCreateRequest.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/controller/request/ReviewCreateRequest.java
@@ -14,7 +14,7 @@ import org.hibernate.validator.constraints.URL;
 
 @Getter
 @NoArgsConstructor
-public class ReviewInsertRequest {
+public class ReviewCreateRequest {
 
 	@NotBlank
 	@Size(min = 1, max = 500)
@@ -44,7 +44,7 @@ public class ReviewInsertRequest {
 	@Size(max = 10)
 	private List<String> images;
 
-	public ReviewInsertRequest(String reviewContent, Long storeId, Float reviewScore,
+	public ReviewCreateRequest(String reviewContent, Long storeId, Float reviewScore,
 		String reviewVisibility, LocalDate visitedDate, List<String> tags,
 		List<String> images) {
 		this.reviewContent = reviewContent;

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/controller/request/ReviewModifyRequest.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/controller/request/ReviewModifyRequest.java
@@ -1,0 +1,59 @@
+package com.jjikmuk.sikdorak.review.controller.request;
+
+import java.time.LocalDate;
+import java.util.List;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.PastOrPresent;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Positive;
+import javax.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.URL;
+
+@Getter
+@NoArgsConstructor
+public class ReviewModifyRequest {
+
+	@NotBlank
+	@Size(min = 1, max = 500)
+	private String reviewContent;
+
+	@NotNull
+	@Positive
+	private Long storeId;
+
+	@NotNull
+	@Pattern(regexp = "1-5")
+	private Float reviewScore;
+
+	@NotNull
+	@Pattern(regexp = "public\\|protected\\|private")
+	private String reviewVisibility;
+
+	@NotNull
+	@PastOrPresent
+	@Pattern(regexp = "yyyy-MM-dd")
+	private LocalDate visitedDate;
+
+	@Size(max = 30)
+	private List<String> tags;
+
+	@URL
+	@Size(max = 10)
+	private List<String> images;
+
+	public ReviewModifyRequest(String reviewContent, Long storeId, Float reviewScore,
+		String reviewVisibility, LocalDate visitedDate, List<String> tags,
+		List<String> images) {
+		this.reviewContent = reviewContent;
+		this.storeId = storeId;
+		this.reviewScore = reviewScore;
+		this.reviewVisibility = reviewVisibility;
+		this.visitedDate = visitedDate;
+		this.tags = tags;
+		this.images = images;
+	}
+
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/domain/Review.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/domain/Review.java
@@ -75,6 +75,10 @@ public class Review extends BaseTimeEntity {
 		return userId;
 	}
 
+	public String getReviewContent() {
+		return reviewContent.getReviewContent();
+	}
+
 	public boolean isAuthor(User user) {
 		return this.userId.equals(user.getId());
 	}

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/domain/Review.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/domain/Review.java
@@ -1,6 +1,7 @@
 package com.jjikmuk.sikdorak.review.domain;
 
 import com.jjikmuk.sikdorak.common.domain.BaseTimeEntity;
+import com.jjikmuk.sikdorak.user.user.domain.User;
 import java.time.LocalDate;
 import java.util.List;
 import javax.persistence.Column;
@@ -72,5 +73,20 @@ public class Review extends BaseTimeEntity {
 
 	public Long getUserId() {
 		return userId;
+	}
+
+	public boolean isAuthor(User user) {
+		return this.userId.equals(user.getId());
+	}
+
+	public void editAll(Long storeId, String reviewContent, Float reviewScore,
+		String reviewVisibility, LocalDate visitedDate, List<String> tags, List<String> images) {
+		this.storeId = storeId;
+		this.reviewContent = new ReviewContent(reviewContent);
+		this.reviewScore = new ReviewScore(reviewScore);
+		this.reviewVisibility = ReviewVisibility.create(reviewVisibility);
+		this.visitedDate = new ReviewVisitedDate(visitedDate);
+		this.tags = new Tags(tags);
+		this.images = images;
 	}
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/exception/NotFoundReviewException.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/exception/NotFoundReviewException.java
@@ -1,12 +1,13 @@
-package com.jjikmuk.sikdorak.store.exception;
+package com.jjikmuk.sikdorak.review.exception;
 
 import com.jjikmuk.sikdorak.common.exception.SikdorakRuntimeException;
 import org.springframework.http.HttpStatus;
 
-public class StoreNotFoundException extends SikdorakRuntimeException {
+public class NotFoundReviewException extends SikdorakRuntimeException {
 
 	@Override
 	public HttpStatus getHttpStatus() {
 		return HttpStatus.NOT_FOUND;
 	}
 }
+

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/exception/ReviewNotFoundException.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/exception/ReviewNotFoundException.java
@@ -1,0 +1,13 @@
+package com.jjikmuk.sikdorak.review.exception;
+
+import com.jjikmuk.sikdorak.common.exception.SikdorakRuntimeException;
+import org.springframework.http.HttpStatus;
+
+public class ReviewNotFoundException extends SikdorakRuntimeException {
+
+	@Override
+	public HttpStatus getHttpStatus() {
+		return HttpStatus.NOT_FOUND;
+	}
+}
+

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/service/ReviewService.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/service/ReviewService.java
@@ -1,6 +1,6 @@
 package com.jjikmuk.sikdorak.review.service;
 
-import com.jjikmuk.sikdorak.review.controller.request.ReviewInsertRequest;
+import com.jjikmuk.sikdorak.review.controller.request.ReviewCreateRequest;
 import com.jjikmuk.sikdorak.review.domain.Review;
 import com.jjikmuk.sikdorak.review.repository.ReviewRepository;
 import com.jjikmuk.sikdorak.store.domain.Store;
@@ -24,20 +24,20 @@ public class ReviewService {
 	private final ReviewRepository reviewRepository;
 
 	@Transactional
-	public Review insertReview(LoginUser loginUser, ReviewInsertRequest reviewInsertRequest) {
+	public Review createReview(LoginUser loginUser, ReviewCreateRequest reviewCreateRequest) {
 		User user = userRespository.findById(loginUser.getId())
 			.orElseThrow(UserNotFoundException::new);
-		Store store = storeRepository.findById(reviewInsertRequest.getStoreId())
+		Store store = storeRepository.findById(reviewCreateRequest.getStoreId())
 			.orElseThrow(StoreNotFoundException::new);
 
 		Review newReview = new Review(user.getId(),
 			store.getId(),
-			reviewInsertRequest.getReviewContent(),
-			reviewInsertRequest.getReviewScore(),
-			reviewInsertRequest.getReviewVisibility(),
-			reviewInsertRequest.getVisitedDate(),
-			reviewInsertRequest.getTags(),
-			reviewInsertRequest.getImages());
+			reviewCreateRequest.getReviewContent(),
+			reviewCreateRequest.getReviewScore(),
+			reviewCreateRequest.getReviewVisibility(),
+			reviewCreateRequest.getVisitedDate(),
+			reviewCreateRequest.getTags(),
+			reviewCreateRequest.getImages());
 
 		return reviewRepository.save(newReview);
 	}

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/service/ReviewService.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/service/ReviewService.java
@@ -3,16 +3,16 @@ package com.jjikmuk.sikdorak.review.service;
 import com.jjikmuk.sikdorak.review.controller.request.ReviewCreateRequest;
 import com.jjikmuk.sikdorak.review.controller.request.ReviewModifyRequest;
 import com.jjikmuk.sikdorak.review.domain.Review;
-import com.jjikmuk.sikdorak.review.exception.ReviewNotFoundException;
+import com.jjikmuk.sikdorak.review.exception.NotFoundReviewException;
 import com.jjikmuk.sikdorak.review.repository.ReviewRepository;
 import com.jjikmuk.sikdorak.store.domain.Store;
-import com.jjikmuk.sikdorak.store.exception.StoreNotFoundException;
+import com.jjikmuk.sikdorak.store.exception.NotFoundStoreException;
 import com.jjikmuk.sikdorak.store.repository.StoreRepository;
 import com.jjikmuk.sikdorak.user.auth.controller.LoginUser;
 import com.jjikmuk.sikdorak.user.user.domain.User;
 import com.jjikmuk.sikdorak.user.user.domain.UserRespository;
+import com.jjikmuk.sikdorak.user.user.exception.NotFoundUserException;
 import com.jjikmuk.sikdorak.user.user.exception.UnauthorizedUserException;
-import com.jjikmuk.sikdorak.user.user.exception.UserNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,9 +29,9 @@ public class ReviewService {
 	@Transactional
 	public Review createReview(LoginUser loginUser, ReviewCreateRequest reviewCreateRequest) {
 		User user = userRespository.findById(loginUser.getId())
-			.orElseThrow(UserNotFoundException::new);
+			.orElseThrow(NotFoundUserException::new);
 		Store store = storeRepository.findById(reviewCreateRequest.getStoreId())
-			.orElseThrow(StoreNotFoundException::new);
+			.orElseThrow(NotFoundStoreException::new);
 
 		Review newReview = new Review(user.getId(),
 			store.getId(),
@@ -47,9 +47,10 @@ public class ReviewService {
 
 	public Review modifyReview(LoginUser loginUser, Long reviewId,
 		ReviewModifyRequest reviewModifyRequest) {
-		Review review = reviewRepository.findById(reviewId).orElseThrow(ReviewNotFoundException::new);
-		User user = userRespository.findById(loginUser.getId()).orElseThrow(UserNotFoundException::new);
-		Store store = storeRepository.findById(reviewModifyRequest.getStoreId()).orElseThrow(StoreNotFoundException::new);
+		Review review = reviewRepository.findById(reviewId).orElseThrow(NotFoundReviewException::new);
+		User user = userRespository.findById(loginUser.getId()).orElseThrow(NotFoundUserException::new);
+		Store store = storeRepository.findById(reviewModifyRequest.getStoreId()).orElseThrow(
+			NotFoundStoreException::new);
 
 		validateReviewWithUser(review, user);
 

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/exception/NotFoundStoreException.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/exception/NotFoundStoreException.java
@@ -1,13 +1,12 @@
-package com.jjikmuk.sikdorak.review.exception;
+package com.jjikmuk.sikdorak.store.exception;
 
 import com.jjikmuk.sikdorak.common.exception.SikdorakRuntimeException;
 import org.springframework.http.HttpStatus;
 
-public class ReviewNotFoundException extends SikdorakRuntimeException {
+public class NotFoundStoreException extends SikdorakRuntimeException {
 
 	@Override
 	public HttpStatus getHttpStatus() {
 		return HttpStatus.NOT_FOUND;
 	}
 }
-

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/service/StoreService.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/service/StoreService.java
@@ -4,7 +4,7 @@ import com.jjikmuk.sikdorak.store.controller.request.StoreCreateRequest;
 import com.jjikmuk.sikdorak.store.controller.request.StoreModifyRequest;
 import com.jjikmuk.sikdorak.store.controller.response.StoreSearchResponse;
 import com.jjikmuk.sikdorak.store.domain.Store;
-import com.jjikmuk.sikdorak.store.exception.StoreNotFoundException;
+import com.jjikmuk.sikdorak.store.exception.NotFoundStoreException;
 import com.jjikmuk.sikdorak.store.repository.StoreRepository;
 import java.util.Collections;
 import java.util.List;
@@ -22,10 +22,10 @@ public class StoreService {
 	@Transactional(readOnly = true)
 	public Store searchById(Long storeId) {
 		if (Objects.isNull(storeId)) {
-			throw new StoreNotFoundException();
+			throw new NotFoundStoreException();
 		}
 
-		return storeRepository.findById(storeId).orElseThrow(StoreNotFoundException::new);
+		return storeRepository.findById(storeId).orElseThrow(NotFoundStoreException::new);
 	}
 
 	@Transactional(readOnly = true)
@@ -58,7 +58,7 @@ public class StoreService {
 	@Transactional
 	public Long modifyStore(Long storeId, StoreModifyRequest modifyRequest) {
 		Store store = storeRepository.findById(storeId)
-			.orElseThrow(StoreNotFoundException::new);
+			.orElseThrow(NotFoundStoreException::new);
 
 		store.editAll(
 			modifyRequest.getStoreName(),

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/auth/service/OAuthService.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/auth/service/OAuthService.java
@@ -7,7 +7,7 @@ import com.jjikmuk.sikdorak.user.auth.controller.response.OAuthTokenResponse;
 import com.jjikmuk.sikdorak.user.auth.domain.JwtProvider;
 import com.jjikmuk.sikdorak.user.auth.domain.JwtTokenPair;
 import com.jjikmuk.sikdorak.user.user.domain.User;
-import com.jjikmuk.sikdorak.user.user.exception.UserNotFoundException;
+import com.jjikmuk.sikdorak.user.user.exception.NotFoundUserException;
 import com.jjikmuk.sikdorak.user.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -50,7 +50,7 @@ public class OAuthService{
         jwtProvider.validateToken(refreshToken);
         String userId = jwtProvider.decodeToken(refreshToken);
         if (!userService.isExistingById(Long.parseLong(userId))) {
-            throw new UserNotFoundException();
+            throw new NotFoundUserException();
         }
         return new AccessTokenResponse(jwtProvider.createAccessToken(userId));
     }

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/exception/NotFoundUserException.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/exception/NotFoundUserException.java
@@ -3,7 +3,7 @@ package com.jjikmuk.sikdorak.user.user.exception;
 import com.jjikmuk.sikdorak.common.exception.SikdorakRuntimeException;
 import org.springframework.http.HttpStatus;
 
-public class UserNotFoundException extends SikdorakRuntimeException {
+public class NotFoundUserException extends SikdorakRuntimeException {
 
 
     @Override

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/exception/UnauthorizedUserException.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/exception/UnauthorizedUserException.java
@@ -1,0 +1,12 @@
+package com.jjikmuk.sikdorak.user.user.exception;
+
+import com.jjikmuk.sikdorak.common.exception.SikdorakRuntimeException;
+import org.springframework.http.HttpStatus;
+
+public class UnauthorizedUserException extends SikdorakRuntimeException {
+
+	@Override
+	public HttpStatus getHttpStatus() {
+		return HttpStatus.UNAUTHORIZED;
+	}
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/service/UserService.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/service/UserService.java
@@ -3,7 +3,7 @@ package com.jjikmuk.sikdorak.user.user.service;
 import com.jjikmuk.sikdorak.user.user.domain.User;
 import com.jjikmuk.sikdorak.user.user.domain.UserRespository;
 import com.jjikmuk.sikdorak.user.user.exception.DuplicateUserException;
-import com.jjikmuk.sikdorak.user.user.exception.UserNotFoundException;
+import com.jjikmuk.sikdorak.user.user.exception.NotFoundUserException;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -25,16 +25,16 @@ public class UserService {
 
     public User searchById(Long userId) {
         if (Objects.isNull(userId)) {
-            throw new UserNotFoundException();
+            throw new NotFoundUserException();
         }
 
         return userRespository.findById(userId)
-            .orElseThrow(UserNotFoundException::new);
+            .orElseThrow(NotFoundUserException::new);
     }
 
     public User searchByUniqueId(long uniqueId) {
         return userRespository.findByUniqueId(uniqueId)
-            .orElseThrow(UserNotFoundException::new);
+            .orElseThrow(NotFoundUserException::new);
     }
 
     public boolean isExistingById(long userId) {

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/review/ReviewInsertAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/review/ReviewInsertAcceptanceTest.java
@@ -1,12 +1,12 @@
 package com.jjikmuk.sikdorak.acceptance.review;
 
-import static com.jjikmuk.sikdorak.acceptance.review.ReviewSnippet.REVIEW_INSERT_REQUEST_SNIPPET;
-import static com.jjikmuk.sikdorak.acceptance.review.ReviewSnippet.REVIEW_INSERT_RESPONSE_SNIPPET;
+import static com.jjikmuk.sikdorak.acceptance.review.ReviewSnippet.REVIEW_CREATE_REQUEST_SNIPPET;
+import static com.jjikmuk.sikdorak.acceptance.review.ReviewSnippet.REVIEW_CREATE_RESPONSE_SNIPPET;
 import static io.restassured.RestAssured.given;
 import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
 
 import com.jjikmuk.sikdorak.acceptance.InitAcceptanceTest;
-import com.jjikmuk.sikdorak.review.controller.request.ReviewInsertRequest;
+import com.jjikmuk.sikdorak.review.controller.request.ReviewCreateRequest;
 import java.time.LocalDate;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -25,7 +25,7 @@ class ReviewInsertAcceptanceTest extends InitAcceptanceTest {
 	@Test
 	@DisplayName("리뷰 생성 요청이 정상적인 경우라면 리뷰 생성 후 정상 상태 코드를 반환한다")
 	void create_review_success() {
-		ReviewInsertRequest reviewInsertRequest = new ReviewInsertRequest(
+		ReviewCreateRequest reviewCreateRequest = new ReviewCreateRequest(
 			"Test review contents",
 			testData.store.getId(),
 			3.f,
@@ -37,12 +37,12 @@ class ReviewInsertAcceptanceTest extends InitAcceptanceTest {
 		given(this.spec)
 			.filter(
 				document(DEFAULT_RESTDOC_PATH,
-					REVIEW_INSERT_REQUEST_SNIPPET,
-					REVIEW_INSERT_RESPONSE_SNIPPET))
+					REVIEW_CREATE_REQUEST_SNIPPET,
+					REVIEW_CREATE_RESPONSE_SNIPPET))
 			.accept(MediaType.APPLICATION_JSON_VALUE)
 			.header("Content-type", "application/json")
 			.header("Authorization", testData.userValidAuthorizationHeader)
-			.body(reviewInsertRequest)
+			.body(reviewCreateRequest)
 
 		.when()
 			.post("/api/reviews")

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/review/ReviewInsertAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/review/ReviewInsertAcceptanceTest.java
@@ -41,7 +41,7 @@ class ReviewInsertAcceptanceTest extends InitAcceptanceTest {
 					REVIEW_CREATE_RESPONSE_SNIPPET))
 			.accept(MediaType.APPLICATION_JSON_VALUE)
 			.header("Content-type", "application/json")
-			.header("Authorization", testData.userValidAuthorizationHeader)
+			.header("Authorization", testData.user1ValidAuthorizationHeader)
 			.body(reviewCreateRequest)
 
 		.when()

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/review/ReviewModifyAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/review/ReviewModifyAcceptanceTest.java
@@ -1,0 +1,63 @@
+package com.jjikmuk.sikdorak.acceptance.review;
+
+
+import static com.jjikmuk.sikdorak.acceptance.review.ReviewSnippet.REVIEW_MODIFY_REQUEST_PARAM_SNIPPET;
+import static com.jjikmuk.sikdorak.acceptance.review.ReviewSnippet.REVIEW_MODIFY_REQUEST_SNIPPET;
+import static com.jjikmuk.sikdorak.acceptance.review.ReviewSnippet.REVIEW_MODIFY_RESPONSE_SNIPPET;
+import static io.restassured.RestAssured.given;
+import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
+
+import com.jjikmuk.sikdorak.acceptance.InitAcceptanceTest;
+import com.jjikmuk.sikdorak.common.ResponseCodeAndMessages;
+import com.jjikmuk.sikdorak.review.controller.request.ReviewModifyRequest;
+import java.time.LocalDate;
+import java.util.List;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+/**
+ * - [ ] 유저, 본인 리뷰 수정 정상 요청 유저
+ * - [ ] 본인 리뷰 수정 비정상 요청(없는 스토어 아이디) -> throw 유저
+ * - [ ] 타인 리뷰 수정 요청 (throw) throw
+ */
+@DisplayName("ReviewUpdate 인수 테스트")
+class ReviewModifyAcceptanceTest extends InitAcceptanceTest {
+
+	@Test
+	@DisplayName("유저가 본인 리뷰의 수정 요청이 정상적인 경우라면 리뷰 수정 후 정상 상태 코드를 반환한다")
+	void modify_review_success() {
+		ReviewModifyRequest reviewModifyRequest = new ReviewModifyRequest(
+			"Modify Test review contents",
+			testData.store.getId(),
+			3.f,
+			"public",
+			LocalDate.of(2022, 1, 1),
+			List.of("tag1", "tag2"),
+			List.of("https://s3.ap-northeast-2.amazonaws.com/sikdorak/test.jpg"));
+
+		given(this.spec)
+			.filter(
+				document(DEFAULT_RESTDOC_PATH,
+					REVIEW_MODIFY_REQUEST_PARAM_SNIPPET,
+					REVIEW_MODIFY_REQUEST_SNIPPET,
+					REVIEW_MODIFY_RESPONSE_SNIPPET))
+			.accept(MediaType.APPLICATION_JSON_VALUE)
+			.header("Content-type", "application/json")
+			.header("Authorization", testData.userValidAuthorizationHeader)
+			.body(reviewModifyRequest)
+
+		.when()
+			.put("/api/reviews/{reviewId}", testData.review.getId())
+
+		.then()
+			.statusCode(HttpStatus.OK.value())
+			.body("code", Matchers.equalTo(ResponseCodeAndMessages.REVIEW_MODIFY_SUCCESS.getCode()))
+			.body("message",
+				Matchers.equalTo(ResponseCodeAndMessages.REVIEW_MODIFY_SUCCESS.getMessage()));
+	}
+
+
+}

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/review/ReviewSnippet.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/review/ReviewSnippet.java
@@ -3,6 +3,8 @@ package com.jjikmuk.sikdorak.acceptance.review;
 import static com.jjikmuk.sikdorak.acceptance.DocumentFormatGenerator.commonRequestFieldsWithValidConstraints;
 import static com.jjikmuk.sikdorak.acceptance.DocumentFormatGenerator.commonResponseNonFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 
 import com.jjikmuk.sikdorak.review.controller.request.ReviewCreateRequest;
 import org.springframework.restdocs.payload.JsonFieldType;
@@ -41,4 +43,7 @@ interface ReviewSnippet {
 
 	Snippet REVIEW_MODIFY_RESPONSE_SNIPPET = commonResponseNonFields();
 
+	Snippet REVIEW_MODIFY_REQUEST_PARAM_SNIPPET = pathParameters(
+		parameterWithName("reviewId").description("리뷰 아이디")
+	);
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/review/ReviewSnippet.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/review/ReviewSnippet.java
@@ -3,17 +3,15 @@ package com.jjikmuk.sikdorak.acceptance.review;
 import static com.jjikmuk.sikdorak.acceptance.DocumentFormatGenerator.commonRequestFieldsWithValidConstraints;
 import static com.jjikmuk.sikdorak.acceptance.DocumentFormatGenerator.commonResponseNonFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 
-import com.jjikmuk.sikdorak.review.controller.request.ReviewInsertRequest;
+import com.jjikmuk.sikdorak.review.controller.request.ReviewCreateRequest;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.restdocs.snippet.Snippet;
 
 interface ReviewSnippet {
 
-	Snippet REVIEW_INSERT_REQUEST_SNIPPET = commonRequestFieldsWithValidConstraints(
-		ReviewInsertRequest.class,
+	Snippet REVIEW_CREATE_REQUEST_SNIPPET = commonRequestFieldsWithValidConstraints(
+		ReviewCreateRequest.class,
 		fieldWithPath("reviewContent")
 			.type(JsonFieldType.STRING)
 			.description("리뷰 내용"),
@@ -37,5 +35,10 @@ interface ReviewSnippet {
 			.description("리뷰를 위한 사진 URL")
 	);
 
-	Snippet REVIEW_INSERT_RESPONSE_SNIPPET = commonResponseNonFields();
+	Snippet REVIEW_CREATE_RESPONSE_SNIPPET = commonResponseNonFields();
+
+	Snippet REVIEW_MODIFY_REQUEST_SNIPPET = REVIEW_CREATE_REQUEST_SNIPPET;
+
+	Snippet REVIEW_MODIFY_RESPONSE_SNIPPET = commonResponseNonFields();
+
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/store/StoreCreateAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/store/StoreCreateAcceptanceTest.java
@@ -38,7 +38,7 @@ class StoreCreateAcceptanceTest extends InitAcceptanceTest {
 				STORE_CREATE_REQUEST_SNIPPET,
 				STORE_CREATE_RESPONSE_SNIPPET))
 			.accept(MediaType.APPLICATION_JSON_VALUE)
-			.header("Authorization", testData.userValidAuthorizationHeader)
+			.header("Authorization", testData.user1ValidAuthorizationHeader)
 			.contentType(ContentType.JSON)
 			.body(storeCreateRequest)
 

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/store/StoreModifyAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/store/StoreModifyAcceptanceTest.java
@@ -9,7 +9,6 @@ import static org.springframework.restdocs.restassured3.RestAssuredRestDocumenta
 import com.jjikmuk.sikdorak.acceptance.InitAcceptanceTest;
 import com.jjikmuk.sikdorak.common.ResponseCodeAndMessages;
 import com.jjikmuk.sikdorak.store.controller.request.StoreModifyRequest;
-import com.jjikmuk.sikdorak.store.domain.Store;
 import io.restassured.http.ContentType;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.DisplayName;
@@ -42,7 +41,7 @@ class StoreModifyAcceptanceTest extends InitAcceptanceTest {
 				STORE_MODIFY_REQUEST_SNIPPET,
 				STORE_MODIFY_RESPONSE_SNIPPET))
 			.accept(MediaType.APPLICATION_JSON_VALUE)
-			.header("Authorization", testData.userValidAuthorizationHeader)
+			.header("Authorization", testData.user1ValidAuthorizationHeader)
 			.contentType(ContentType.JSON)
 			.body(storeModifyRequest)
 

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/store/StoreSearchAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/store/StoreSearchAcceptanceTest.java
@@ -33,7 +33,7 @@ public class StoreSearchAcceptanceTest extends InitAcceptanceTest {
             .filter(document(DEFAULT_RESTDOC_PATH, STORE_SEARCH_REQUEST, STORE_SEARCH_RESPONSE))
             .accept(MediaType.APPLICATION_JSON_VALUE)
             .header("Content-type", "application/json")
-            .header("Authorization", testData.userValidAuthorizationHeader)
+            .header("Authorization", testData.user1ValidAuthorizationHeader)
             .param("storeName", storeNameSearchKeywork)
 
         .when()
@@ -56,7 +56,7 @@ public class StoreSearchAcceptanceTest extends InitAcceptanceTest {
         given()
             .accept(MediaType.APPLICATION_JSON_VALUE)
             .header("Content-type", "application/json")
-            .header("Authorization", testData.userValidAuthorizationHeader)
+            .header("Authorization", testData.user1ValidAuthorizationHeader)
             .param("storeName", notExistStoreName)
 
         .when()

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/auth/OAuthUpdateTokenAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/auth/OAuthUpdateTokenAcceptanceTest.java
@@ -28,7 +28,7 @@ class OAuthUpdateTokenAcceptanceTest extends InitAcceptanceTest {
     void update_access_token_success() {
 
         String refreshToken = jwtProvider.createRefreshToken(
-            testData.user.getId().toString());
+            testData.user1.getId().toString());
 
         given(this.spec)
             .filter(document(DEFAULT_RESTDOC_PATH,

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/auth/OAuthUpdateTokenAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/auth/OAuthUpdateTokenAcceptanceTest.java
@@ -85,8 +85,8 @@ class OAuthUpdateTokenAcceptanceTest extends InitAcceptanceTest {
 
         .then()
             .statusCode(HttpStatus.NOT_FOUND.value())
-            .body("code", equalTo(ExceptionCodeAndMessages.USER_NOT_FOUND.getCode()))
-            .body("message", equalTo(ExceptionCodeAndMessages.USER_NOT_FOUND.getMessage()));
+            .body("code", equalTo(ExceptionCodeAndMessages.NOT_FOUND_USER.getCode()))
+            .body("message", equalTo(ExceptionCodeAndMessages.NOT_FOUND_USER.getMessage()));
     }
 
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/common/DatabaseConfigurator.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/common/DatabaseConfigurator.java
@@ -1,5 +1,7 @@
 package com.jjikmuk.sikdorak.common;
 
+import com.jjikmuk.sikdorak.review.domain.Review;
+import com.jjikmuk.sikdorak.review.repository.ReviewRepository;
 import com.jjikmuk.sikdorak.store.domain.Store;
 import com.jjikmuk.sikdorak.store.repository.StoreRepository;
 import com.jjikmuk.sikdorak.user.auth.domain.JwtProvider;
@@ -9,6 +11,7 @@ import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.EntityManager;
@@ -32,24 +35,38 @@ public class DatabaseConfigurator implements InitializingBean {
 	private UserRespository userRespository;
 
 	@Autowired
+	private ReviewRepository reviewRepository;
+
+	@Autowired
 	private JwtProvider jwtProvider;
 
 	public Store store;
 	public User user;
 	public String userValidAuthorizationHeader;
 	public String userInvalidAuthorizationHeader;
+	public Review review;
 
 	public void initDataSource() {
 		this.store = storeRepository.save(new Store("맛있는가게",
-				"02-0000-0000",
-				"서울시 송파구 좋은길 1",
-				"1층 101호",
-				37.5093890,
-				127.105143));
-		this.user = userRespository.save(new User(12345678L,"test-user", "https://profile.com","sikdorak@gmail.com"));
-		this.userValidAuthorizationHeader = "Bearer " + jwtProvider.createAccessToken(String.valueOf(this.user.getId()));
-		this.userInvalidAuthorizationHeader ="Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6IjIzNjgyMjM2MzgiLCJleHAiOjE2MzA2MzkzNTF9.SnT_Nxgspg3cUomCieDyBRH9TowtWh21YIfAKntuguA";
+			"02-0000-0000",
+			"서울시 송파구 좋은길 1",
+			"1층 101호",
+			37.5093890,
+			127.105143));
+		this.user = userRespository.save(
+			new User(12345678L, "test-user", "https://profile.com", "sikdorak@gmail.com"));
+		this.userValidAuthorizationHeader =
+			"Bearer " + jwtProvider.createAccessToken(String.valueOf(this.user.getId()));
+		this.userInvalidAuthorizationHeader = "Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6IjIzNjgyMjM2MzgiLCJleHAiOjE2MzA2MzkzNTF9.SnT_Nxgspg3cUomCieDyBRH9TowtWh21YIfAKntuguA";
 
+		this.review = reviewRepository.save(new Review(this.user.getId(),
+			this.store.getId(),
+			"Test review contents",
+			3.f,
+			"public",
+			LocalDate.of(2022, 1, 1),
+			List.of("tag1", "tag2"),
+			List.of("https://s3.ap-northeast-2.amazonaws.com/sikdorak/test.jpg")));
 	}
 
 	public void clear() {

--- a/be/src/test/java/com/jjikmuk/sikdorak/common/DatabaseConfigurator.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/common/DatabaseConfigurator.java
@@ -41,8 +41,10 @@ public class DatabaseConfigurator implements InitializingBean {
 	private JwtProvider jwtProvider;
 
 	public Store store;
-	public User user;
-	public String userValidAuthorizationHeader;
+	public User user1;
+	public User user2;
+	public String user1ValidAuthorizationHeader;
+	public String user2ValidAuthorizationHeader;
 	public String userInvalidAuthorizationHeader;
 	public Review review;
 
@@ -53,13 +55,17 @@ public class DatabaseConfigurator implements InitializingBean {
 			"1층 101호",
 			37.5093890,
 			127.105143));
-		this.user = userRespository.save(
-			new User(12345678L, "test-user", "https://profile.com", "sikdorak@gmail.com"));
-		this.userValidAuthorizationHeader =
-			"Bearer " + jwtProvider.createAccessToken(String.valueOf(this.user.getId()));
+		this.user1 = userRespository.save(
+			new User(12345678L, "test-user1", "https://profile1.com", "sikdorak1@gmail.com"));
+		this.user2 = userRespository.save(
+			new User(87654321L, "test-user2", "https://profile2.com", "sikdorak2@gmail.com"));
+		this.user1ValidAuthorizationHeader =
+			"Bearer " + jwtProvider.createAccessToken(String.valueOf(this.user1.getId()));
+		this.user2ValidAuthorizationHeader =
+			"Bearer " + jwtProvider.createAccessToken(String.valueOf(this.user2.getId()));
 		this.userInvalidAuthorizationHeader = "Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6IjIzNjgyMjM2MzgiLCJleHAiOjE2MzA2MzkzNTF9.SnT_Nxgspg3cUomCieDyBRH9TowtWh21YIfAKntuguA";
 
-		this.review = reviewRepository.save(new Review(this.user.getId(),
+		this.review = reviewRepository.save(new Review(this.user1.getId(),
 			this.store.getId(),
 			"Test review contents",
 			3.f,

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/review/ReviewInsertIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/review/ReviewInsertIntegrationTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.jjikmuk.sikdorak.integration.InitIntegrationTest;
-import com.jjikmuk.sikdorak.review.controller.request.ReviewInsertRequest;
+import com.jjikmuk.sikdorak.review.controller.request.ReviewCreateRequest;
 import com.jjikmuk.sikdorak.review.domain.Review;
 import com.jjikmuk.sikdorak.review.service.ReviewService;
 import com.jjikmuk.sikdorak.store.exception.StoreNotFoundException;
@@ -32,7 +32,7 @@ public class ReviewInsertIntegrationTest extends InitIntegrationTest {
 	@DisplayName("만약 회원이 정상적인 리뷰 생성 요청이 주어진다면 리뷰를 등록할 수 있다.")
 	void create_review_valid_user_store() {
 		LoginUser loginUser = new LoginUser(testData.user.getId(), Authority.USER);
-		ReviewInsertRequest reviewInsertRequest = new ReviewInsertRequest(
+		ReviewCreateRequest reviewCreateRequest = new ReviewCreateRequest(
 			"Test review contents",
 			testData.store.getId(),
 			3.f,
@@ -41,7 +41,7 @@ public class ReviewInsertIntegrationTest extends InitIntegrationTest {
 			List.of("tag1", "tag2"),
 			List.of("https://s3.ap-northeast-2.amazonaws.com/sikdorak/test.jpg"));
 
-		Review saveReview = reviewService.insertReview(loginUser, reviewInsertRequest);
+		Review saveReview = reviewService.createReview(loginUser, reviewCreateRequest);
 
 		assertThat(saveReview.getId()).isNotNull();
 		assertThat(saveReview.getUserId()).isEqualTo(testData.user.getId());
@@ -52,7 +52,7 @@ public class ReviewInsertIntegrationTest extends InitIntegrationTest {
 	void create_review_valid_user_invalid_store() {
 		LoginUser loginUser = new LoginUser(testData.user.getId(), Authority.USER);
 		Long invalidStoreId = Long.MAX_VALUE;
-		ReviewInsertRequest reviewInsertRequest = new ReviewInsertRequest(
+		ReviewCreateRequest reviewCreateRequest = new ReviewCreateRequest(
 			"Test review contents",
 			invalidStoreId,
 			3.f,
@@ -61,7 +61,7 @@ public class ReviewInsertIntegrationTest extends InitIntegrationTest {
 			List.of("tag1", "tag2"),
 			List.of("https://s3.ap-northeast-2.amazonaws.com/sikdorak/test.jpg"));
 
-		assertThatThrownBy(() -> reviewService.insertReview(loginUser, reviewInsertRequest))
+		assertThatThrownBy(() -> reviewService.createReview(loginUser, reviewCreateRequest))
 			.isInstanceOf(StoreNotFoundException.class);
 	}
 
@@ -69,7 +69,7 @@ public class ReviewInsertIntegrationTest extends InitIntegrationTest {
 	@DisplayName("만약 비회원이 정상적인 리뷰 생성 요청을 한다면 예외를 발생시킨다.")
 	void create_review_invalid_user_valid_store() {
 		LoginUser loginUser = new LoginUser(Long.MAX_VALUE, Authority.USER);
-		ReviewInsertRequest reviewInsertRequest = new ReviewInsertRequest(
+		ReviewCreateRequest reviewCreateRequest = new ReviewCreateRequest(
 			"Test review contents",
 			testData.store.getId(),
 			3.f,
@@ -78,7 +78,7 @@ public class ReviewInsertIntegrationTest extends InitIntegrationTest {
 			List.of("tag1", "tag2"),
 			List.of("https://s3.ap-northeast-2.amazonaws.com/sikdorak/test.jpg"));
 
-		assertThatThrownBy(() -> reviewService.insertReview(loginUser, reviewInsertRequest))
+		assertThatThrownBy(() -> reviewService.createReview(loginUser, reviewCreateRequest))
 			.isInstanceOf(UserNotFoundException.class);
 	}
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/review/ReviewInsertIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/review/ReviewInsertIntegrationTest.java
@@ -7,10 +7,10 @@ import com.jjikmuk.sikdorak.integration.InitIntegrationTest;
 import com.jjikmuk.sikdorak.review.controller.request.ReviewCreateRequest;
 import com.jjikmuk.sikdorak.review.domain.Review;
 import com.jjikmuk.sikdorak.review.service.ReviewService;
-import com.jjikmuk.sikdorak.store.exception.StoreNotFoundException;
+import com.jjikmuk.sikdorak.store.exception.NotFoundStoreException;
 import com.jjikmuk.sikdorak.user.auth.controller.Authority;
 import com.jjikmuk.sikdorak.user.auth.controller.LoginUser;
-import com.jjikmuk.sikdorak.user.user.exception.UserNotFoundException;
+import com.jjikmuk.sikdorak.user.user.exception.NotFoundUserException;
 import java.time.LocalDate;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -62,7 +62,7 @@ public class ReviewInsertIntegrationTest extends InitIntegrationTest {
 			List.of("https://s3.ap-northeast-2.amazonaws.com/sikdorak/test.jpg"));
 
 		assertThatThrownBy(() -> reviewService.createReview(loginUser, reviewCreateRequest))
-			.isInstanceOf(StoreNotFoundException.class);
+			.isInstanceOf(NotFoundStoreException.class);
 	}
 
 	@Test
@@ -79,7 +79,7 @@ public class ReviewInsertIntegrationTest extends InitIntegrationTest {
 			List.of("https://s3.ap-northeast-2.amazonaws.com/sikdorak/test.jpg"));
 
 		assertThatThrownBy(() -> reviewService.createReview(loginUser, reviewCreateRequest))
-			.isInstanceOf(UserNotFoundException.class);
+			.isInstanceOf(NotFoundUserException.class);
 	}
 }
 

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/review/ReviewInsertIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/review/ReviewInsertIntegrationTest.java
@@ -31,7 +31,7 @@ public class ReviewInsertIntegrationTest extends InitIntegrationTest {
 	@Test
 	@DisplayName("만약 회원이 정상적인 리뷰 생성 요청이 주어진다면 리뷰를 등록할 수 있다.")
 	void create_review_valid_user_store() {
-		LoginUser loginUser = new LoginUser(testData.user.getId(), Authority.USER);
+		LoginUser loginUser = new LoginUser(testData.user1.getId(), Authority.USER);
 		ReviewCreateRequest reviewCreateRequest = new ReviewCreateRequest(
 			"Test review contents",
 			testData.store.getId(),
@@ -44,13 +44,13 @@ public class ReviewInsertIntegrationTest extends InitIntegrationTest {
 		Review saveReview = reviewService.createReview(loginUser, reviewCreateRequest);
 
 		assertThat(saveReview.getId()).isNotNull();
-		assertThat(saveReview.getUserId()).isEqualTo(testData.user.getId());
+		assertThat(saveReview.getUserId()).isEqualTo(testData.user1.getId());
 	}
 
 	@Test
 	@DisplayName("만약 회원이 존재하지 않은 상점 id의 리뷰 생성 요청이 주어진다면 예외를 발생시킨다.")
 	void create_review_valid_user_invalid_store() {
-		LoginUser loginUser = new LoginUser(testData.user.getId(), Authority.USER);
+		LoginUser loginUser = new LoginUser(testData.user1.getId(), Authority.USER);
 		Long invalidStoreId = Long.MAX_VALUE;
 		ReviewCreateRequest reviewCreateRequest = new ReviewCreateRequest(
 			"Test review contents",

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/review/ReviewModifyIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/review/ReviewModifyIntegrationTest.java
@@ -48,7 +48,7 @@ class ReviewModifyIntegrationTest extends InitIntegrationTest {
 	}
 
 	@Test
-	@DisplayName("존재하지 않는 리뷰에 대해 수정 요청이 주어진다면 리뷰를 수정할 수 있다.")
+	@DisplayName("존재하지 않는 리뷰에 대해 수정 요청이 주어진다면 예외를 발생시킨다.")
 	void modify_review_invalid_review() {
 		long invalidReviewId = Long.MAX_VALUE;
 		LoginUser loginUser = new LoginUser(testData.user1.getId(), Authority.USER);
@@ -67,7 +67,7 @@ class ReviewModifyIntegrationTest extends InitIntegrationTest {
 	}
 
 	@Test
-	@DisplayName("존재하지 않는 스토어에 대한 수정 요청이 주어진다면 리뷰를 수정할 수 있다.")
+	@DisplayName("존재하지 않는 스토어에 대한 수정 요청이 주어진다면 예외를 발생시킨다.")
 	void modify_review_invalid_store() {
 		long invalidStoreId = Long.MAX_VALUE;
 		LoginUser loginUser = new LoginUser(testData.user1.getId(), Authority.USER);
@@ -86,7 +86,7 @@ class ReviewModifyIntegrationTest extends InitIntegrationTest {
 	}
 
 	@Test
-	@DisplayName("존재하지 않는 유저에 대한 수정 요청이 주어진다면 리뷰를 수정할 수 있다.")
+	@DisplayName("존재하지 않는 유저에 대한 수정 요청이 주어진다면 예외를 발생시킨다")
 	void modify_review_invalid_user() {
 		long invalidUserId = Long.MAX_VALUE;
 		LoginUser loginUser = new LoginUser(invalidUserId, Authority.USER);

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/review/ReviewModifyIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/review/ReviewModifyIntegrationTest.java
@@ -1,0 +1,107 @@
+package com.jjikmuk.sikdorak.integration.review;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.jjikmuk.sikdorak.integration.InitIntegrationTest;
+import com.jjikmuk.sikdorak.review.controller.request.ReviewModifyRequest;
+import com.jjikmuk.sikdorak.review.domain.Review;
+import com.jjikmuk.sikdorak.review.exception.NotFoundReviewException;
+import com.jjikmuk.sikdorak.review.service.ReviewService;
+import com.jjikmuk.sikdorak.store.exception.NotFoundStoreException;
+import com.jjikmuk.sikdorak.user.auth.controller.Authority;
+import com.jjikmuk.sikdorak.user.auth.controller.LoginUser;
+import com.jjikmuk.sikdorak.user.user.exception.NotFoundUserException;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayName("ReviewModify 통합테스트")
+class ReviewModifyIntegrationTest extends InitIntegrationTest {
+
+
+	@Autowired
+	ReviewService reviewService;
+
+	@Test
+	@DisplayName("만약 유저가 본인 리뷰에 대한 수정 요청이 주어진다면 리뷰를 수정할 수 있다.")
+	void modify_review_valid() {
+		LoginUser loginUser = new LoginUser(testData.user1.getId(), Authority.USER);
+		ReviewModifyRequest reviewModifyRequest = new ReviewModifyRequest(
+			"Modify Test review contents",
+			testData.store.getId(),
+			3.f,
+			"public",
+			LocalDate.of(2022, 1, 1),
+			List.of("tag1", "tag2"),
+			List.of("https://s3.ap-northeast-2.amazonaws.com/sikdorak/test.jpg"));
+
+		Review modifyReview = reviewService.modifyReview(loginUser, testData.review.getId(),
+			reviewModifyRequest);
+
+		assertThat(modifyReview.getReviewContent()).isEqualTo(
+			reviewModifyRequest.getReviewContent());
+		assertThat(modifyReview.getUserId()).isEqualTo(testData.user1.getId());
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 리뷰에 대해 수정 요청이 주어진다면 리뷰를 수정할 수 있다.")
+	void modify_review_invalid_review() {
+		long invalidReviewId = Long.MAX_VALUE;
+		LoginUser loginUser = new LoginUser(testData.user1.getId(), Authority.USER);
+		ReviewModifyRequest reviewModifyRequest = new ReviewModifyRequest(
+			"Modify Test review contents",
+			testData.store.getId(),
+			3.f,
+			"public",
+			LocalDate.of(2022, 1, 1),
+			List.of("tag1", "tag2"),
+			List.of("https://s3.ap-northeast-2.amazonaws.com/sikdorak/test.jpg"));
+
+		assertThatThrownBy(() ->
+			reviewService.modifyReview(loginUser, invalidReviewId, reviewModifyRequest))
+			.isInstanceOf(NotFoundReviewException.class);
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 스토어에 대한 수정 요청이 주어진다면 리뷰를 수정할 수 있다.")
+	void modify_review_invalid_store() {
+		long invalidStoreId = Long.MAX_VALUE;
+		LoginUser loginUser = new LoginUser(testData.user1.getId(), Authority.USER);
+		ReviewModifyRequest reviewModifyRequest = new ReviewModifyRequest(
+			"Modify Test review contents",
+			invalidStoreId,
+			3.f,
+			"public",
+			LocalDate.of(2022, 1, 1),
+			List.of("tag1", "tag2"),
+			List.of("https://s3.ap-northeast-2.amazonaws.com/sikdorak/test.jpg"));
+
+		assertThatThrownBy(() ->
+			reviewService.modifyReview(loginUser, testData.review.getId(), reviewModifyRequest))
+			.isInstanceOf(NotFoundStoreException.class);
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 유저에 대한 수정 요청이 주어진다면 리뷰를 수정할 수 있다.")
+	void modify_review_invalid_user() {
+		long invalidUserId = Long.MAX_VALUE;
+		LoginUser loginUser = new LoginUser(invalidUserId, Authority.USER);
+		ReviewModifyRequest reviewModifyRequest = new ReviewModifyRequest(
+			"Modify Test review contents",
+			testData.store.getId(),
+			3.f,
+			"public",
+			LocalDate.of(2022, 1, 1),
+			List.of("tag1", "tag2"),
+			List.of("https://s3.ap-northeast-2.amazonaws.com/sikdorak/test.jpg"));
+
+		assertThatThrownBy(() ->
+			reviewService.modifyReview(loginUser, testData.review.getId(), reviewModifyRequest))
+			.isInstanceOf(NotFoundUserException.class);
+	}
+
+}

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/user/auth/OAuthArgumentResolverIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/user/auth/OAuthArgumentResolverIntegrationTest.java
@@ -29,12 +29,12 @@ class OAuthArgumentResolverIntegrationTest extends InitIntegrationTest {
 	@Test
 	@DisplayName("올바른 유저 Id가 넘어오는 경우 로그인 유저 객체를 반환한다.")
 	void oAuth_argument_resolver_success() {
-		mockHttpServletRequest.addHeader("Authorization", testData.userValidAuthorizationHeader);
+		mockHttpServletRequest.addHeader("Authorization", testData.user1ValidAuthorizationHeader);
 
 		LoginUser loginUser = (LoginUser) oAuthUserArgumentResolver.resolveArgument(null, null,
 			new ServletWebRequest(mockHttpServletRequest), null);
 
-		assertThat(loginUser.getId()).isEqualTo(testData.user.getId());
+		assertThat(loginUser.getId()).isEqualTo(testData.user1.getId());
 		assertThat(loginUser.getAuthority()).isEqualTo(Authority.USER);
 	}
 


### PR DESCRIPTION
### ❗️ 이슈 번호

[SER-122]

<br><br>

### 📝 구현 내용

- 리뷰 API 구현
- 인수, 통합 테스트 구현
- 테스트 유저 1,2 추가
- API 문서 추가 (수정)
- XXXNotFound -> NotFoundXXX 으로 통일 (리뷰, 유저, 스토어)
- [SDR-116] 에서 CommonResponseEntity 에서 ResponseBody(data) 를 넣지 않는 경우를 위해, 생성자를 추가, 적용 빠진 부분 수정

<br><br>

### 🙇🏻‍♂️ 리뷰어에게 부탁합니다!

- 제이, 포키와 함께 상의했던 [SDR-116] 기본으로 구현되었습니다.
 
<br><br>


[SDR-116]: https://jjikmuk.atlassian.net/browse/SDR-116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SDR-116]: https://jjikmuk.atlassian.net/browse/SDR-116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ