### PR TITLE
SDR-117 가게 삭제 API 구현

### DIFF
--- a/be/src/docs/asciidoc/store/store.adoc
+++ b/be/src/docs/asciidoc/store/store.adoc
@@ -39,3 +39,29 @@ operation::store_modify_acceptance_test/modify_store_success[snippets='http-requ
 ==== `Response`
 
 operation::store_modify_acceptance_test/modify_store_success[snippets='http-response,response-fields']
+
+=== 가게 삭제
+
+API : `DELETE /api/stores`
+
+=== `200 SUCCESS`
+
+==== `Request`
+
+operation::store_remove_acceptance_test/remove_store_success[snippets='http-request,path-parameters']
+
+==== `Response`
+
+operation::store_remove_acceptance_test/remove_store_success[snippets='http-response,response-fields']
+
+=== `400 BAD REQUEST`
+
+존재하지 않는 가게를 삭제할 경우, 실패합니다.
+
+==== `Request`
+
+operation::store_remove_acceptance_test/remove_store_failed[snippets='http-request,path-parameters']
+
+==== `Response`
+
+operation::store_remove_acceptance_test/remove_store_failed[snippets='http-response,response-fields']

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/ResponseCodeAndMessages.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/ResponseCodeAndMessages.java
@@ -13,6 +13,7 @@ public enum ResponseCodeAndMessages implements CodeAndMessages {
     STORE_SEARCH_SUCCESS("T-S001", "가게 목록 조회에 성공했습니다."),
     STORE_CREATE_SUCCESS("T-S002", "가게 등록에 성공했습니다."),
     STORE_MODIFY_SUCCESS("T-S003", "가게 수정에 성공했습니다."),
+    STORE_REMOVE_SUCCESS("T-S004", "가게 삭제에 성공했습니다."),
 
     //User
     USER_MODIFY_SUCCESS("T-U001", "유저 프로필 수정에 성공했습니다.");

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/domain/Deleted.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/domain/Deleted.java
@@ -1,0 +1,23 @@
+package com.jjikmuk.sikdorak.common.domain;
+
+import javax.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Deleted {
+
+	public static final Deleted TRUE = new Deleted(true);
+	public static final Deleted FALSE = new Deleted(false);
+
+	private boolean deleted;
+
+	public Deleted(boolean deleted) {
+		this.deleted = deleted;
+	}
+
+	public void delete() {
+		deleted = TRUE.deleted;
+	}
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/exception/ExceptionCodeAndMessages.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/exception/ExceptionCodeAndMessages.java
@@ -12,6 +12,7 @@ import com.jjikmuk.sikdorak.store.exception.InvalidAddressException;
 import com.jjikmuk.sikdorak.store.exception.InvalidContactNumberException;
 import com.jjikmuk.sikdorak.store.exception.InvalidStoreLocationException;
 import com.jjikmuk.sikdorak.store.exception.InvalidStoreNameException;
+import com.jjikmuk.sikdorak.store.exception.StoreDeleteFailedException;
 import com.jjikmuk.sikdorak.store.exception.NotFoundStoreException;
 import com.jjikmuk.sikdorak.user.auth.exception.InvalidTokenException;
 import com.jjikmuk.sikdorak.user.auth.exception.NeedLoginException;
@@ -44,6 +45,7 @@ public enum ExceptionCodeAndMessages implements CodeAndMessages {
     INVALID_CONTACT_NUMER("F-S003", "유효하지 않은 연락처 입니다.", InvalidContactNumberException.class),
     INVALID_ADDRESS("F-S004", "유효하지 않은 연락처 입니다.", InvalidAddressException.class),
     INVALID_STORE_LOCATION("F-S005", "유효하지 않은 좌표 입니다.",InvalidStoreLocationException .class),
+    FAILED_DELETE_STORE("F-S006", "가게를 삭제하는데 실패하였습니다.", StoreDeleteFailedException.class),
 
     // User
     DUPLICATE_USER("F-U001", "중복된 유저입니다.",DuplicateUserException.class),

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/controller/StoreController.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/controller/StoreController.java
@@ -2,6 +2,7 @@ package com.jjikmuk.sikdorak.store.controller;
 
 import static com.jjikmuk.sikdorak.common.ResponseCodeAndMessages.STORE_CREATE_SUCCESS;
 import static com.jjikmuk.sikdorak.common.ResponseCodeAndMessages.STORE_MODIFY_SUCCESS;
+import static com.jjikmuk.sikdorak.common.ResponseCodeAndMessages.STORE_REMOVE_SUCCESS;
 import static com.jjikmuk.sikdorak.common.ResponseCodeAndMessages.STORE_SEARCH_SUCCESS;
 
 import com.jjikmuk.sikdorak.common.response.CommonResponseEntity;
@@ -12,6 +13,7 @@ import com.jjikmuk.sikdorak.store.service.StoreService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -49,5 +51,12 @@ public class StoreController {
 		storeService.modifyStore(storeId, modifyRequest);
 
 		return new CommonResponseEntity<>(STORE_MODIFY_SUCCESS, HttpStatus.OK);
+	}
+
+	@DeleteMapping("/{storeId}")
+	public CommonResponseEntity<Void> removeStore(@PathVariable("storeId") Long storeId) {
+		storeService.removeStore(storeId);
+
+		return new CommonResponseEntity<>(STORE_REMOVE_SUCCESS, HttpStatus.OK);
 	}
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/domain/Store.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/domain/Store.java
@@ -1,14 +1,16 @@
 package com.jjikmuk.sikdorak.store.domain;
 
 import com.jjikmuk.sikdorak.common.domain.BaseTimeEntity;
-import lombok.NoArgsConstructor;
-
+import com.jjikmuk.sikdorak.common.domain.Deleted;
 import javax.persistence.Column;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Entity
 @NoArgsConstructor // for @Entity
@@ -30,6 +32,9 @@ public class Store extends BaseTimeEntity {
 
     @Embedded
     private StoreLocation location; // Float latitude, Float longitude
+
+    @Embedded
+    private Deleted deleted = Deleted.FALSE;
 
     public Store(String storeName, String contactNumber, String baseAddress, String detailAddress, Double latitude, Double longitude) {
         this.storeName = new StoreName(storeName);
@@ -66,10 +71,18 @@ public class Store extends BaseTimeEntity {
         return location.longitude();
     }
 
+    public boolean isDeleted() {
+        return isDeleted();
+    }
+
     public void editAll(String storeName, String contactNumber, String baseAddress, String detailAddress, Double latitude, Double longitude) {
         this.storeName = new StoreName(storeName);
         this.contactNumber = new ContactNumber(contactNumber);
         this.address = new Address(baseAddress, detailAddress);
         this.location = new StoreLocation(latitude, longitude);
+    }
+
+    public void delete() {
+        deleted.delete();
     }
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/domain/Store.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/domain/Store.java
@@ -14,6 +14,8 @@ import org.hibernate.annotations.Where;
 
 @Entity
 @NoArgsConstructor // for @Entity
+@SQLDelete(sql = "UPDATE store SET deleted = true WHERE store_id = ?")
+@Where(clause = "deleted = false")
 public class Store extends BaseTimeEntity {
 
     @Id
@@ -69,10 +71,6 @@ public class Store extends BaseTimeEntity {
 
     public double getLongitude() {
         return location.longitude();
-    }
-
-    public boolean isDeleted() {
-        return isDeleted();
     }
 
     public void editAll(String storeName, String contactNumber, String baseAddress, String detailAddress, Double latitude, Double longitude) {

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/exception/StoreDeleteFailedException.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/exception/StoreDeleteFailedException.java
@@ -1,0 +1,12 @@
+package com.jjikmuk.sikdorak.store.exception;
+
+import com.jjikmuk.sikdorak.common.exception.SikdorakRuntimeException;
+import org.springframework.http.HttpStatus;
+
+public class StoreDeleteFailedException extends SikdorakRuntimeException {
+
+	@Override
+	public HttpStatus getHttpStatus() {
+		return HttpStatus.BAD_REQUEST;
+	}
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/service/StoreService.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/service/StoreService.java
@@ -4,6 +4,7 @@ import com.jjikmuk.sikdorak.store.controller.request.StoreCreateRequest;
 import com.jjikmuk.sikdorak.store.controller.request.StoreModifyRequest;
 import com.jjikmuk.sikdorak.store.controller.response.StoreSearchResponse;
 import com.jjikmuk.sikdorak.store.domain.Store;
+import com.jjikmuk.sikdorak.store.exception.StoreDeleteFailedException;
 import com.jjikmuk.sikdorak.store.exception.NotFoundStoreException;
 import com.jjikmuk.sikdorak.store.repository.StoreRepository;
 import java.util.Collections;
@@ -74,6 +75,10 @@ public class StoreService {
 
 	@Transactional
 	public void removeStore(Long storeId) {
-		storeRepository.deleteById(storeId);
+		try {
+			storeRepository.deleteById(storeId);
+		} catch (Exception e) {
+			throw new StoreDeleteFailedException();
+		}
 	}
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/service/StoreService.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/service/StoreService.java
@@ -4,7 +4,6 @@ import com.jjikmuk.sikdorak.store.controller.request.StoreCreateRequest;
 import com.jjikmuk.sikdorak.store.controller.request.StoreModifyRequest;
 import com.jjikmuk.sikdorak.store.controller.response.StoreSearchResponse;
 import com.jjikmuk.sikdorak.store.domain.Store;
-import com.jjikmuk.sikdorak.store.exception.StoreDeleteFailedException;
 import com.jjikmuk.sikdorak.store.exception.NotFoundStoreException;
 import com.jjikmuk.sikdorak.store.repository.StoreRepository;
 import java.util.Collections;
@@ -75,10 +74,9 @@ public class StoreService {
 
 	@Transactional
 	public void removeStore(Long storeId) {
-		try {
-			storeRepository.deleteById(storeId);
-		} catch (Exception e) {
-			throw new StoreDeleteFailedException();
-		}
+		Store store = storeRepository.findById(storeId)
+			.orElseThrow(NotFoundStoreException::new);
+
+		store.delete();
 	}
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/service/StoreService.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/service/StoreService.java
@@ -71,4 +71,9 @@ public class StoreService {
 
 		return store.getId();
 	}
+
+	@Transactional
+	public void removeStore(Long storeId) {
+		storeRepository.deleteById(storeId);
+	}
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/store/StoreModifyAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/store/StoreModifyAcceptanceTest.java
@@ -20,7 +20,7 @@ import org.springframework.http.MediaType;
 class StoreModifyAcceptanceTest extends InitAcceptanceTest {
 
 	@Test
-	@DisplayName("가게 수정 요청이 정상적인 경우라면, 리뷰 생성 후 정상 상태 코드를 반환한다.")
+	@DisplayName("가게 수정 요청이 정상적인 경우라면, 가게 수정 후 정상 상태 코드를 반환한다.")
 	void modify_store_success() {
 		Long savedStoreId = testData.store.getId();
 

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/store/StoreRemoveAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/store/StoreRemoveAcceptanceTest.java
@@ -1,0 +1,43 @@
+package com.jjikmuk.sikdorak.acceptance.store;
+
+import static com.jjikmuk.sikdorak.acceptance.store.StoreSnippet.STORE_REMOVE_REQUEST_PARAM_SNIPPET;
+import static com.jjikmuk.sikdorak.acceptance.store.StoreSnippet.STORE_REMOVE_RESPONSE_SNIPPET;
+import static io.restassured.RestAssured.given;
+import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
+
+import com.jjikmuk.sikdorak.acceptance.InitAcceptanceTest;
+import com.jjikmuk.sikdorak.common.ResponseCodeAndMessages;
+import io.restassured.http.ContentType;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.cloud.contract.spec.internal.HttpStatus;
+import org.springframework.http.MediaType;
+
+@DisplayName("StoreRemove 인수 테스트")
+class StoreRemoveAcceptanceTest extends InitAcceptanceTest {
+
+	@Test
+	@DisplayName("가게 삭제 요청이 정상적인 경우라면, 가게 삭제 후 정상 상태 코드를 반환한다.")
+	void modify_store_success() {
+		Long savedStoreId = testData.store.getId();
+
+		ResponseCodeAndMessages expectedCodeAndMessage = ResponseCodeAndMessages.STORE_REMOVE_SUCCESS;
+
+		given(this.spec).log().all()
+			.filter(document(DEFAULT_RESTDOC_PATH,
+				STORE_REMOVE_REQUEST_PARAM_SNIPPET,
+				STORE_REMOVE_RESPONSE_SNIPPET))
+			.accept(MediaType.APPLICATION_JSON_VALUE)
+			.header("Authorization", testData.userValidAuthorizationHeader)
+			.contentType(ContentType.JSON)
+
+		.when()
+			.delete("/api/stores/{storeId}", savedStoreId)
+
+		.then()
+			.statusCode(HttpStatus.OK)
+			.body("code", Matchers.equalTo(expectedCodeAndMessage.getCode()))
+			.body("message", Matchers.equalTo(expectedCodeAndMessage.getMessage()));
+	}
+}

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/store/StoreRemoveAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/store/StoreRemoveAcceptanceTest.java
@@ -19,7 +19,7 @@ class StoreRemoveAcceptanceTest extends InitAcceptanceTest {
 
 	@Test
 	@DisplayName("가게 삭제 요청이 정상적인 경우라면, 가게 삭제 후 정상 상태 코드를 반환한다.")
-	void modify_store_success() {
+	void remove_store_success() {
 		Long savedStoreId = testData.store.getId();
 
 		ResponseCodeAndMessages expectedCodeAndMessage = ResponseCodeAndMessages.STORE_REMOVE_SUCCESS;

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/store/StoreRemoveAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/store/StoreRemoveAcceptanceTest.java
@@ -31,7 +31,7 @@ class StoreRemoveAcceptanceTest extends InitAcceptanceTest {
 				STORE_REMOVE_REQUEST_PARAM_SNIPPET,
 				STORE_REMOVE_RESPONSE_SNIPPET))
 			.accept(MediaType.APPLICATION_JSON_VALUE)
-			.header("Authorization", testData.userValidAuthorizationHeader)
+			.header("Authorization", testData.user1ValidAuthorizationHeader)
 			.contentType(ContentType.JSON)
 
 		.when()
@@ -55,7 +55,7 @@ class StoreRemoveAcceptanceTest extends InitAcceptanceTest {
 				STORE_REMOVE_REQUEST_PARAM_SNIPPET,
 				STORE_REMOVE_RESPONSE_SNIPPET))
 			.accept(MediaType.APPLICATION_JSON_VALUE)
-			.header("Authorization", testData.userValidAuthorizationHeader)
+			.header("Authorization", testData.user1ValidAuthorizationHeader)
 			.contentType(ContentType.JSON)
 
 			.when()

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/store/StoreRemoveAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/store/StoreRemoveAcceptanceTest.java
@@ -6,7 +6,9 @@ import static io.restassured.RestAssured.given;
 import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
 
 import com.jjikmuk.sikdorak.acceptance.InitAcceptanceTest;
+import com.jjikmuk.sikdorak.common.CodeAndMessages;
 import com.jjikmuk.sikdorak.common.ResponseCodeAndMessages;
+import com.jjikmuk.sikdorak.common.exception.ExceptionCodeAndMessages;
 import io.restassured.http.ContentType;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.DisplayName;
@@ -37,6 +39,30 @@ class StoreRemoveAcceptanceTest extends InitAcceptanceTest {
 
 		.then()
 			.statusCode(HttpStatus.OK)
+			.body("code", Matchers.equalTo(expectedCodeAndMessage.getCode()))
+			.body("message", Matchers.equalTo(expectedCodeAndMessage.getMessage()));
+	}
+
+	@Test
+	@DisplayName("가게 삭제 요청 시 존재하지 않는 가게에 대한 요청이라면, 삭제되지 않고 실패 메세지를 전송한다.")
+	void remove_store_failed() {
+		Long unsavedStoreId = Long.MIN_VALUE;
+
+		CodeAndMessages expectedCodeAndMessage = ExceptionCodeAndMessages.FAILED_DELETE_STORE;
+
+		given(this.spec).log().all()
+			.filter(document(DEFAULT_RESTDOC_PATH,
+				STORE_REMOVE_REQUEST_PARAM_SNIPPET,
+				STORE_REMOVE_RESPONSE_SNIPPET))
+			.accept(MediaType.APPLICATION_JSON_VALUE)
+			.header("Authorization", testData.userValidAuthorizationHeader)
+			.contentType(ContentType.JSON)
+
+			.when()
+			.delete("/api/stores/{storeId}", unsavedStoreId)
+
+			.then()
+			.statusCode(HttpStatus.BAD_REQUEST)
 			.body("code", Matchers.equalTo(expectedCodeAndMessage.getCode()))
 			.body("message", Matchers.equalTo(expectedCodeAndMessage.getMessage()));
 	}

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/store/StoreRemoveAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/store/StoreRemoveAcceptanceTest.java
@@ -48,7 +48,7 @@ class StoreRemoveAcceptanceTest extends InitAcceptanceTest {
 	void remove_store_failed() {
 		Long unsavedStoreId = Long.MIN_VALUE;
 
-		CodeAndMessages expectedCodeAndMessage = ExceptionCodeAndMessages.FAILED_DELETE_STORE;
+		CodeAndMessages expectedCodeAndMessage = ExceptionCodeAndMessages.NOT_FOUND_STORE;
 
 		given(this.spec).log().all()
 			.filter(document(DEFAULT_RESTDOC_PATH,
@@ -62,7 +62,7 @@ class StoreRemoveAcceptanceTest extends InitAcceptanceTest {
 			.delete("/api/stores/{storeId}", unsavedStoreId)
 
 			.then()
-			.statusCode(HttpStatus.BAD_REQUEST)
+			.statusCode(HttpStatus.NOT_FOUND)
 			.body("code", Matchers.equalTo(expectedCodeAndMessage.getCode()))
 			.body("message", Matchers.equalTo(expectedCodeAndMessage.getMessage()));
 	}

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/store/StoreSnippet.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/store/StoreSnippet.java
@@ -55,6 +55,12 @@ public interface StoreSnippet {
 
 	Snippet STORE_MODIFY_RESPONSE_SNIPPET = commonResponseNonFields();
 
+	Snippet STORE_REMOVE_REQUEST_PARAM_SNIPPET = pathParameters(
+		parameterWithName("storeId").description(Constants.ID_DESCRIPTION)
+	);
+
+	Snippet STORE_REMOVE_RESPONSE_SNIPPET = commonResponseNonFields();
+
 	class Constants {
 		private static final String ID_DESCRIPTION = "가게 아이디";
 		private static final String STORENAME_DESCRIPTION = "가게 이름";

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/store/StoreRemoveIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/store/StoreRemoveIntegrationTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.jjikmuk.sikdorak.integration.InitIntegrationTest;
 import com.jjikmuk.sikdorak.store.domain.Store;
-import com.jjikmuk.sikdorak.store.exception.StoreNotFoundException;
+import com.jjikmuk.sikdorak.store.exception.NotFoundStoreException;
 import com.jjikmuk.sikdorak.store.repository.StoreRepository;
 import com.jjikmuk.sikdorak.store.service.StoreService;
 import java.util.Optional;
@@ -48,7 +48,7 @@ public class StoreRemoveIntegrationTest extends InitIntegrationTest {
 
             // then
             assertThatThrownBy(() -> storeService.removeStore(notSavedStoreId))
-                .isInstanceOf(StoreNotFoundException.class);
+                .isInstanceOf(NotFoundStoreException.class);
         }
     }
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/store/StoreRemoveIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/store/StoreRemoveIntegrationTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.jjikmuk.sikdorak.integration.InitIntegrationTest;
 import com.jjikmuk.sikdorak.store.domain.Store;
-import com.jjikmuk.sikdorak.store.exception.StoreDeleteFailedException;
+import com.jjikmuk.sikdorak.store.exception.StoreNotFoundException;
 import com.jjikmuk.sikdorak.store.repository.StoreRepository;
 import com.jjikmuk.sikdorak.store.service.StoreService;
 import java.util.Optional;
@@ -48,7 +48,7 @@ public class StoreRemoveIntegrationTest extends InitIntegrationTest {
 
             // then
             assertThatThrownBy(() -> storeService.removeStore(notSavedStoreId))
-                .isInstanceOf(StoreDeleteFailedException.class);
+                .isInstanceOf(StoreNotFoundException.class);
         }
     }
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/store/StoreRemoveIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/store/StoreRemoveIntegrationTest.java
@@ -1,0 +1,54 @@
+package com.jjikmuk.sikdorak.integration.store;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.jjikmuk.sikdorak.integration.InitIntegrationTest;
+import com.jjikmuk.sikdorak.store.domain.Store;
+import com.jjikmuk.sikdorak.store.exception.StoreDeleteFailedException;
+import com.jjikmuk.sikdorak.store.repository.StoreRepository;
+import com.jjikmuk.sikdorak.store.service.StoreService;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayName("StoreRemove 통합테스트")
+public class StoreRemoveIntegrationTest extends InitIntegrationTest {
+
+    @Autowired
+    private StoreService storeService;
+
+    @Autowired
+    private StoreRepository storeRepository;
+
+    @Nested
+    @DisplayName("가게를 삭제할 때")
+    class ModifyStoreTest {
+
+        @Test
+        @DisplayName("존재하는 가게에 대한 삭제 요청이라면 가게를 삭제할 수 있다.")
+        void remove_store_success() {
+            // given
+            Long deleteTargetStoreId = testData.store.getId();
+
+            // when
+            storeService.removeStore(deleteTargetStoreId);
+
+            // then
+            Optional<Store> findResult = storeRepository.findById(deleteTargetStoreId);
+            assertThat(findResult.isPresent()).isFalse();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 가게에 대한 삭제 요청이라면 예외를 발생시킨다.")
+        void create_store_failed() {
+            long notSavedStoreId = Long.MIN_VALUE;
+
+            // then
+            assertThatThrownBy(() -> storeService.removeStore(notSavedStoreId))
+                .isInstanceOf(StoreDeleteFailedException.class);
+        }
+    }
+}

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/store/StoreSearchIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/store/StoreSearchIntegrationTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.jjikmuk.sikdorak.integration.InitIntegrationTest;
 import com.jjikmuk.sikdorak.store.controller.response.StoreSearchResponse;
+import com.jjikmuk.sikdorak.store.domain.Store;
+import com.jjikmuk.sikdorak.store.repository.StoreRepository;
 import com.jjikmuk.sikdorak.store.service.StoreService;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -16,6 +18,9 @@ public class StoreSearchIntegrationTest extends InitIntegrationTest {
 
     @Autowired
     private StoreService storeService;
+
+    @Autowired
+    private StoreRepository storeRepository;
 
     @Nested
     @DisplayName("가게 이름으로 검색할 때")
@@ -82,6 +87,22 @@ public class StoreSearchIntegrationTest extends InitIntegrationTest {
             // then
             assertThat(stores).isNotNull();
             assertThat(stores).isEmpty();
+        }
+
+        @Test
+        @DisplayName("삭제된 가게는 조회 결과에 포함되지 않는다.")
+        void deleted_store_not_containing_in_result() {
+            // given
+            Store deletedStore = testData.store;
+            storeRepository.deleteById(deletedStore.getId());
+
+            // when
+            List<StoreSearchResponse> storeSearchResponses = storeService.searchStoresByStoreNameContaining(
+                deletedStore.getStoreName());
+
+            // then
+            assertThat(storeSearchResponses).isNotNull();
+            assertThat(storeSearchResponses).isEmpty();
         }
     }
 }


### PR DESCRIPTION
### ❗️ 이슈 번호

[SDR 117]

<br><br>

### 📝 구현 내용

- Store 삭제 기능 구현(Soft delete)
- 삭제 상태 공통 도메인 클래스 추가(Deleted)
- 가게 삭제 API 문서 추가

<br><br>

### 🙇🏻‍♂️ 리뷰어에게 부탁합니다!

- 삭제 상태 공통 도메인 클래스 추가에 대한 피드백 부탁드려요!
(댓글로 남겨놓겠습니다.)

<br><br>
