### PR TITLE
SDR-146 User Detail View

### DIFF
--- a/fe/src/App.tsx
+++ b/fe/src/App.tsx
@@ -3,6 +3,7 @@ import Login from 'pages/Login/Login';
 import ReviewDetail from 'pages/ReviewDetail/ReviewDetail';
 import ReviewList from 'pages/ReviewList/ReviewList';
 import ReviewWrite from 'pages/ReviewWrite/ReviewWrite';
+import UserDetail from 'pages/UserDetail/userDetail';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import GlobalStyle from 'styles/GlobalStyle';
 
@@ -37,6 +38,7 @@ function App() {
               </Portal>
             }
           />
+          <Route path="/userDetail" element={<UserDetail />} />
           <Route path="/reviewList" element={<ReviewList />} />
         </Routes>
       </BrowserRouter>

--- a/fe/src/components/Common/CommonHeader.tsx
+++ b/fe/src/components/Common/CommonHeader.tsx
@@ -2,24 +2,29 @@ import Icon, { IconComponentsKeys } from 'common/Icon';
 import Logo from 'common/Logo/Logo';
 import Portal from 'common/Portal/Portal';
 import { useOutsideClick } from 'hooks/useOutsideClick';
+import useToggle from 'hooks/useToggle';
 import ReviewWrite from 'pages/ReviewWrite/ReviewWrite';
+import UserDetail from 'pages/UserDetail/userDetail';
 import { useRef, useState } from 'react';
 import { createKey } from 'utils/utils';
 import { ButtonWrap, IconWrap, Input, SearchFormWrap, Header, Wrap } from './CommonHeader.styled';
 
 function CommonHeader() {
   const [isReviewWrite, setIsReviewWrite] = useState(false);
-  const modalRef = useRef(null);
+  const [isUserProfile, toggleIsUserProfile] = useToggle(false);
+  const reviewWriteModalRef = useRef(null);
+  const userDetailModalRef = useRef(null);
 
   const iconInfo: IconInfoProps[] = [
-    { icon: 'Home' },
+    { icon: 'Home', handler: toggleIsUserProfile },
     { icon: 'Map' },
     { icon: 'PostBtn', handler: handleReviewWrite },
     { icon: 'Alarm' },
     { icon: 'Profile' },
   ];
 
-  useOutsideClick(modalRef, handleReviewWrite);
+  useOutsideClick(reviewWriteModalRef, handleReviewWrite);
+  useOutsideClick(userDetailModalRef, toggleIsUserProfile);
 
   return (
     <Wrap>
@@ -39,8 +44,13 @@ function CommonHeader() {
           ))}
         </ButtonWrap>
         {isReviewWrite && (
-          <Portal selector="#portal" ref={modalRef}>
+          <Portal selector="#portal" ref={reviewWriteModalRef}>
             <ReviewWrite />
+          </Portal>
+        )}
+        {isUserProfile && (
+          <Portal selector="#portal" ref={userDetailModalRef}>
+            <UserDetail />
           </Portal>
         )}
       </Header>

--- a/fe/src/components/UserDetail/FollowButton/FollowButton.styled.ts
+++ b/fe/src/components/UserDetail/FollowButton/FollowButton.styled.ts
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+export const Wrap = styled.div`
+  width: 120px;
+  background-color: blue;
+  color: #fff;
+  text-align: center;
+  padding: 10px;
+  border-radius: 10px;
+`;

--- a/fe/src/components/UserDetail/FollowButton/FollowButton.tsx
+++ b/fe/src/components/UserDetail/FollowButton/FollowButton.tsx
@@ -1,0 +1,11 @@
+import { Wrap } from './FollowButton.styled';
+
+function FollowButton({ already }: FollowButtonProps) {
+  return <Wrap>{already ? '언팔로우' : '팔로우'}</Wrap>;
+}
+
+type FollowButtonProps = {
+  already?: boolean;
+};
+
+export default FollowButton;

--- a/fe/src/components/UserDetail/UserProfilePhoto/UserProfilePhoto.styled.ts
+++ b/fe/src/components/UserDetail/UserProfilePhoto/UserProfilePhoto.styled.ts
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+
+export const PhotoImg = styled.img`
+  width: 136px;
+  height: 136px;
+  border-radius: 50%;
+`;

--- a/fe/src/components/UserDetail/UserProfilePhoto/UserProfilePhoto.tsx
+++ b/fe/src/components/UserDetail/UserProfilePhoto/UserProfilePhoto.tsx
@@ -1,0 +1,11 @@
+import { PhotoImg } from './UserProfilePhoto.styled';
+
+function UserProfilePhoto({ src }: UserProfileProps) {
+  return <PhotoImg src={src} />;
+}
+
+type UserProfileProps = {
+  src: string;
+};
+
+export default UserProfilePhoto;

--- a/fe/src/pages/UserDetail/userDetail.styled.ts
+++ b/fe/src/pages/UserDetail/userDetail.styled.ts
@@ -1,0 +1,29 @@
+import styled from 'styled-components';
+import { flexLayoutMixin } from 'utils/utils';
+
+export const Wrap = styled.div`
+  width: 100%;
+  height: 100%;
+`;
+
+export const UserDetailWrap = styled.div`
+  ${() => flexLayoutMixin('', 'center', 'center')};
+  margin-top: 40px;
+`;
+
+export const UserInfoWrap = styled.div`
+  margin-left: 40px;
+`;
+
+export const UserInfoHeader = styled.div`
+  ${() => flexLayoutMixin('', 'space-between')};
+`;
+
+export const ActivityInfoWrap = styled.div`
+  ${() => flexLayoutMixin('', 'space-between')};
+  margin-top: 20px;
+`;
+
+export const ProfileInfoWrap = styled.div`
+  margin-top: 20px;
+`;

--- a/fe/src/pages/UserDetail/userDetail.tsx
+++ b/fe/src/pages/UserDetail/userDetail.tsx
@@ -1,0 +1,48 @@
+import CommonHeader from 'components/Common/CommonHeader';
+import FollowButton from 'components/UserDetail/FollowButton/FollowButton';
+import UserProfilePhoto from 'components/UserDetail/UserProfilePhoto/UserProfilePhoto';
+import {
+  ActivityInfoWrap,
+  ProfileInfoWrap,
+  UserDetailWrap,
+  UserInfoHeader,
+  UserInfoWrap,
+  Wrap,
+} from './userDetail.styled';
+
+const MockUserInfo = {
+  name: 'Dashawn',
+  postCnt: 10,
+  followCnt: 1101,
+  followerCnt: 333,
+  profileMessage: '맛잘알 리스트는 아닙니다.. 그냥 기록용 입니다',
+  profileImg: 'https://avatars.githubusercontent.com/u/87521172?v=4',
+};
+
+function UserDetail() {
+  return (
+    <Wrap>
+      <CommonHeader />
+      <UserDetailWrap>
+        <UserProfilePhoto src={MockUserInfo.profileImg} />
+        <UserInfoWrap>
+          <UserInfoHeader>
+            {MockUserInfo.name}
+            <FollowButton />
+          </UserInfoHeader>
+          <ActivityInfoWrap>
+            <div>게시물 {MockUserInfo.postCnt}</div>
+            <div>팔로우 {MockUserInfo.followCnt}</div>
+            <div>팔로워 {MockUserInfo.followerCnt}</div>
+          </ActivityInfoWrap>
+          <ProfileInfoWrap>
+            {MockUserInfo.name}
+            {MockUserInfo.profileMessage}
+          </ProfileInfoWrap>
+        </UserInfoWrap>
+      </UserDetailWrap>
+    </Wrap>
+  );
+}
+
+export default UserDetail;


### PR DESCRIPTION
### 📝 구현 내용

- 유저 프로필 사진 (136x136) 컴포넌트 구현했습니다.
- 팔로우 버튼 컴포넌트를 구현했습니다.
- 유저 디테일 페이지에서 각 컴포넌트를 적용했습니다. 곧 api가 나올 것 같아서 userDetail 페이지 자체에서 mockData를 선언했습니다. 혹시 불편하다면 dummyData로 옮기겠습니다.
- /userDetail에 라우팅 해뒀습니다.
- 개발 단계에서 확인이 편하고자 공통 헤더 컴포넌트의 홈 버튼에 모달 형태로 적용했습니다.

### 🙇🏻‍♂️ 리뷰어에게 부탁합니다!

- 확인 후 머지 부탁드립니다. (변경 요청사항이 있으시다면 체인지 리퀘스트 부탁드립니다.)
