### PR TITLE
SDR-143 리뷰 삭제 API & 테스트

### DIFF
--- a/be/src/docs/asciidoc/review/review.adoc
+++ b/be/src/docs/asciidoc/review/review.adoc
@@ -41,3 +41,31 @@ operation::review_modify_acceptance_test/modify_review_failed[snippets='http-req
 ==== `Response`
 
 operation::review_modify_acceptance_test/modify_review_failed[snippets='http-response,response-fields']
+
+=== 리뷰 삭제
+
+API : `DELETE /api/reviews/{reviewId}`
+
+=== `200 OK`
+
+리뷰 작성자가 리뷰 삭제한 경우
+
+==== `Request`
+
+operation::review_remove_accecptance_test/remove_review_success[snippets='http-request']
+
+==== `Response`
+
+operation::review_remove_accecptance_test/remove_review_success[snippets='http-response,response-fields']
+
+=== `401 UNATHORIZED`
+
+비회원이 리뷰 삭제 요청한 경우
+
+==== `Request`
+
+operation::review_remove_accecptance_test/remove_review_failed_need_login[snippets='http-request']
+
+==== `Response`
+
+operation::review_remove_accecptance_test/remove_review_failed_need_login[snippets='http-response,response-fields']

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/ResponseCodeAndMessages.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/ResponseCodeAndMessages.java
@@ -2,8 +2,10 @@ package com.jjikmuk.sikdorak.common;
 
 public enum ResponseCodeAndMessages implements CodeAndMessages {
 
+    // Review
     REVIEW_CREATE_SUCCESS("T-R001", "리뷰 생성 성공했습니다."),
     REVIEW_MODIFY_SUCCESS("T-R002", "리뷰 수정 성공했습니다."),
+    REVIEW_REMOVE_SUCCESS("T-R003", "리뷰 삭제 성공했습니다."),
 
     // OAuth
     LOGIN_SUCCESS("T-O001", "로그인에 성공했습니다."),

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/controller/ReviewController.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/controller/ReviewController.java
@@ -53,7 +53,7 @@ public class ReviewController {
 		@AuthenticatedUser LoginUser loginUser) {
 		reviewService.removeReview(loginUser, reviewId);
 
-		return new CommonResponseEntity<>(ResponseCodeAndMessages.REVIEW_MODIFY_SUCCESS,
+		return new CommonResponseEntity<>(ResponseCodeAndMessages.REVIEW_REMOVE_SUCCESS,
 			HttpStatus.OK);
 	}
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/controller/ReviewController.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/controller/ReviewController.java
@@ -10,6 +10,7 @@ import com.jjikmuk.sikdorak.user.auth.controller.LoginUser;
 import com.jjikmuk.sikdorak.user.auth.domain.AuthenticatedUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -40,6 +41,17 @@ public class ReviewController {
 		@AuthenticatedUser LoginUser loginUser,
 		@RequestBody ReviewModifyRequest reviewModifyRequest) {
 		reviewService.modifyReview(loginUser, reviewId, reviewModifyRequest);
+
+		return new CommonResponseEntity<>(ResponseCodeAndMessages.REVIEW_MODIFY_SUCCESS,
+			HttpStatus.OK);
+	}
+
+	@UserOnly
+	@DeleteMapping("/api/reviews/{reviewId}")
+	public CommonResponseEntity<Void> removeReview(
+		@PathVariable Long reviewId,
+		@AuthenticatedUser LoginUser loginUser) {
+		reviewService.removeReview(loginUser, reviewId);
 
 		return new CommonResponseEntity<>(ResponseCodeAndMessages.REVIEW_MODIFY_SUCCESS,
 			HttpStatus.OK);

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/domain/Review.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/domain/Review.java
@@ -14,9 +14,13 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Transient;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Entity
 @NoArgsConstructor
+@SQLDelete(sql = "update review set deleted = true where review_id = ?")
+@Where(clause = "deleted = false")
 public class Review extends BaseTimeEntity {
 
 	@Id
@@ -45,6 +49,8 @@ public class Review extends BaseTimeEntity {
 
 	@Transient
 	private List<String> images;
+
+	private boolean deleted = Boolean.FALSE;
 
 	public Review(Long id, Long userId, Long storeId, String reviewContent, Float reviewScore,
 		String reviewVisibility,
@@ -83,6 +89,10 @@ public class Review extends BaseTimeEntity {
 		return this.userId.equals(user.getId());
 	}
 
+	public boolean isDeleted() {
+		return deleted;
+	}
+
 	public void editAll(Long storeId, String reviewContent, Float reviewScore,
 		String reviewVisibility, LocalDate visitedDate, List<String> tags, List<String> images) {
 		this.storeId = storeId;
@@ -92,5 +102,9 @@ public class Review extends BaseTimeEntity {
 		this.visitedDate = new ReviewVisitedDate(visitedDate);
 		this.tags = new Tags(tags);
 		this.images = images;
+	}
+
+	public void delete() {
+		this.deleted = true;
 	}
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/domain/Tags.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/domain/Tags.java
@@ -1,45 +1,47 @@
 package com.jjikmuk.sikdorak.review.domain;
 
 import com.jjikmuk.sikdorak.review.exception.InvalidTagsException;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
-
-import javax.persistence.*;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.persistence.CollectionTable;
+import javax.persistence.ElementCollection;
+import javax.persistence.Embeddable;
+import javax.persistence.JoinColumn;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Tags {
 
-    private static final int LIMIT_SIZE = 30;
+	private static final int LIMIT_SIZE = 30;
 
-    @ElementCollection
-    @CollectionTable(
-            name = "review_tags",
-            joinColumns = @JoinColumn(name = "review_id")
-    )
-    private Set<Tag> tags;
+	@ElementCollection
+	@CollectionTable(
+		name = "review_tags",
+		joinColumns = @JoinColumn(name = "review_id")
+	)
+	private Set<Tag> tags;
 
-    public Tags(List<String> tags) {
-        if (Objects.isNull(tags)) {
-            throw new InvalidTagsException();
-        }
+	public Tags(List<String> tags) {
+		if (Objects.isNull(tags)) {
+			throw new InvalidTagsException();
+		}
 
-        Set<Tag> filteredTags = tags.stream()
-                .map(Tag::new)
-                .collect(Collectors.toSet());
+		Set<Tag> filteredTags = tags.stream()
+			.map(Tag::new)
+			.collect(Collectors.toSet());
 
-        if (filteredTags.size() > LIMIT_SIZE) {
-            throw new InvalidTagsException();
-        }
+		if (filteredTags.size() > LIMIT_SIZE) {
+			throw new InvalidTagsException();
+		}
 
-        this.tags = filteredTags;
-    }
+		this.tags = filteredTags;
+	}
 
-    public int size() {
-        return tags.size();
-    }
+	public int size() {
+		return tags.size();
+	}
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/service/ReviewService.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/service/ReviewService.java
@@ -66,6 +66,18 @@ public class ReviewService {
 		return review;
 	}
 
+	@Transactional
+	public Review removeReview(LoginUser loginUser, Long reviewId) {
+		Review review = reviewRepository.findById(reviewId).orElseThrow(NotFoundReviewException::new);
+		User user = userRespository.findById(loginUser.getId()).orElseThrow(NotFoundUserException::new);
+
+		validateReviewWithUser(review, user);
+
+		review.delete();
+
+		return review;
+	}
+
 	private void validateReviewWithUser(Review review, User user) {
 		if (!review.isAuthor(user)) {
 			throw new UnauthorizedUserException();

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/service/ReviewService.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/service/ReviewService.java
@@ -45,6 +45,7 @@ public class ReviewService {
 		return reviewRepository.save(newReview);
 	}
 
+	@Transactional
 	public Review modifyReview(LoginUser loginUser, Long reviewId,
 		ReviewModifyRequest reviewModifyRequest) {
 		Review review = reviewRepository.findById(reviewId).orElseThrow(NotFoundReviewException::new);

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/review/ReviewRemoveAccecptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/review/ReviewRemoveAccecptanceTest.java
@@ -7,6 +7,7 @@ import static org.springframework.restdocs.restassured3.RestAssuredRestDocumenta
 
 import com.jjikmuk.sikdorak.acceptance.InitAcceptanceTest;
 import com.jjikmuk.sikdorak.common.ResponseCodeAndMessages;
+import com.jjikmuk.sikdorak.common.exception.ExceptionCodeAndMessages;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,9 +15,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
 /**
- * [ ] Soft Delete
- * [ ] 유저, 본인 리뷰 수정 정상 요청 유저
- * [ ] 본인 리뷰 수정 비정상 요청(없는 스토어 아이디) -> throw
+ * [x] Soft Delete
+ * [x] 유저, 본인 리뷰 수정 정상 요청 유저
+ * [x] 본인 리뷰 수정 비정상 요청(없는 스토어 아이디) -> throw
  */
 @DisplayName("ReviewRemove 인수 테스트")
 class ReviewRemoveAccecptanceTest extends InitAcceptanceTest {
@@ -43,5 +44,25 @@ class ReviewRemoveAccecptanceTest extends InitAcceptanceTest {
 				Matchers.equalTo(ResponseCodeAndMessages.REVIEW_REMOVE_SUCCESS.getMessage()));
 	}
 
+	@Test
+	@DisplayName("비회원이 리뷰의 삭제 요청이 주어진다면 예외를 반환한다.")
+	void remove_review_failed_needLogin() {
+		given(this.spec)
+			.filter(
+				document(DEFAULT_RESTDOC_PATH,
+					REVIEW_REMOVE_REQUEST_PARAM_SNIPPET,
+					REVIEW_REMOVE_RESPONSE_SNIPPET))
+			.accept(MediaType.APPLICATION_JSON_VALUE)
+			.header("Content-type", "application/json")
+
+		.when()
+			.delete("/api/reviews/{reviewId}", testData.review.getId())
+
+		.then()
+			.statusCode(HttpStatus.UNAUTHORIZED.value())
+			.body("code", Matchers.equalTo(ExceptionCodeAndMessages.NEED_LOGIN.getCode()))
+			.body("message",
+				Matchers.equalTo(ExceptionCodeAndMessages.NEED_LOGIN.getMessage()));
+	}
 
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/review/ReviewRemoveAccecptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/review/ReviewRemoveAccecptanceTest.java
@@ -1,0 +1,47 @@
+package com.jjikmuk.sikdorak.acceptance.review;
+
+import static com.jjikmuk.sikdorak.acceptance.review.ReviewSnippet.REVIEW_REMOVE_REQUEST_PARAM_SNIPPET;
+import static com.jjikmuk.sikdorak.acceptance.review.ReviewSnippet.REVIEW_REMOVE_RESPONSE_SNIPPET;
+import static io.restassured.RestAssured.given;
+import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
+
+import com.jjikmuk.sikdorak.acceptance.InitAcceptanceTest;
+import com.jjikmuk.sikdorak.common.ResponseCodeAndMessages;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+/**
+ * [ ] Soft Delete
+ * [ ] 유저, 본인 리뷰 수정 정상 요청 유저
+ * [ ] 본인 리뷰 수정 비정상 요청(없는 스토어 아이디) -> throw
+ */
+@DisplayName("ReviewRemove 인수 테스트")
+class ReviewRemoveAccecptanceTest extends InitAcceptanceTest {
+
+	@Test
+	@DisplayName("유저가 본인 리뷰의 삭제 요청이 정상적인 경우라면 리뷰 삭제 후 정상 상태 코드를 반환한다")
+	void remove_review_success() {
+		given(this.spec)
+			.filter(
+				document(DEFAULT_RESTDOC_PATH,
+					REVIEW_REMOVE_REQUEST_PARAM_SNIPPET,
+					REVIEW_REMOVE_RESPONSE_SNIPPET))
+			.accept(MediaType.APPLICATION_JSON_VALUE)
+			.header("Content-type", "application/json")
+			.header("Authorization", testData.user1ValidAuthorizationHeader)
+
+		.when()
+			.delete("/api/reviews/{reviewId}", testData.review.getId())
+
+		.then()
+			.statusCode(HttpStatus.OK.value())
+			.body("code", Matchers.equalTo(ResponseCodeAndMessages.REVIEW_REMOVE_SUCCESS.getCode()))
+			.body("message",
+				Matchers.equalTo(ResponseCodeAndMessages.REVIEW_REMOVE_SUCCESS.getMessage()));
+	}
+
+
+}

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/review/ReviewSnippet.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/review/ReviewSnippet.java
@@ -46,4 +46,11 @@ interface ReviewSnippet {
 	Snippet REVIEW_MODIFY_REQUEST_PARAM_SNIPPET = pathParameters(
 		parameterWithName("reviewId").description("리뷰 아이디")
 	);
+
+	Snippet REVIEW_REMOVE_REQUEST_PARAM_SNIPPET = pathParameters(
+		parameterWithName("reviewId").description("리뷰 아이디")
+	);
+
+	Snippet REVIEW_REMOVE_RESPONSE_SNIPPET = commonResponseNonFields();
+
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/review/ReviewRemoveIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/review/ReviewRemoveIntegrationTest.java
@@ -1,0 +1,31 @@
+package com.jjikmuk.sikdorak.integration.review;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.jjikmuk.sikdorak.integration.InitIntegrationTest;
+import com.jjikmuk.sikdorak.review.domain.Review;
+import com.jjikmuk.sikdorak.review.service.ReviewService;
+import com.jjikmuk.sikdorak.user.auth.controller.Authority;
+import com.jjikmuk.sikdorak.user.auth.controller.LoginUser;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayName("ReviewRemove 통합 테스트")
+class ReviewRemoveIntegrationTest extends InitIntegrationTest {
+
+	@Autowired
+	ReviewService reviewService;
+
+	@Test
+	@DisplayName("만약 유저가 본인 리뷰에 대한 삭제 요청이 주어진다면 리뷰가 Soft 삭제된다.")
+	void remove_review_valid_() {
+		LoginUser loginUser = new LoginUser(testData.user1.getId(), Authority.USER);
+
+		Review removeReview = reviewService.removeReview(loginUser, testData.review.getId());
+
+		assertThat(removeReview.isDeleted()).isTrue();
+	}
+
+
+}

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/review/ReviewRemoveIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/review/ReviewRemoveIntegrationTest.java
@@ -1,12 +1,16 @@
 package com.jjikmuk.sikdorak.integration.review;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.jjikmuk.sikdorak.integration.InitIntegrationTest;
 import com.jjikmuk.sikdorak.review.domain.Review;
+import com.jjikmuk.sikdorak.review.exception.NotFoundReviewException;
 import com.jjikmuk.sikdorak.review.service.ReviewService;
 import com.jjikmuk.sikdorak.user.auth.controller.Authority;
 import com.jjikmuk.sikdorak.user.auth.controller.LoginUser;
+import com.jjikmuk.sikdorak.user.user.exception.NotFoundUserException;
+import com.jjikmuk.sikdorak.user.user.exception.UnauthorizedUserException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,7 +23,7 @@ class ReviewRemoveIntegrationTest extends InitIntegrationTest {
 
 	@Test
 	@DisplayName("만약 유저가 본인 리뷰에 대한 삭제 요청이 주어진다면 리뷰가 Soft 삭제된다.")
-	void remove_review_valid_() {
+	void remove_review_valid() {
 		LoginUser loginUser = new LoginUser(testData.user1.getId(), Authority.USER);
 
 		Review removeReview = reviewService.removeReview(loginUser, testData.review.getId());
@@ -27,5 +31,44 @@ class ReviewRemoveIntegrationTest extends InitIntegrationTest {
 		assertThat(removeReview.isDeleted()).isTrue();
 	}
 
+
+	@Test
+	@DisplayName("만약 유저가 존재하지 않은 리뷰에 대한 삭제 요청이 주어진다면 예외를 발생시킨다")
+	void remove_review_invalid_exist1() {
+		LoginUser loginUser = new LoginUser(testData.user1.getId(), Authority.USER);
+		long invalidReviewId = Long.MAX_VALUE;
+
+		assertThatThrownBy(() -> reviewService.removeReview(loginUser, invalidReviewId))
+			.isInstanceOf(NotFoundReviewException.class);
+	}
+
+	@Test
+	@DisplayName("만약 유저가 이미 삭제된 리뷰에 대한 삭제 요청이 주어진다면 예외를 발생시킨다")
+	void remove_review_invalid_exist2() {
+		LoginUser loginUser = new LoginUser(testData.user1.getId(), Authority.USER);
+		reviewService.removeReview(loginUser, testData.review.getId());
+
+		assertThatThrownBy(() -> reviewService.removeReview(loginUser, testData.review.getId()))
+			.isInstanceOf(NotFoundReviewException.class);
+	}
+
+	@Test
+	@DisplayName("만약 존재하지 않은 유저가 삭제 요청이 주어진다면 예외를 발생시킨다")
+	void remove_review_invalid_user() {
+		long invalidUserId = Long.MAX_VALUE;
+		LoginUser loginUser = new LoginUser(invalidUserId, Authority.USER);
+
+		assertThatThrownBy(() -> reviewService.removeReview(loginUser, testData.review.getId()))
+			.isInstanceOf(NotFoundUserException.class);
+	}
+
+	@Test
+	@DisplayName("만약 유저가 다른 유저의 리뷰에 대한 삭제 요청이 주어진다면 예외를 발생시킨다")
+	void remove_review_invalid_authorized() {
+		LoginUser loginUser = new LoginUser(testData.user2.getId(), Authority.USER);
+
+		assertThatThrownBy(() -> reviewService.removeReview(loginUser, testData.review.getId()))
+			.isInstanceOf(UnauthorizedUserException.class);
+	}
 
 }


### PR DESCRIPTION
### ❗️ 이슈 번호

[SDR-143]

<br><br>

### 📝 구현 내용

- 로그인 회원에 대한 리뷰 삭제 API
- 비회원 유저는 해당 API 사용할 수 없음 
- 통합테스트에서 테스트할 수 있는 모든 범위 테스트
- 인수테스트에서는 성공 케이스 1건과, 통합테스트에서 할 수 없는 테스트(비회원 검증, AOP) 진행
- 문제점) Soft Delete 시 element collections가 hard delete 되는 문제 / 예를 들어reviewRepository.delete() 메서드로 지우면 review_tags 테이블 데이터가 soft delete 안되기 때문에 review.delete() 도메인 객체를 통해 Soft Delete 하는 것으로 구현 => 추후 수정이 필요함 (티켓 만들어놓을게요)

### 🙇🏻‍♂️ 리뷰어에게 부탁합니다!

- Delete 객체는 jay의 가게 삭제 API PR 되면 그 후 리팩토링할게요

<br><br>

### 💡 참고 자료

API 문서

![image](https://user-images.githubusercontent.com/57086195/185532115-24c7f34a-ae65-43ae-b31d-e6c3c0fb4c17.png)

![image](https://user-images.githubusercontent.com/57086195/185532135-fc4cc5e5-3263-4089-a675-0da0db852ea9.png)


[SDR-143]: https://jjikmuk.atlassian.net/browse/SDR-143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ