### PR TITLE
SDR-36 유저 팔로우/언팔로우 기능

### DIFF
--- a/be/.gitignore
+++ b/be/.gitignore
@@ -106,9 +106,7 @@ Temporary Items
 .apdisk
 
 # 빌드 시 복사된 application.yml 파일
-src/main/resources/application.yml
-src/main/resources/application-*.yml
-src/main/resources/*-config.yml
+src/main/resources/*.yml
 
 # 빌드 시 복사된 db 관련 파일들
 src/main/resources/db/**

--- a/be/src/docs/asciidoc/user/user.adoc
+++ b/be/src/docs/asciidoc/user/user.adoc
@@ -12,3 +12,35 @@ operation::user_modify_acceptance_test/modify_user_profile_success[snippets='htt
 ==== `Response`
 
 operation::user_modify_acceptance_test/modify_user_profile_success[snippets='http-response']
+
+
+=== 유저 팔로우 요청
+
+API : `PUT /api/user/follow`
+
+
+=== `200 OK`
+
+==== `Request`
+
+operation::user_follow_acceptance_test/user_follow_success[snippets='http-request,request-body']
+
+==== `Response`
+
+operation::user_follow_acceptance_test/user_follow_success[snippets='http-response']
+
+
+=== 유저 언팔로우 요청
+
+API : `PUT /api/user/unfollow`
+
+
+=== `200 OK`
+
+==== `Request`
+
+operation::user_follow_acceptance_test/user_unfollow_success[snippets='http-request,request-body']
+
+==== `Response`
+
+operation::user_follow_acceptance_test/user_unfollow_success[snippets='http-response']

--- a/be/src/docs/asciidoc/user/user.adoc
+++ b/be/src/docs/asciidoc/user/user.adoc
@@ -23,11 +23,11 @@ API : `PUT /api/user/follow`
 
 ==== `Request`
 
-operation::user_follow_acceptance_test/user_follow_success[snippets='http-request,request-body']
+operation::user_follow_unfollow_acceptance_test/user_follow_success[snippets='http-request,request-body']
 
 ==== `Response`
 
-operation::user_follow_acceptance_test/user_follow_success[snippets='http-response']
+operation::user_follow_unfollow_acceptance_test/user_follow_success[snippets='http-response']
 
 
 === 유저 언팔로우 요청
@@ -39,8 +39,8 @@ API : `PUT /api/user/unfollow`
 
 ==== `Request`
 
-operation::user_follow_acceptance_test/user_unfollow_success[snippets='http-request,request-body']
+operation::user_follow_unfollow_acceptance_test/user_unfollow_success[snippets='http-request,request-body']
 
 ==== `Response`
 
-operation::user_follow_acceptance_test/user_unfollow_success[snippets='http-response']
+operation::user_follow_unfollow_acceptance_test/user_unfollow_success[snippets='http-response']

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/ResponseCodeAndMessages.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/ResponseCodeAndMessages.java
@@ -17,7 +17,10 @@ public enum ResponseCodeAndMessages implements CodeAndMessages {
     STORE_MODIFY_SUCCESS("T-S003", "가게 수정에 성공했습니다."),
 
     //User
-    USER_MODIFY_SUCCESS("T-U001", "유저 프로필 수정에 성공했습니다.");
+    USER_MODIFY_SUCCESS("T-U001", "유저 프로필 수정에 성공했습니다."),
+    USER_FOLLOW_SUCCESS("T-U002", "유저 팔로우에 성공했습니다."),
+    USER_UNFOLLOW_SUCCESS("T-U003", "유저 언팔로우에 성공했습니다.");
+
 
     private final String code;
     private final String message;

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/exception/ExceptionCodeAndMessages.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/exception/ExceptionCodeAndMessages.java
@@ -19,6 +19,8 @@ import com.jjikmuk.sikdorak.user.auth.exception.OAuthServerException;
 import com.jjikmuk.sikdorak.user.user.exception.DuplicateFollowingException;
 import com.jjikmuk.sikdorak.user.user.exception.DuplicateUserException;
 import com.jjikmuk.sikdorak.user.user.exception.DuplicateSendAcceptUserException;
+import com.jjikmuk.sikdorak.user.user.exception.InvalidFollowersException;
+import com.jjikmuk.sikdorak.user.user.exception.InvalidFollowingException;
 import com.jjikmuk.sikdorak.user.user.exception.InvalidUserEmailException;
 import com.jjikmuk.sikdorak.user.user.exception.InvalidUserNicknameException;
 import com.jjikmuk.sikdorak.user.user.exception.InvalidUserProfileImageUrlException;
@@ -53,11 +55,13 @@ public enum ExceptionCodeAndMessages implements CodeAndMessages {
     INVALID_USER_NIKCNAME("F-U002", "유효하지 않은 닉네임 입니다.", InvalidUserNicknameException.class),
     INVALID_USER_PROFILE_IMAGE("F-U003", "유효하지 않은 프로필 이미지 url의 형식입니다.", InvalidUserProfileImageUrlException.class),
     INVALID_USER_EMAIL("F-U004", "유효하지 않은 이메일 형식입니다.", InvalidUserEmailException.class),
-    NOT_FOUND_USER("F-U005", "존재하지 않는 유저입니다.", NotFoundUserException.class),
-    UNAUTHORIZED_USER("F-U006", "권한이 없는 유저입니다.", UnauthorizedUserException.class),
-    DUPLICATE_SEND_ACCEPT_USER("F-U007", "팔로우 요청자와 대상자의 정보가 중복됩니다.", DuplicateSendAcceptUserException.class),
-    DUPLICATE_FOLLOWING_USER("F-U008", "이미 팔로우 된 유저입니다", DuplicateFollowingException.class),
-    NOT_FOUND_FOLLOWING_USER("F-U009","존재하지 않는 팔로우 정보 입니다.", NotFoundFollowException.class),
+    INVALID_FOLLOWERS("F-U005", "유효하지 않은 팔로워 목록입니다.", InvalidFollowersException.class),
+    INVALID_FOLLOWINGS("F-U06", "유효하지 않은 팔로잉 목록입니다.", InvalidFollowingException.class),
+    NOT_FOUND_USER("F-U007", "존재하지 않는 유저입니다.", NotFoundUserException.class),
+    UNAUTHORIZED_USER("F-U008", "권한이 없는 유저입니다.", UnauthorizedUserException.class),
+    DUPLICATE_SEND_ACCEPT_USER("F-U009", "팔로우 요청자와 대상자의 정보가 중복됩니다.", DuplicateSendAcceptUserException.class),
+    DUPLICATE_FOLLOWING_USER("F-U0010", "이미 팔로우 된 유저입니다", DuplicateFollowingException.class),
+    NOT_FOUND_FOLLOWING_USER("F-U011","존재하지 않는 팔로우 정보 입니다.", NotFoundFollowException.class),
 
     //OAuth
     FAILED_CONNECTION_WITH_OAUTH_SERVER("F-O001", "OAuth 서버와의 통신이 원할하지 않습니다.", OAuthServerException.class),

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/exception/ExceptionCodeAndMessages.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/exception/ExceptionCodeAndMessages.java
@@ -16,10 +16,13 @@ import com.jjikmuk.sikdorak.store.exception.NotFoundStoreException;
 import com.jjikmuk.sikdorak.user.auth.exception.InvalidTokenException;
 import com.jjikmuk.sikdorak.user.auth.exception.NeedLoginException;
 import com.jjikmuk.sikdorak.user.auth.exception.OAuthServerException;
+import com.jjikmuk.sikdorak.user.user.exception.DuplicateFollowingException;
 import com.jjikmuk.sikdorak.user.user.exception.DuplicateUserException;
+import com.jjikmuk.sikdorak.user.user.exception.DuplicateSendAcceptUserException;
 import com.jjikmuk.sikdorak.user.user.exception.InvalidUserEmailException;
 import com.jjikmuk.sikdorak.user.user.exception.InvalidUserNicknameException;
 import com.jjikmuk.sikdorak.user.user.exception.InvalidUserProfileImageUrlException;
+import com.jjikmuk.sikdorak.user.user.exception.NotFoundFollowException;
 import com.jjikmuk.sikdorak.user.user.exception.NotFoundUserException;
 import com.jjikmuk.sikdorak.user.user.exception.UnauthorizedUserException;
 import java.util.Arrays;
@@ -52,6 +55,9 @@ public enum ExceptionCodeAndMessages implements CodeAndMessages {
     INVALID_USER_EMAIL("F-U004", "유효하지 않은 이메일 형식입니다.", InvalidUserEmailException.class),
     NOT_FOUND_USER("F-U005", "존재하지 않는 유저입니다.", NotFoundUserException.class),
     UNAUTHORIZED_USER("F-U006", "권한이 없는 유저입니다.", UnauthorizedUserException.class),
+    DUPLICATE_SEND_ACCEPT_USER("F-U007", "팔로우 요청자와 대상자의 정보가 중복됩니다.", DuplicateSendAcceptUserException.class),
+    DUPLICATE_FOLLOWING_USER("F-U008", "이미 팔로우 된 유저입니다", DuplicateFollowingException.class),
+    NOT_FOUND_FOLLOWING_USER("F-U009","존재하지 않는 팔로우 정보 입니다.", NotFoundFollowException.class),
 
     //OAuth
     FAILED_CONNECTION_WITH_OAUTH_SERVER("F-O001", "OAuth 서버와의 통신이 원할하지 않습니다.", OAuthServerException.class),

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/controller/UserController.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/controller/UserController.java
@@ -5,6 +5,7 @@ import com.jjikmuk.sikdorak.common.aop.UserOnly;
 import com.jjikmuk.sikdorak.common.response.CommonResponseEntity;
 import com.jjikmuk.sikdorak.user.auth.controller.LoginUser;
 import com.jjikmuk.sikdorak.user.auth.domain.AuthenticatedUser;
+import com.jjikmuk.sikdorak.user.user.controller.request.UserFollowAndUnfollowRequest;
 import com.jjikmuk.sikdorak.user.user.controller.request.UserModifyRequest;
 import com.jjikmuk.sikdorak.user.user.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -29,5 +30,27 @@ public class UserController {
         return new CommonResponseEntity<>(ResponseCodeAndMessages.USER_MODIFY_SUCCESS,
             HttpStatus.OK);
 
+    }
+
+    @UserOnly
+    @PutMapping("api/user/follow")
+    public CommonResponseEntity<Void> follow(@AuthenticatedUser LoginUser loginUser,
+        @RequestBody UserFollowAndUnfollowRequest userFollowAndUnfollowRequest) {
+
+        userService.followUser(loginUser, userFollowAndUnfollowRequest);
+
+        return new CommonResponseEntity<>(ResponseCodeAndMessages.USER_FOLLOW_SUCCESS,
+            HttpStatus.OK);
+    }
+
+    @UserOnly
+    @PutMapping("api/user/unfollow")
+    public CommonResponseEntity<Void> unfollow(@AuthenticatedUser LoginUser loginUser,
+        @RequestBody UserFollowAndUnfollowRequest userFollowAndUnfollowRequest) {
+
+        userService.unfollowUser(loginUser, userFollowAndUnfollowRequest);
+
+        return new CommonResponseEntity<>(ResponseCodeAndMessages.USER_UNFOLLOW_SUCCESS,
+            HttpStatus.OK);
     }
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/controller/UserController.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/controller/UserController.java
@@ -33,7 +33,7 @@ public class UserController {
     }
 
     @UserOnly
-    @PutMapping("api/user/follow")
+    @PutMapping("/api/user/follow")
     public CommonResponseEntity<Void> follow(@AuthenticatedUser LoginUser loginUser,
         @RequestBody UserFollowAndUnfollowRequest userFollowAndUnfollowRequest) {
 
@@ -44,7 +44,7 @@ public class UserController {
     }
 
     @UserOnly
-    @PutMapping("api/user/unfollow")
+    @PutMapping("/api/user/unfollow")
     public CommonResponseEntity<Void> unfollow(@AuthenticatedUser LoginUser loginUser,
         @RequestBody UserFollowAndUnfollowRequest userFollowAndUnfollowRequest) {
 

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/controller/request/UserFollowAndUnfollowRequest.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/controller/request/UserFollowAndUnfollowRequest.java
@@ -1,0 +1,17 @@
+package com.jjikmuk.sikdorak.user.user.controller.request;
+
+import javax.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UserFollowAndUnfollowRequest {
+
+    @NotNull
+    private long userId;
+
+    public UserFollowAndUnfollowRequest(long userId) {
+        this.userId = userId;
+    }
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/controller/request/UserFollowAndUnfollowRequest.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/controller/request/UserFollowAndUnfollowRequest.java
@@ -1,5 +1,7 @@
 package com.jjikmuk.sikdorak.user.user.controller.request;
 
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,7 +11,10 @@ import lombok.NoArgsConstructor;
 public class UserFollowAndUnfollowRequest {
 
     @NotNull
+    @Min(1)
+    @Max(Long.MAX_VALUE)
     private long userId;
+
 
     public UserFollowAndUnfollowRequest(long userId) {
         this.userId = userId;

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/domain/Followers.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/domain/Followers.java
@@ -1,0 +1,26 @@
+package com.jjikmuk.sikdorak.user.user.domain;
+
+import java.util.HashSet;
+import java.util.Set;
+import javax.persistence.CollectionTable;
+import javax.persistence.Column;
+import javax.persistence.ElementCollection;
+import javax.persistence.Embeddable;
+import javax.persistence.JoinColumn;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Followers {
+
+    @ElementCollection
+    @CollectionTable(
+        name = "follower",
+        joinColumns = @JoinColumn(name = "user_id")
+    )
+    @Column(name = "follower")
+    private Set<Long> follower = new HashSet<>();
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/domain/Followers.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/domain/Followers.java
@@ -1,9 +1,10 @@
 package com.jjikmuk.sikdorak.user.user.domain;
 
+import com.jjikmuk.sikdorak.user.user.exception.InvalidFollowersException;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 import javax.persistence.CollectionTable;
-import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Embeddable;
 import javax.persistence.JoinColumn;
@@ -18,9 +19,16 @@ public class Followers {
 
     @ElementCollection
     @CollectionTable(
-        name = "follower",
+        name = "user_followers",
         joinColumns = @JoinColumn(name = "user_id")
     )
-    @Column(name = "follower")
     private Set<Long> follower = new HashSet<>();
+
+    public Followers(Set<Long> follower) {
+        if (Objects.isNull(follower)) {
+            throw new InvalidFollowersException();
+        }
+
+        this.follower = follower;
+    }
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/domain/Followers.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/domain/Followers.java
@@ -1,8 +1,6 @@
 package com.jjikmuk.sikdorak.user.user.domain;
 
-import com.jjikmuk.sikdorak.user.user.exception.InvalidFollowersException;
 import java.util.HashSet;
-import java.util.Objects;
 import java.util.Set;
 import javax.persistence.CollectionTable;
 import javax.persistence.ElementCollection;
@@ -24,11 +22,4 @@ public class Followers {
     )
     private Set<Long> follower = new HashSet<>();
 
-    public Followers(Set<Long> follower) {
-        if (Objects.isNull(follower)) {
-            throw new InvalidFollowersException();
-        }
-
-        this.follower = follower;
-    }
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/domain/Followings.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/domain/Followings.java
@@ -1,9 +1,10 @@
 package com.jjikmuk.sikdorak.user.user.domain;
 
+import com.jjikmuk.sikdorak.user.user.exception.InvalidFollowingException;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 import javax.persistence.CollectionTable;
-import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Embeddable;
 import javax.persistence.JoinColumn;
@@ -18,10 +19,17 @@ public class Followings {
 
     @ElementCollection
     @CollectionTable(
-        name = "following",
+        name = "user_following",
         joinColumns = @JoinColumn(name = "user_id")
     )
-    @Column(name = "following")
     private Set<Long> following = new HashSet<>();
 
+    public Followings(Set<Long> following) {
+
+        if (Objects.isNull(following)) {
+            throw new InvalidFollowingException();
+        }
+
+        this.following = following;
+    }
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/domain/Followings.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/domain/Followings.java
@@ -1,0 +1,27 @@
+package com.jjikmuk.sikdorak.user.user.domain;
+
+import java.util.HashSet;
+import java.util.Set;
+import javax.persistence.CollectionTable;
+import javax.persistence.Column;
+import javax.persistence.ElementCollection;
+import javax.persistence.Embeddable;
+import javax.persistence.JoinColumn;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Followings {
+
+    @ElementCollection
+    @CollectionTable(
+        name = "following",
+        joinColumns = @JoinColumn(name = "user_id")
+    )
+    @Column(name = "following")
+    private Set<Long> following = new HashSet<>();
+
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/domain/Followings.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/domain/Followings.java
@@ -1,8 +1,6 @@
 package com.jjikmuk.sikdorak.user.user.domain;
 
-import com.jjikmuk.sikdorak.user.user.exception.InvalidFollowingException;
 import java.util.HashSet;
-import java.util.Objects;
 import java.util.Set;
 import javax.persistence.CollectionTable;
 import javax.persistence.ElementCollection;
@@ -24,12 +22,4 @@ public class Followings {
     )
     private Set<Long> following = new HashSet<>();
 
-    public Followings(Set<Long> following) {
-
-        if (Objects.isNull(following)) {
-            throw new InvalidFollowingException();
-        }
-
-        this.following = following;
-    }
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/domain/User.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/domain/User.java
@@ -1,7 +1,6 @@
 package com.jjikmuk.sikdorak.user.user.domain;
 
 import com.jjikmuk.sikdorak.common.domain.BaseTimeEntity;
-import java.util.HashSet;
 import java.util.Set;
 import javax.persistence.Column;
 import javax.persistence.Embedded;
@@ -42,27 +41,17 @@ public class User extends BaseTimeEntity {
     private Followers followers;
 
     public User(Long uniqueId, String nickname, String profileImage, String email) {
-        this(null, uniqueId, nickname, profileImage, email, new HashSet<>(), new HashSet<>());
+        this(null, uniqueId, nickname, profileImage, email);
     }
 
     public User(Long id, Long uniqueId, String nickname, String profileImage, String email) {
-        this(id, uniqueId, nickname, profileImage, email, new HashSet<>(), new HashSet<>());
-    }
-
-    public User(Long uniqueId, String nickname, String profileImage, String email,
-        Set<Long> followings, Set<Long> followers) {
-        this(null, uniqueId, nickname, profileImage, email, followings, followers);
-    }
-
-    public User(Long id,Long uniqueId, String nickname, String profileImage, String email,
-        Set<Long> followings, Set<Long> followers) {
         this.id = id;
         this.uniqueId = uniqueId;
         this.nickname = new Nickname(nickname);
         this.profileImage = new ProfileImage(profileImage);
         this.email = new Email(email);
-        this.followings = new Followings(followings);
-        this.followers = new Followers(followers);
+        this.followings = new Followings();
+        this.followers = new Followers();
     }
 
     public Long getId() {

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/domain/User.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/domain/User.java
@@ -1,6 +1,7 @@
 package com.jjikmuk.sikdorak.user.user.domain;
 
 import com.jjikmuk.sikdorak.common.domain.BaseTimeEntity;
+import java.util.HashSet;
 import java.util.Set;
 import javax.persistence.Column;
 import javax.persistence.Embedded;
@@ -41,29 +42,28 @@ public class User extends BaseTimeEntity {
     private Followers followers;
 
     public User(Long uniqueId, String nickname, String profileImage, String email) {
-        this(null, uniqueId, nickname, profileImage, email);
+        this(null, uniqueId, nickname, profileImage, email, new HashSet<>(), new HashSet<>());
     }
 
     public User(Long id, Long uniqueId, String nickname, String profileImage, String email) {
+        this(id, uniqueId, nickname, profileImage, email, new HashSet<>(), new HashSet<>());
+    }
+
+    public User(Long uniqueId, String nickname, String profileImage, String email,
+        Set<Long> followings, Set<Long> followers) {
+        this(null, uniqueId, nickname, profileImage, email, followings, followers);
+    }
+
+    public User(Long id,Long uniqueId, String nickname, String profileImage, String email,
+        Set<Long> followings, Set<Long> followers) {
         this.id = id;
         this.uniqueId = uniqueId;
         this.nickname = new Nickname(nickname);
         this.profileImage = new ProfileImage(profileImage);
         this.email = new Email(email);
-        this.followings = new Followings();
-        this.followers = new Followers();
+        this.followings = new Followings(followings);
+        this.followers = new Followers(followers);
     }
-//
-//    public User(Long id, Long uniqueId, String nickname, String profileImage, String email,
-//        Set<Long> followings, Set<Long> followers) {
-//        this.id = id;
-//        this.uniqueId = uniqueId;
-//        this.nickname = new Nickname(nickname);
-//        this.profileImage = new ProfileImage(profileImage);
-//        this.email = new Email(email);
-//        this.followings = new Followings(followings);
-//        this.followers = new Followers(followers);
-//    }
 
     public Long getId() {
         return id;

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/domain/User.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/domain/User.java
@@ -1,17 +1,20 @@
 package com.jjikmuk.sikdorak.user.user.domain;
 
 import com.jjikmuk.sikdorak.common.domain.BaseTimeEntity;
+import java.util.Set;
 import javax.persistence.Column;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
 
 @Entity
 @NoArgsConstructor
+@EqualsAndHashCode(callSuper = false)
 public class User extends BaseTimeEntity {
 
     @Id
@@ -31,6 +34,12 @@ public class User extends BaseTimeEntity {
     @Embedded
     private Email email;
 
+    @Embedded
+    private Followings followings;
+
+    @Embedded
+    private Followers followers;
+
     public User(Long uniqueId, String nickname, String profileImage, String email) {
         this(null, uniqueId, nickname, profileImage, email);
     }
@@ -41,7 +50,20 @@ public class User extends BaseTimeEntity {
         this.nickname = new Nickname(nickname);
         this.profileImage = new ProfileImage(profileImage);
         this.email = new Email(email);
+        this.followings = new Followings();
+        this.followers = new Followers();
     }
+//
+//    public User(Long id, Long uniqueId, String nickname, String profileImage, String email,
+//        Set<Long> followings, Set<Long> followers) {
+//        this.id = id;
+//        this.uniqueId = uniqueId;
+//        this.nickname = new Nickname(nickname);
+//        this.profileImage = new ProfileImage(profileImage);
+//        this.email = new Email(email);
+//        this.followings = new Followings(followings);
+//        this.followers = new Followers(followers);
+//    }
 
     public Long getId() {
         return id;
@@ -63,9 +85,48 @@ public class User extends BaseTimeEntity {
         return email.getEmail();
     }
 
+    public Set<Long> getFollowings() {
+        return followings.getFollowing();
+    }
+
+    public Set<Long> getFollowers() {
+        return followers.getFollower();
+    }
+
     public void editAll(String nickname, String email, String profileImage) {
         this.nickname = new Nickname(nickname);
         this.email = new Email(email);
         this.profileImage = new ProfileImage(profileImage);
     }
+
+    public void follow(User acceptUser) {
+        acceptUser.addFollower(this);
+        this.addFollowing(acceptUser);
+    }
+
+    public void unfollow(User acceptUser) {
+        acceptUser.removeFollower(this);
+        this.removeFollowing(acceptUser);
+    }
+
+    public boolean isFollowing(User acceptUser) {
+        return this.getFollowings().contains(acceptUser.getId());
+    }
+
+    private void addFollower(User sendUser) {
+        this.getFollowers().add(sendUser.id);
+    }
+
+    private void addFollowing(User acceptUser) {
+        this.getFollowings().add(acceptUser.id);
+    }
+
+    private void removeFollower(User sendUser) {
+        this.getFollowers().remove(sendUser.getId());
+    }
+
+    private void removeFollowing(User acceptUser) {
+        this.getFollowings().remove(acceptUser.getId());
+    }
+
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/domain/UserRespository.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/domain/UserRespository.java
@@ -1,7 +1,9 @@
 package com.jjikmuk.sikdorak.user.user.domain;
 
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface UserRespository extends JpaRepository<User, Long> {
 
@@ -11,5 +13,10 @@ public interface UserRespository extends JpaRepository<User, Long> {
 
     boolean existsByUniqueId(long uniqueId);
 
+    @Query("select f from User as u join u.followers.follower f where u.id = :userId")
+    Set<Long> findFollowers(long userId);
+
+    @Query("select f from User as u join u.followings.following f where u.id = :userId")
+    Set<Long> findFollowings(long userId);
 
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/exception/DuplicateFollowingException.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/exception/DuplicateFollowingException.java
@@ -1,0 +1,12 @@
+package com.jjikmuk.sikdorak.user.user.exception;
+
+import com.jjikmuk.sikdorak.common.exception.SikdorakRuntimeException;
+import org.springframework.http.HttpStatus;
+
+public class DuplicateFollowingException extends SikdorakRuntimeException {
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HttpStatus.BAD_REQUEST;
+    }
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/exception/DuplicateSendAcceptUserException.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/exception/DuplicateSendAcceptUserException.java
@@ -1,0 +1,12 @@
+package com.jjikmuk.sikdorak.user.user.exception;
+
+import com.jjikmuk.sikdorak.common.exception.SikdorakRuntimeException;
+import org.springframework.http.HttpStatus;
+
+public class DuplicateSendAcceptUserException extends SikdorakRuntimeException {
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HttpStatus.BAD_REQUEST;
+    }
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/exception/InvalidFollowersException.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/exception/InvalidFollowersException.java
@@ -1,0 +1,13 @@
+package com.jjikmuk.sikdorak.user.user.exception;
+
+import com.jjikmuk.sikdorak.common.exception.SikdorakRuntimeException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidFollowersException extends SikdorakRuntimeException {
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HttpStatus.BAD_REQUEST;
+    }
+
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/exception/InvalidFollowingException.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/exception/InvalidFollowingException.java
@@ -1,0 +1,12 @@
+package com.jjikmuk.sikdorak.user.user.exception;
+
+import com.jjikmuk.sikdorak.common.exception.SikdorakRuntimeException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidFollowingException extends SikdorakRuntimeException {
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HttpStatus.BAD_REQUEST;
+    }
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/exception/NotFoundFollowException.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/exception/NotFoundFollowException.java
@@ -1,0 +1,12 @@
+package com.jjikmuk.sikdorak.user.user.exception;
+
+import com.jjikmuk.sikdorak.common.exception.SikdorakRuntimeException;
+import org.springframework.http.HttpStatus;
+
+public class NotFoundFollowException extends SikdorakRuntimeException {
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HttpStatus.NOT_FOUND;
+    }
+}

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/user/UserFollowAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/user/UserFollowAcceptanceTest.java
@@ -1,0 +1,74 @@
+package com.jjikmuk.sikdorak.acceptance.user.user;
+
+import static com.jjikmuk.sikdorak.acceptance.user.user.UserSnippet.USER_FOLLOW_REQUEST_SNIPPET;
+import static com.jjikmuk.sikdorak.acceptance.user.user.UserSnippet.USER_FOLLOW_RESPONSE_SNIPPET;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
+
+import com.jjikmuk.sikdorak.acceptance.InitAcceptanceTest;
+import com.jjikmuk.sikdorak.common.ResponseCodeAndMessages;
+import com.jjikmuk.sikdorak.user.user.controller.request.UserFollowAndUnfollowRequest;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+@DisplayName("유저 팔로우 인수 테스트")
+class UserFollowAcceptanceTest extends InitAcceptanceTest {
+
+    @Test
+    @DisplayName("유저의 팔로우 요청이 올바른 경우라면 성공 상태코드를 응답한다.")
+    void user_follow_success() {
+
+        UserFollowAndUnfollowRequest userFollowAndUnfollowRequest = new UserFollowAndUnfollowRequest(testData.user2.getId());
+
+        given(this.spec)
+            .filter(document(
+                DEFAULT_RESTDOC_PATH,
+                USER_FOLLOW_REQUEST_SNIPPET,
+                USER_FOLLOW_RESPONSE_SNIPPET
+            ))
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+            .contentType(ContentType.JSON)
+            .header("Authorization", testData.user1ValidAuthorizationHeader)
+            .body(userFollowAndUnfollowRequest)
+
+        .when()
+            .put("/api/user/follow")
+
+        .then()
+            .statusCode(HttpStatus.OK.value())
+            .body("code", equalTo(ResponseCodeAndMessages.USER_FOLLOW_SUCCESS.getCode()))
+            .body("message", equalTo(ResponseCodeAndMessages.USER_FOLLOW_SUCCESS.getMessage()));
+    }
+
+    @Test
+    @DisplayName("유저의 팔로우 취소 요청이 올바른 경우라면 성공 상태코드를 응답한다.")
+    void user_unfollow_success() {
+
+        UserFollowAndUnfollowRequest userFollowAndUnfollowRequest = new UserFollowAndUnfollowRequest(testData.user2.getId());
+
+        given(this.spec)
+            .filter(document(
+                DEFAULT_RESTDOC_PATH,
+                USER_FOLLOW_REQUEST_SNIPPET,
+                USER_FOLLOW_RESPONSE_SNIPPET
+            ))
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+            .contentType(ContentType.JSON)
+            .header("Authorization", testData.user1ValidAuthorizationHeader)
+            .body(userFollowAndUnfollowRequest)
+
+        .when()
+            .put("/api/user/unfollow")
+
+        .then()
+            .statusCode(HttpStatus.OK.value())
+            .body("code", equalTo(ResponseCodeAndMessages.USER_UNFOLLOW_SUCCESS.getCode()))
+            .body("message", equalTo(ResponseCodeAndMessages.USER_UNFOLLOW_SUCCESS.getMessage()));
+
+    }
+
+}

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/user/UserFollowAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/user/UserFollowAcceptanceTest.java
@@ -8,6 +8,7 @@ import static org.springframework.restdocs.restassured3.RestAssuredRestDocumenta
 
 import com.jjikmuk.sikdorak.acceptance.InitAcceptanceTest;
 import com.jjikmuk.sikdorak.common.ResponseCodeAndMessages;
+import com.jjikmuk.sikdorak.common.exception.ExceptionCodeAndMessages;
 import com.jjikmuk.sikdorak.user.user.controller.request.UserFollowAndUnfollowRequest;
 import io.restassured.http.ContentType;
 import org.junit.jupiter.api.DisplayName;
@@ -45,7 +46,7 @@ class UserFollowAcceptanceTest extends InitAcceptanceTest {
     }
 
     @Test
-    @DisplayName("유저의 팔로우 취소 요청이 올바른 경우라면 성공 상태코드를 응답한다.")
+    @DisplayName("유저의 언팔로우 요청이 올바른 경우라면 성공 상태코드를 응답한다.")
     void user_unfollow_success() {
 
         UserFollowAndUnfollowRequest userFollowAndUnfollowRequest = new UserFollowAndUnfollowRequest(testData.user2.getId());
@@ -58,7 +59,7 @@ class UserFollowAcceptanceTest extends InitAcceptanceTest {
             ))
             .accept(MediaType.APPLICATION_JSON_VALUE)
             .contentType(ContentType.JSON)
-            .header("Authorization", testData.user1ValidAuthorizationHeader)
+            .header("Authorization", testData.user3ValidAuthorizationHeader)
             .body(userFollowAndUnfollowRequest)
 
         .when()
@@ -68,6 +69,59 @@ class UserFollowAcceptanceTest extends InitAcceptanceTest {
             .statusCode(HttpStatus.OK.value())
             .body("code", equalTo(ResponseCodeAndMessages.USER_UNFOLLOW_SUCCESS.getCode()))
             .body("message", equalTo(ResponseCodeAndMessages.USER_UNFOLLOW_SUCCESS.getMessage()));
+
+    }
+
+    @Test
+    @DisplayName("비회원이 유저에 대한 팔로우 요청을 하면 실패 상태코드를 반환한다.")
+    void anonymous_user_follow_fail() {
+
+        UserFollowAndUnfollowRequest userFollowAndUnfollowRequest = new UserFollowAndUnfollowRequest(testData.user2.getId());
+
+        given(this.spec)
+            .filter(document(
+                DEFAULT_RESTDOC_PATH,
+                USER_FOLLOW_REQUEST_SNIPPET,
+                USER_FOLLOW_RESPONSE_SNIPPET
+            ))
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+            .contentType(ContentType.JSON)
+            .body(userFollowAndUnfollowRequest)
+
+        .when()
+            .put("/api/user/follow")
+
+        .then()
+            .statusCode(HttpStatus.UNAUTHORIZED.value())
+            .body("code", equalTo(ExceptionCodeAndMessages.NEED_LOGIN.getCode()))
+            .body("message", equalTo(ExceptionCodeAndMessages.NEED_LOGIN.getMessage()));
+
+    }
+
+
+    @Test
+    @DisplayName("비회원이 유저에 대한 언팔로우 요청을 하면 실패 상태코드를 반환한다.")
+    void anonymous_user_unfollow_fail() {
+
+        UserFollowAndUnfollowRequest userFollowAndUnfollowRequest = new UserFollowAndUnfollowRequest(testData.user2.getId());
+
+        given(this.spec)
+            .filter(document(
+                DEFAULT_RESTDOC_PATH,
+                USER_FOLLOW_REQUEST_SNIPPET,
+                USER_FOLLOW_RESPONSE_SNIPPET
+            ))
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+            .contentType(ContentType.JSON)
+            .body(userFollowAndUnfollowRequest)
+
+        .when()
+            .put("/api/user/unfollow")
+
+        .then()
+            .statusCode(HttpStatus.UNAUTHORIZED.value())
+            .body("code", equalTo(ExceptionCodeAndMessages.NEED_LOGIN.getCode()))
+            .body("message", equalTo(ExceptionCodeAndMessages.NEED_LOGIN.getMessage()));
 
     }
 

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/user/UserFollowUnfollowAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/user/UserFollowUnfollowAcceptanceTest.java
@@ -16,14 +16,14 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
-@DisplayName("유저 팔로우 인수 테스트")
-class UserFollowAcceptanceTest extends InitAcceptanceTest {
+@DisplayName("UserFollowUnfollow 인수 테스트")
+class UserFollowUnfollowAcceptanceTest extends InitAcceptanceTest {
 
     @Test
     @DisplayName("유저의 팔로우 요청이 올바른 경우라면 성공 상태코드를 응답한다.")
     void user_follow_success() {
 
-        UserFollowAndUnfollowRequest userFollowAndUnfollowRequest = new UserFollowAndUnfollowRequest(testData.user2.getId());
+        UserFollowAndUnfollowRequest userFollowAndUnfollowRequest = new UserFollowAndUnfollowRequest(testData.followAcceptUser.getId());
 
         given(this.spec)
             .filter(document(
@@ -49,7 +49,7 @@ class UserFollowAcceptanceTest extends InitAcceptanceTest {
     @DisplayName("유저의 언팔로우 요청이 올바른 경우라면 성공 상태코드를 응답한다.")
     void user_unfollow_success() {
 
-        UserFollowAndUnfollowRequest userFollowAndUnfollowRequest = new UserFollowAndUnfollowRequest(testData.user2.getId());
+        UserFollowAndUnfollowRequest userFollowAndUnfollowRequest = new UserFollowAndUnfollowRequest(testData.followAcceptUser.getId());
 
         given(this.spec)
             .filter(document(
@@ -59,7 +59,7 @@ class UserFollowAcceptanceTest extends InitAcceptanceTest {
             ))
             .accept(MediaType.APPLICATION_JSON_VALUE)
             .contentType(ContentType.JSON)
-            .header("Authorization", testData.user3ValidAuthorizationHeader)
+            .header("Authorization", testData.followSendUserValidAuthorizationHeader)
             .body(userFollowAndUnfollowRequest)
 
         .when()
@@ -76,7 +76,7 @@ class UserFollowAcceptanceTest extends InitAcceptanceTest {
     @DisplayName("비회원이 유저에 대한 팔로우 요청을 하면 실패 상태코드를 반환한다.")
     void anonymous_user_follow_fail() {
 
-        UserFollowAndUnfollowRequest userFollowAndUnfollowRequest = new UserFollowAndUnfollowRequest(testData.user2.getId());
+        UserFollowAndUnfollowRequest userFollowAndUnfollowRequest = new UserFollowAndUnfollowRequest(testData.followAcceptUser.getId());
 
         given(this.spec)
             .filter(document(
@@ -103,7 +103,7 @@ class UserFollowAcceptanceTest extends InitAcceptanceTest {
     @DisplayName("비회원이 유저에 대한 언팔로우 요청을 하면 실패 상태코드를 반환한다.")
     void anonymous_user_unfollow_fail() {
 
-        UserFollowAndUnfollowRequest userFollowAndUnfollowRequest = new UserFollowAndUnfollowRequest(testData.user2.getId());
+        UserFollowAndUnfollowRequest userFollowAndUnfollowRequest = new UserFollowAndUnfollowRequest(testData.followAcceptUser.getId());
 
         given(this.spec)
             .filter(document(

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/user/UserModifyAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/user/UserModifyAcceptanceTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
-@DisplayName("유저 프로필 수정 인수테스트")
+@DisplayName("UserModify 인수테스트")
 class UserModifyAcceptanceTest extends InitAcceptanceTest {
 
     @Test

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/user/UserSnippet.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/user/UserSnippet.java
@@ -4,6 +4,7 @@ import static com.jjikmuk.sikdorak.acceptance.DocumentFormatGenerator.commonRequ
 import static com.jjikmuk.sikdorak.acceptance.DocumentFormatGenerator.commonResponseNonFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 
+import com.jjikmuk.sikdorak.user.user.controller.request.UserFollowAndUnfollowRequest;
 import com.jjikmuk.sikdorak.user.user.controller.request.UserModifyRequest;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.restdocs.snippet.Snippet;
@@ -18,5 +19,12 @@ public interface UserSnippet {
     );
 
     Snippet USER_MODIFY_RESPONSE_SNIPPET = commonResponseNonFields();
+
+    Snippet USER_FOLLOW_REQUEST_SNIPPET = commonRequestFieldsWithValidConstraints(
+        UserFollowAndUnfollowRequest.class,
+        fieldWithPath("userId").type(JsonFieldType.NUMBER).description("팔로우 할 유저 아이디")
+    );
+
+    Snippet USER_FOLLOW_RESPONSE_SNIPPET = commonResponseNonFields();
 
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/common/DatabaseConfigurator.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/common/DatabaseConfigurator.java
@@ -13,7 +13,6 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.time.LocalDate;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
@@ -44,43 +43,20 @@ public class DatabaseConfigurator implements InitializingBean {
     public Store store;
     public User user1;
     public User user2;
-    public User user3;
+    public User followSendUser;
+    public User followAcceptUser;
     public String user1ValidAuthorizationHeader;
     public String user2ValidAuthorizationHeader;
-    public String user3ValidAuthorizationHeader;
+    public String followSendUserValidAuthorizationHeader;
     public String userInvalidAuthorizationHeader;
     public Review review;
 
     public void initDataSource() {
-        this.store = storeRepository.save(new Store("맛있는가게",
-            "02-0000-0000",
-            "서울시 송파구 좋은길 1",
-            "1층 101호",
-            37.5093890,
-            127.105143));
-        this.user1 = userRespository.save(
-            new User(12345678L, "test-user1", "https://profile1.com", "sikdorak1@gmail.com"));
-        this.user2 = userRespository.save(
-            new User(87654321L, "test-user2", "https://profile2.com", "sikdorak2@gmail.com"));
-        this.user3 = userRespository.save(
-            new User(23456781L, "test-user3", "https://profile3.com", "sikdorak3@gmail.com",
-                new HashSet<>(List.of(user2.getId())), new HashSet<>()));
-        this.user1ValidAuthorizationHeader =
-            "Bearer " + jwtProvider.createAccessToken(String.valueOf(this.user1.getId()));
-        this.user2ValidAuthorizationHeader =
-            "Bearer " + jwtProvider.createAccessToken(String.valueOf(this.user2.getId()));
-        this.user3ValidAuthorizationHeader =
-            "Bearer " + jwtProvider.createAccessToken(String.valueOf(this.user3.getId()));
-        this.userInvalidAuthorizationHeader = "Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6IjIzNjgyMjM2MzgiLCJleHAiOjE2MzA2MzkzNTF9.SnT_Nxgspg3cUomCieDyBRH9TowtWh21YIfAKntuguA";
-
-        this.review = reviewRepository.save(new Review(this.user1.getId(),
-            this.store.getId(),
-            "Test review contents",
-            3.f,
-            "public",
-            LocalDate.of(2022, 1, 1),
-            List.of("tag1", "tag2"),
-            List.of("https://s3.ap-northeast-2.amazonaws.com/sikdorak/test.jpg")));
+        initStoreData();
+        initBasicUserData();
+        initFollowingUserData();
+        initUserAuthorizationData();
+        initReviewData();
     }
 
     public void clear() {
@@ -91,6 +67,7 @@ public class DatabaseConfigurator implements InitializingBean {
     public void afterPropertiesSet() {
         entityManager.unwrap(Session.class).doWork(this::extractTableNames);
     }
+
 
     // reference : https://www.baeldung.com/jdbc-database-metadata
     private void extractTableNames(Connection connection) throws SQLException {
@@ -121,4 +98,54 @@ public class DatabaseConfigurator implements InitializingBean {
         }
     }
 
+    private void initStoreData() {
+        this.store = storeRepository.save(new Store("맛있는가게",
+            "02-0000-0000",
+            "서울시 송파구 좋은길 1",
+            "1층 101호",
+            37.5093890,
+            127.105143));
+    }
+
+    private void initBasicUserData() {
+        this.user1 = userRespository.save(
+            new User(12345678L, "test-user1", "https://profile1.com", "sikdorak1@gmail.com"));
+        this.user2 = userRespository.save(
+            new User(87654321L, "test-user2", "https://profile2.com", "sikdorak2@gmail.com"));
+    }
+
+
+    private void initFollowingUserData() {
+        User sendUser = userRespository.save(
+            new User(23456781L, "test-user3", "https://profile3.com", "sikdorak3@gmail.com"));
+        User acceptUser = userRespository.save(
+            new User(76543218L, "test-user4", "https://profile4.com", "sikdorak4@gmail.com"));
+
+        sendUser.follow(acceptUser);
+
+        this.followSendUser = userRespository.save(sendUser);
+        this.followAcceptUser = userRespository.save(acceptUser);
+
+    }
+
+    private void initUserAuthorizationData() {
+        this.user1ValidAuthorizationHeader =
+            "Bearer " + jwtProvider.createAccessToken(String.valueOf(this.user1.getId()));
+        this.user2ValidAuthorizationHeader =
+            "Bearer " + jwtProvider.createAccessToken(String.valueOf(this.user2.getId()));
+        this.followSendUserValidAuthorizationHeader =
+            "Bearer " + jwtProvider.createAccessToken(String.valueOf(this.followSendUser.getId()));
+        this.userInvalidAuthorizationHeader = "Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6IjIzNjgyMjM2MzgiLCJleHAiOjE2MzA2MzkzNTF9.SnT_Nxgspg3cUomCieDyBRH9TowtWh21YIfAKntuguA";
+    }
+
+    private void initReviewData() {
+        this.review = reviewRepository.save(new Review(this.user1.getId(),
+            this.store.getId(),
+            "Test review contents",
+            3.f,
+            "public",
+            LocalDate.of(2022, 1, 1),
+            List.of("tag1", "tag2"),
+            List.of("https://s3.ap-northeast-2.amazonaws.com/sikdorak/test.jpg")));
+    }
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/common/DatabaseConfigurator.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/common/DatabaseConfigurator.java
@@ -13,6 +13,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
@@ -24,93 +25,100 @@ import org.springframework.stereotype.Component;
 @Component
 public class DatabaseConfigurator implements InitializingBean {
 
-	@PersistenceContext
-	private EntityManager entityManager;
-	private List<String> tableNames;
+    @PersistenceContext
+    private EntityManager entityManager;
+    private List<String> tableNames;
 
-	@Autowired
-	private StoreRepository storeRepository;
+    @Autowired
+    private StoreRepository storeRepository;
 
-	@Autowired
-	private UserRespository userRespository;
+    @Autowired
+    private UserRespository userRespository;
 
-	@Autowired
-	private ReviewRepository reviewRepository;
+    @Autowired
+    private ReviewRepository reviewRepository;
 
-	@Autowired
-	private JwtProvider jwtProvider;
+    @Autowired
+    private JwtProvider jwtProvider;
 
-	public Store store;
-	public User user1;
-	public User user2;
-	public String user1ValidAuthorizationHeader;
-	public String user2ValidAuthorizationHeader;
-	public String userInvalidAuthorizationHeader;
-	public Review review;
+    public Store store;
+    public User user1;
+    public User user2;
+    public User user3;
+    public String user1ValidAuthorizationHeader;
+    public String user2ValidAuthorizationHeader;
+    public String user3ValidAuthorizationHeader;
+    public String userInvalidAuthorizationHeader;
+    public Review review;
 
-	public void initDataSource() {
-		this.store = storeRepository.save(new Store("맛있는가게",
-			"02-0000-0000",
-			"서울시 송파구 좋은길 1",
-			"1층 101호",
-			37.5093890,
-			127.105143));
-		this.user1 = userRespository.save(
-			new User(12345678L, "test-user1", "https://profile1.com", "sikdorak1@gmail.com"));
-		this.user2 = userRespository.save(
-			new User(87654321L, "test-user2", "https://profile2.com", "sikdorak2@gmail.com"));
-		this.user1ValidAuthorizationHeader =
-			"Bearer " + jwtProvider.createAccessToken(String.valueOf(this.user1.getId()));
-		this.user2ValidAuthorizationHeader =
-			"Bearer " + jwtProvider.createAccessToken(String.valueOf(this.user2.getId()));
-		this.userInvalidAuthorizationHeader = "Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6IjIzNjgyMjM2MzgiLCJleHAiOjE2MzA2MzkzNTF9.SnT_Nxgspg3cUomCieDyBRH9TowtWh21YIfAKntuguA";
+    public void initDataSource() {
+        this.store = storeRepository.save(new Store("맛있는가게",
+            "02-0000-0000",
+            "서울시 송파구 좋은길 1",
+            "1층 101호",
+            37.5093890,
+            127.105143));
+        this.user1 = userRespository.save(
+            new User(12345678L, "test-user1", "https://profile1.com", "sikdorak1@gmail.com"));
+        this.user2 = userRespository.save(
+            new User(87654321L, "test-user2", "https://profile2.com", "sikdorak2@gmail.com"));
+        this.user3 = userRespository.save(
+            new User(23456781L, "test-user3", "https://profile3.com", "sikdorak3@gmail.com",
+                new HashSet<>(List.of(user2.getId())), new HashSet<>()));
+        this.user1ValidAuthorizationHeader =
+            "Bearer " + jwtProvider.createAccessToken(String.valueOf(this.user1.getId()));
+        this.user2ValidAuthorizationHeader =
+            "Bearer " + jwtProvider.createAccessToken(String.valueOf(this.user2.getId()));
+        this.user3ValidAuthorizationHeader =
+            "Bearer " + jwtProvider.createAccessToken(String.valueOf(this.user3.getId()));
+        this.userInvalidAuthorizationHeader = "Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6IjIzNjgyMjM2MzgiLCJleHAiOjE2MzA2MzkzNTF9.SnT_Nxgspg3cUomCieDyBRH9TowtWh21YIfAKntuguA";
 
-		this.review = reviewRepository.save(new Review(this.user1.getId(),
-			this.store.getId(),
-			"Test review contents",
-			3.f,
-			"public",
-			LocalDate.of(2022, 1, 1),
-			List.of("tag1", "tag2"),
-			List.of("https://s3.ap-northeast-2.amazonaws.com/sikdorak/test.jpg")));
-	}
+        this.review = reviewRepository.save(new Review(this.user1.getId(),
+            this.store.getId(),
+            "Test review contents",
+            3.f,
+            "public",
+            LocalDate.of(2022, 1, 1),
+            List.of("tag1", "tag2"),
+            List.of("https://s3.ap-northeast-2.amazonaws.com/sikdorak/test.jpg")));
+    }
 
-	public void clear() {
-		entityManager.unwrap(Session.class).doWork(this::cleanUpDatabase);
-	}
+    public void clear() {
+        entityManager.unwrap(Session.class).doWork(this::cleanUpDatabase);
+    }
 
-	@Override
-	public void afterPropertiesSet() {
-		entityManager.unwrap(Session.class).doWork(this::extractTableNames);
-	}
+    @Override
+    public void afterPropertiesSet() {
+        entityManager.unwrap(Session.class).doWork(this::extractTableNames);
+    }
 
-	// reference : https://www.baeldung.com/jdbc-database-metadata
-	private void extractTableNames(Connection connection) throws SQLException {
-		List<String> tableNames = new ArrayList<>();
+    // reference : https://www.baeldung.com/jdbc-database-metadata
+    private void extractTableNames(Connection connection) throws SQLException {
+        List<String> tableNames = new ArrayList<>();
 
-		ResultSet tables = connection
-			.getMetaData()
-			.getTables(connection.getCatalog(), null, "%", new String[]{"TABLE"});
+        ResultSet tables = connection
+            .getMetaData()
+            .getTables(connection.getCatalog(), null, "%", new String[]{"TABLE"});
 
-		try (tables) {
-			while (tables.next()) {
-				tableNames.add(tables.getString("table_name"));
-			}
+        try (tables) {
+            while (tables.next()) {
+                tableNames.add(tables.getString("table_name"));
+            }
 
-			this.tableNames = tableNames;
-		}
-	}
+            this.tableNames = tableNames;
+        }
+    }
 
-	private void cleanUpDatabase(Connection connection) throws SQLException {
-		try (Statement statement = connection.createStatement()) {
-			statement.executeUpdate("SET FOREIGN_KEY_CHECKS = 0");
+    private void cleanUpDatabase(Connection connection) throws SQLException {
+        try (Statement statement = connection.createStatement()) {
+            statement.executeUpdate("SET FOREIGN_KEY_CHECKS = 0");
 
-			for (String tableName : tableNames) {
-				statement.executeUpdate("TRUNCATE TABLE " + tableName);
-			}
+            for (String tableName : tableNames) {
+                statement.executeUpdate("TRUNCATE TABLE " + tableName);
+            }
 
-			statement.executeUpdate("SET FOREIGN_KEY_CHECKS = 1");
-		}
-	}
+            statement.executeUpdate("SET FOREIGN_KEY_CHECKS = 1");
+        }
+    }
 
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserCreateIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserCreateIntegrationTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-@DisplayName("UserCreate 통합 테스트")
+@DisplayName("유저 생성 통합 테스트")
 public class UserCreateIntegrationTest extends InitIntegrationTest {
 
     @Autowired

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserFollowIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserFollowIntegrationTest.java
@@ -36,7 +36,7 @@ class UserFollowIntegrationTest extends InitIntegrationTest {
     }
 
     @Test
-    @DisplayName("올바른 유저 정보가 들어오면 유저를 팔로우 한다.")
+    @DisplayName("팔로우 되어 있지 않은 유저에 대한 팔로우 요청이 들어오면 유저를 팔로우 한다.")
     void user_follow_success() {
 
         UserFollowAndUnfollowRequest request = new UserFollowAndUnfollowRequest(
@@ -52,7 +52,7 @@ class UserFollowIntegrationTest extends InitIntegrationTest {
     }
 
     @Test
-    @DisplayName("유저 본인의 정보가 들어오면 예외를 반환한다.")
+    @DisplayName("유저 본인에 대한 팔로우 요청이 들어오면 예외를 반환한다.")
     void user_follow_with_same_user_id() {
 
         UserFollowAndUnfollowRequest request = new UserFollowAndUnfollowRequest(
@@ -63,7 +63,7 @@ class UserFollowIntegrationTest extends InitIntegrationTest {
     }
 
     @Test
-    @DisplayName("존재하지 않는 유저의 정보가 들어오면 예외를 반환한다.")
+    @DisplayName("존재하지 않는 유저에 대한 팔로우 요청이 들어오면 예외를 반환한다.")
     void user_follow_with_not_found_user() {
 
         UserFollowAndUnfollowRequest request2 = new UserFollowAndUnfollowRequest(987654321L);
@@ -74,7 +74,7 @@ class UserFollowIntegrationTest extends InitIntegrationTest {
     }
 
     @Test
-    @DisplayName("이미 팔로우 한 유저의 정보가 들어오면 예외를 반환한다.")
+    @DisplayName("이미 팔로우 한 유저에 대한 팔로우 요청이 들어오면 예외를 반환한다.")
     void user_follow_with_already_followed_user() {
 
         UserFollowAndUnfollowRequest request1 = new UserFollowAndUnfollowRequest(
@@ -91,7 +91,7 @@ class UserFollowIntegrationTest extends InitIntegrationTest {
 
 
     @Test
-    @DisplayName("올바른 유저 정보가 들어오면 유저를 언팔로우 한다.")
+    @DisplayName("팔로우 되어 있는 유저에 대한 언팔로우 요청이 들어오면 언팔로우 한다.")
     void user_unfollow_success() {
 
         UserFollowAndUnfollowRequest followRequest = new UserFollowAndUnfollowRequest(
@@ -112,7 +112,29 @@ class UserFollowIntegrationTest extends InitIntegrationTest {
     }
 
     @Test
-    @DisplayName("팔로우 하지 않은 유저의 정보가 들어오면 예외를 반환한다.")
+    @DisplayName("유저 본인에 대한 언팔로우 요청이 들어오면 예외를 반환한다.")
+    void user_unfollow_with_same_user_id() {
+
+        UserFollowAndUnfollowRequest request = new UserFollowAndUnfollowRequest(
+            testData.user1.getId());
+
+        assertThatThrownBy(() -> userService.unfollowUser(loginUser, request))
+            .isInstanceOf(DuplicateSendAcceptUserException.class);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 유저에 대한 언팔로우 요청이 들어오면 예외를 반환한다.")
+    void user_unfollow_with_not_found_user() {
+
+        UserFollowAndUnfollowRequest request2 = new UserFollowAndUnfollowRequest(987654321L);
+
+        assertThatThrownBy(() -> userService.unfollowUser(loginUser, request2))
+            .isInstanceOf(NotFoundUserException.class);
+
+    }
+
+    @Test
+    @DisplayName("팔로우 하지 않은 유저에 대한 언팔로우 요청이 들어오면 예외를 반환한다.")
     void user_unfollow_with_unfollowed_user() {
 
         UserFollowAndUnfollowRequest unfollowRequest = new UserFollowAndUnfollowRequest(

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserFollowIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserFollowIntegrationTest.java
@@ -1,0 +1,126 @@
+package com.jjikmuk.sikdorak.integration.user.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.jjikmuk.sikdorak.integration.InitIntegrationTest;
+import com.jjikmuk.sikdorak.user.auth.controller.Authority;
+import com.jjikmuk.sikdorak.user.auth.controller.LoginUser;
+import com.jjikmuk.sikdorak.user.user.controller.request.UserFollowAndUnfollowRequest;
+import com.jjikmuk.sikdorak.user.user.domain.UserRespository;
+import com.jjikmuk.sikdorak.user.user.exception.DuplicateFollowingException;
+import com.jjikmuk.sikdorak.user.user.exception.DuplicateSendAcceptUserException;
+import com.jjikmuk.sikdorak.user.user.exception.NotFoundFollowException;
+import com.jjikmuk.sikdorak.user.user.exception.NotFoundUserException;
+import com.jjikmuk.sikdorak.user.user.service.UserService;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayName("유저 팔로우 통합 테스트")
+class UserFollowIntegrationTest extends InitIntegrationTest {
+
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private UserRespository userRespository;
+
+    private LoginUser loginUser;
+
+    @BeforeEach
+    void setup() {
+        loginUser = new LoginUser(testData.user1.getId(), Authority.USER);
+    }
+
+    @Test
+    @DisplayName("올바른 유저 정보가 들어오면 유저를 팔로우 한다.")
+    void user_follow_success() {
+
+        UserFollowAndUnfollowRequest request = new UserFollowAndUnfollowRequest(
+            testData.user2.getId());
+
+        userService.followUser(loginUser, request);
+
+        Set<Long> user1Followings = userRespository.findFollowings(testData.user1.getId());
+        Set<Long> user2Followers = userRespository.findFollowers(testData.user2.getId());
+
+        assertThat(user1Followings.contains(testData.user2.getId())).isTrue();
+        assertThat(user2Followers.contains(testData.user1.getId())).isTrue();
+    }
+
+    @Test
+    @DisplayName("유저 본인의 정보가 들어오면 예외를 반환한다.")
+    void user_follow_with_same_user_id() {
+
+        UserFollowAndUnfollowRequest request = new UserFollowAndUnfollowRequest(
+            testData.user1.getId());
+
+        assertThatThrownBy(() -> userService.followUser(loginUser, request))
+            .isInstanceOf(DuplicateSendAcceptUserException.class);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 유저의 정보가 들어오면 예외를 반환한다.")
+    void user_follow_with_not_found_user() {
+
+        UserFollowAndUnfollowRequest request2 = new UserFollowAndUnfollowRequest(987654321L);
+
+        assertThatThrownBy(() -> userService.followUser(loginUser, request2))
+            .isInstanceOf(NotFoundUserException.class);
+
+    }
+
+    @Test
+    @DisplayName("이미 팔로우 한 유저의 정보가 들어오면 예외를 반환한다.")
+    void user_follow_with_already_followed_user() {
+
+        UserFollowAndUnfollowRequest request1 = new UserFollowAndUnfollowRequest(
+            testData.user2.getId());
+        userService.followUser(loginUser, request1);
+
+        UserFollowAndUnfollowRequest request2 = new UserFollowAndUnfollowRequest(
+            testData.user2.getId());
+
+        assertThatThrownBy(() -> userService.followUser(loginUser, request2))
+            .isInstanceOf(DuplicateFollowingException.class);
+
+    }
+
+
+    @Test
+    @DisplayName("올바른 유저 정보가 들어오면 유저를 언팔로우 한다.")
+    void user_unfollow_success() {
+
+        UserFollowAndUnfollowRequest followRequest = new UserFollowAndUnfollowRequest(
+            testData.user2.getId());
+        userService.followUser(loginUser, followRequest);
+
+        UserFollowAndUnfollowRequest unfollowRequest = new UserFollowAndUnfollowRequest(
+            testData.user2.getId());
+
+        userService.unfollowUser(loginUser, unfollowRequest);
+
+        Set<Long> user1Followings = userRespository.findFollowings(testData.user1.getId());
+        Set<Long> user2Followers = userRespository.findFollowers(testData.user2.getId());
+
+        assertThat(user1Followings.contains(testData.user2.getId())).isFalse();
+        assertThat(user2Followers.contains(testData.user1.getId())).isFalse();
+
+    }
+
+    @Test
+    @DisplayName("팔로우 하지 않은 유저의 정보가 들어오면 예외를 반환한다.")
+    void user_unfollow_with_unfollowed_user() {
+
+        UserFollowAndUnfollowRequest unfollowRequest = new UserFollowAndUnfollowRequest(
+            testData.user2.getId());
+
+        assertThatThrownBy(() -> userService.unfollowUser(loginUser, unfollowRequest))
+            .isInstanceOf(NotFoundFollowException.class);
+
+    }
+
+}

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserFollowIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserFollowIntegrationTest.java
@@ -14,7 +14,6 @@ import com.jjikmuk.sikdorak.user.user.exception.NotFoundFollowException;
 import com.jjikmuk.sikdorak.user.user.exception.NotFoundUserException;
 import com.jjikmuk.sikdorak.user.user.service.UserService;
 import java.util.Set;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,17 +27,11 @@ class UserFollowIntegrationTest extends InitIntegrationTest {
     @Autowired
     private UserRespository userRespository;
 
-    private LoginUser loginUser;
-
-    @BeforeEach
-    void setup() {
-        loginUser = new LoginUser(testData.user1.getId(), Authority.USER);
-    }
-
     @Test
     @DisplayName("팔로우 되어 있지 않은 유저에 대한 팔로우 요청이 들어오면 유저를 팔로우 한다.")
     void user_follow_success() {
 
+        LoginUser loginUser = new LoginUser(testData.user1.getId(), Authority.USER);
         UserFollowAndUnfollowRequest request = new UserFollowAndUnfollowRequest(
             testData.user2.getId());
 
@@ -55,8 +48,9 @@ class UserFollowIntegrationTest extends InitIntegrationTest {
     @DisplayName("유저 본인에 대한 팔로우 요청이 들어오면 예외를 반환한다.")
     void user_follow_with_same_user_id() {
 
+        LoginUser loginUser = new LoginUser(testData.user3.getId(), Authority.USER);
         UserFollowAndUnfollowRequest request = new UserFollowAndUnfollowRequest(
-            testData.user1.getId());
+            testData.user3.getId());
 
         assertThatThrownBy(() -> userService.followUser(loginUser, request))
             .isInstanceOf(DuplicateSendAcceptUserException.class);
@@ -66,9 +60,10 @@ class UserFollowIntegrationTest extends InitIntegrationTest {
     @DisplayName("존재하지 않는 유저에 대한 팔로우 요청이 들어오면 예외를 반환한다.")
     void user_follow_with_not_found_user() {
 
-        UserFollowAndUnfollowRequest request2 = new UserFollowAndUnfollowRequest(987654321L);
+        LoginUser loginUser = new LoginUser(testData.user3.getId(), Authority.USER);
+        UserFollowAndUnfollowRequest request = new UserFollowAndUnfollowRequest(123123123L);
 
-        assertThatThrownBy(() -> userService.followUser(loginUser, request2))
+        assertThatThrownBy(() -> userService.followUser(loginUser, request))
             .isInstanceOf(NotFoundUserException.class);
 
     }
@@ -77,14 +72,11 @@ class UserFollowIntegrationTest extends InitIntegrationTest {
     @DisplayName("이미 팔로우 한 유저에 대한 팔로우 요청이 들어오면 예외를 반환한다.")
     void user_follow_with_already_followed_user() {
 
-        UserFollowAndUnfollowRequest request1 = new UserFollowAndUnfollowRequest(
-            testData.user2.getId());
-        userService.followUser(loginUser, request1);
-
-        UserFollowAndUnfollowRequest request2 = new UserFollowAndUnfollowRequest(
+        LoginUser loginUser = new LoginUser(testData.user3.getId(), Authority.USER);
+        UserFollowAndUnfollowRequest request = new UserFollowAndUnfollowRequest(
             testData.user2.getId());
 
-        assertThatThrownBy(() -> userService.followUser(loginUser, request2))
+        assertThatThrownBy(() -> userService.followUser(loginUser, request))
             .isInstanceOf(DuplicateFollowingException.class);
 
     }
@@ -94,20 +86,17 @@ class UserFollowIntegrationTest extends InitIntegrationTest {
     @DisplayName("팔로우 되어 있는 유저에 대한 언팔로우 요청이 들어오면 언팔로우 한다.")
     void user_unfollow_success() {
 
-        UserFollowAndUnfollowRequest followRequest = new UserFollowAndUnfollowRequest(
-            testData.user2.getId());
-        userService.followUser(loginUser, followRequest);
-
+        LoginUser loginUser = new LoginUser(testData.user3.getId(), Authority.USER);
         UserFollowAndUnfollowRequest unfollowRequest = new UserFollowAndUnfollowRequest(
             testData.user2.getId());
 
         userService.unfollowUser(loginUser, unfollowRequest);
 
-        Set<Long> user1Followings = userRespository.findFollowings(testData.user1.getId());
-        Set<Long> user2Followers = userRespository.findFollowers(testData.user2.getId());
+        Set<Long> sendUserFollowings = userRespository.findFollowings(testData.user3.getId());
+        Set<Long> acceptUserFollowers = userRespository.findFollowers(testData.user2.getId());
 
-        assertThat(user1Followings.contains(testData.user2.getId())).isFalse();
-        assertThat(user2Followers.contains(testData.user1.getId())).isFalse();
+        assertThat(sendUserFollowings.contains(testData.user2.getId())).isFalse();
+        assertThat(acceptUserFollowers.contains(testData.user3.getId())).isFalse();
 
     }
 
@@ -115,8 +104,9 @@ class UserFollowIntegrationTest extends InitIntegrationTest {
     @DisplayName("유저 본인에 대한 언팔로우 요청이 들어오면 예외를 반환한다.")
     void user_unfollow_with_same_user_id() {
 
+        LoginUser loginUser = new LoginUser(testData.user3.getId(), Authority.USER);
         UserFollowAndUnfollowRequest request = new UserFollowAndUnfollowRequest(
-            testData.user1.getId());
+            testData.user3.getId());
 
         assertThatThrownBy(() -> userService.unfollowUser(loginUser, request))
             .isInstanceOf(DuplicateSendAcceptUserException.class);
@@ -126,9 +116,10 @@ class UserFollowIntegrationTest extends InitIntegrationTest {
     @DisplayName("존재하지 않는 유저에 대한 언팔로우 요청이 들어오면 예외를 반환한다.")
     void user_unfollow_with_not_found_user() {
 
-        UserFollowAndUnfollowRequest request2 = new UserFollowAndUnfollowRequest(987654321L);
+        LoginUser loginUser = new LoginUser(testData.user3.getId(), Authority.USER);
+        UserFollowAndUnfollowRequest request = new UserFollowAndUnfollowRequest(123123123L);
 
-        assertThatThrownBy(() -> userService.unfollowUser(loginUser, request2))
+        assertThatThrownBy(() -> userService.unfollowUser(loginUser, request))
             .isInstanceOf(NotFoundUserException.class);
 
     }
@@ -137,8 +128,9 @@ class UserFollowIntegrationTest extends InitIntegrationTest {
     @DisplayName("팔로우 하지 않은 유저에 대한 언팔로우 요청이 들어오면 예외를 반환한다.")
     void user_unfollow_with_unfollowed_user() {
 
+        LoginUser loginUser = new LoginUser(testData.user3.getId(), Authority.USER);
         UserFollowAndUnfollowRequest unfollowRequest = new UserFollowAndUnfollowRequest(
-            testData.user2.getId());
+            testData.user1.getId());
 
         assertThatThrownBy(() -> userService.unfollowUser(loginUser, unfollowRequest))
             .isInstanceOf(NotFoundFollowException.class);

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserFollowUnfollowIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserFollowUnfollowIntegrationTest.java
@@ -40,8 +40,8 @@ class UserFollowUnfollowIntegrationTest extends InitIntegrationTest {
         Set<Long> sendUserFollowings = userRespository.findFollowings(testData.followSendUser.getId());
         Set<Long> acceptUserFollowers = userRespository.findFollowers(testData.user1.getId());
 
-        assertThat(sendUserFollowings.contains(testData.user1.getId())).isTrue();
-        assertThat(acceptUserFollowers.contains(testData.followSendUser.getId())).isTrue();
+        assertThat(sendUserFollowings).contains(testData.user1.getId());
+        assertThat(acceptUserFollowers).contains(testData.followSendUser.getId());
     }
 
     @Test
@@ -95,8 +95,8 @@ class UserFollowUnfollowIntegrationTest extends InitIntegrationTest {
         Set<Long> sendUserFollowings = userRespository.findFollowings(testData.followSendUser.getId());
         Set<Long> acceptUserFollowers = userRespository.findFollowers(testData.user2.getId());
 
-        assertThat(sendUserFollowings.contains(testData.user2.getId())).isFalse();
-        assertThat(acceptUserFollowers.contains(testData.followSendUser.getId())).isFalse();
+        assertThat(sendUserFollowings).doesNotContain(testData.user2.getId());
+        assertThat(acceptUserFollowers).doesNotContain(testData.followSendUser.getId());
 
     }
 

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserFollowUnfollowIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserFollowUnfollowIntegrationTest.java
@@ -18,8 +18,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-@DisplayName("유저 팔로우 통합 테스트")
-class UserFollowIntegrationTest extends InitIntegrationTest {
+@DisplayName("UserFollowUnfollow 통합 테스트")
+class UserFollowUnfollowIntegrationTest extends InitIntegrationTest {
 
     @Autowired
     private UserService userService;
@@ -31,26 +31,26 @@ class UserFollowIntegrationTest extends InitIntegrationTest {
     @DisplayName("팔로우 되어 있지 않은 유저에 대한 팔로우 요청이 들어오면 유저를 팔로우 한다.")
     void user_follow_success() {
 
-        LoginUser loginUser = new LoginUser(testData.user1.getId(), Authority.USER);
+        LoginUser loginUser = new LoginUser(testData.followSendUser.getId(), Authority.USER);
         UserFollowAndUnfollowRequest request = new UserFollowAndUnfollowRequest(
-            testData.user2.getId());
+            testData.user1.getId());
 
         userService.followUser(loginUser, request);
 
-        Set<Long> user1Followings = userRespository.findFollowings(testData.user1.getId());
-        Set<Long> user2Followers = userRespository.findFollowers(testData.user2.getId());
+        Set<Long> sendUserFollowings = userRespository.findFollowings(testData.followSendUser.getId());
+        Set<Long> acceptUserFollowers = userRespository.findFollowers(testData.user1.getId());
 
-        assertThat(user1Followings.contains(testData.user2.getId())).isTrue();
-        assertThat(user2Followers.contains(testData.user1.getId())).isTrue();
+        assertThat(sendUserFollowings.contains(testData.user1.getId())).isTrue();
+        assertThat(acceptUserFollowers.contains(testData.followSendUser.getId())).isTrue();
     }
 
     @Test
     @DisplayName("유저 본인에 대한 팔로우 요청이 들어오면 예외를 반환한다.")
     void user_follow_with_same_user_id() {
 
-        LoginUser loginUser = new LoginUser(testData.user3.getId(), Authority.USER);
+        LoginUser loginUser = new LoginUser(testData.followSendUser.getId(), Authority.USER);
         UserFollowAndUnfollowRequest request = new UserFollowAndUnfollowRequest(
-            testData.user3.getId());
+            testData.followSendUser.getId());
 
         assertThatThrownBy(() -> userService.followUser(loginUser, request))
             .isInstanceOf(DuplicateSendAcceptUserException.class);
@@ -60,7 +60,7 @@ class UserFollowIntegrationTest extends InitIntegrationTest {
     @DisplayName("존재하지 않는 유저에 대한 팔로우 요청이 들어오면 예외를 반환한다.")
     void user_follow_with_not_found_user() {
 
-        LoginUser loginUser = new LoginUser(testData.user3.getId(), Authority.USER);
+        LoginUser loginUser = new LoginUser(testData.followSendUser.getId(), Authority.USER);
         UserFollowAndUnfollowRequest request = new UserFollowAndUnfollowRequest(123123123L);
 
         assertThatThrownBy(() -> userService.followUser(loginUser, request))
@@ -72,9 +72,9 @@ class UserFollowIntegrationTest extends InitIntegrationTest {
     @DisplayName("이미 팔로우 한 유저에 대한 팔로우 요청이 들어오면 예외를 반환한다.")
     void user_follow_with_already_followed_user() {
 
-        LoginUser loginUser = new LoginUser(testData.user3.getId(), Authority.USER);
+        LoginUser loginUser = new LoginUser(testData.followSendUser.getId(), Authority.USER);
         UserFollowAndUnfollowRequest request = new UserFollowAndUnfollowRequest(
-            testData.user2.getId());
+            testData.followAcceptUser.getId());
 
         assertThatThrownBy(() -> userService.followUser(loginUser, request))
             .isInstanceOf(DuplicateFollowingException.class);
@@ -86,17 +86,17 @@ class UserFollowIntegrationTest extends InitIntegrationTest {
     @DisplayName("팔로우 되어 있는 유저에 대한 언팔로우 요청이 들어오면 언팔로우 한다.")
     void user_unfollow_success() {
 
-        LoginUser loginUser = new LoginUser(testData.user3.getId(), Authority.USER);
+        LoginUser loginUser = new LoginUser(testData.followSendUser.getId(), Authority.USER);
         UserFollowAndUnfollowRequest unfollowRequest = new UserFollowAndUnfollowRequest(
-            testData.user2.getId());
+            testData.followAcceptUser.getId());
 
         userService.unfollowUser(loginUser, unfollowRequest);
 
-        Set<Long> sendUserFollowings = userRespository.findFollowings(testData.user3.getId());
+        Set<Long> sendUserFollowings = userRespository.findFollowings(testData.followSendUser.getId());
         Set<Long> acceptUserFollowers = userRespository.findFollowers(testData.user2.getId());
 
         assertThat(sendUserFollowings.contains(testData.user2.getId())).isFalse();
-        assertThat(acceptUserFollowers.contains(testData.user3.getId())).isFalse();
+        assertThat(acceptUserFollowers.contains(testData.followSendUser.getId())).isFalse();
 
     }
 
@@ -104,9 +104,9 @@ class UserFollowIntegrationTest extends InitIntegrationTest {
     @DisplayName("유저 본인에 대한 언팔로우 요청이 들어오면 예외를 반환한다.")
     void user_unfollow_with_same_user_id() {
 
-        LoginUser loginUser = new LoginUser(testData.user3.getId(), Authority.USER);
+        LoginUser loginUser = new LoginUser(testData.followSendUser.getId(), Authority.USER);
         UserFollowAndUnfollowRequest request = new UserFollowAndUnfollowRequest(
-            testData.user3.getId());
+            testData.followSendUser.getId());
 
         assertThatThrownBy(() -> userService.unfollowUser(loginUser, request))
             .isInstanceOf(DuplicateSendAcceptUserException.class);
@@ -116,7 +116,7 @@ class UserFollowIntegrationTest extends InitIntegrationTest {
     @DisplayName("존재하지 않는 유저에 대한 언팔로우 요청이 들어오면 예외를 반환한다.")
     void user_unfollow_with_not_found_user() {
 
-        LoginUser loginUser = new LoginUser(testData.user3.getId(), Authority.USER);
+        LoginUser loginUser = new LoginUser(testData.followSendUser.getId(), Authority.USER);
         UserFollowAndUnfollowRequest request = new UserFollowAndUnfollowRequest(123123123L);
 
         assertThatThrownBy(() -> userService.unfollowUser(loginUser, request))
@@ -128,7 +128,7 @@ class UserFollowIntegrationTest extends InitIntegrationTest {
     @DisplayName("팔로우 하지 않은 유저에 대한 언팔로우 요청이 들어오면 예외를 반환한다.")
     void user_unfollow_with_unfollowed_user() {
 
-        LoginUser loginUser = new LoginUser(testData.user3.getId(), Authority.USER);
+        LoginUser loginUser = new LoginUser(testData.followSendUser.getId(), Authority.USER);
         UserFollowAndUnfollowRequest unfollowRequest = new UserFollowAndUnfollowRequest(
             testData.user1.getId());
 

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserModifyIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserModifyIntegrationTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-@DisplayName("유저 프로필 수정 통합 테스트")
+@DisplayName("UserModify 통합 테스트")
 class UserModifyIntegrationTest extends InitIntegrationTest {
 
     @Autowired

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserModifyIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserModifyIntegrationTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+@DisplayName("유저 프로필 수정 통합 테스트")
 class UserModifyIntegrationTest extends InitIntegrationTest {
 
     @Autowired


### PR DESCRIPTION
### ❗️ 이슈 번호

[SDR-36]

<br><br>

### 📝 구현 내용

- 유저 팔로우/언팔로우 인수,통합 테스트 작성
- 유저 팔로우/언팔로우 기능 구현

<br><br>

### 🙇🏻‍♂️ 리뷰어에게 부탁합니다!

- 유저의 계정 공개/비공개 여부는 미래의 태스크로 넘깁니다.(구현을 위해서는 더 많은 학습이 필요할듯하여..)
- 유저가 생성될때 팔로워,팔로잉이 설정된 상태로 생성될 일은 없다고 판단되어 Followers, Following 클래스에는 생성자를 만들지 않았으며 단위 테스트가 없습니다.

<br><br>

### 💡 참고 자료

- (없다면 지워도 됩니다!)


[SDR-36]: https://jjikmuk.atlassian.net/browse/SDR-36?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ