### PR TITLE
SDR-174 카카오 유저 이메일이 존재하지 않는 경우에 대한 검증 로직 추가

### DIFF
--- a/be/src/main/java/com/jjikmuk/sikdorak/common/config/feignclient/KakaoAccountResponseDeserializer.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/config/feignclient/KakaoAccountResponseDeserializer.java
@@ -24,12 +24,14 @@ public class KakaoAccountResponseDeserializer extends JsonDeserializer<KakaoAcco
                 .get("profile_image_url")
                 .asText();
 
-        String email = kakaoAccountNode.get("email").asText();
-        boolean isEmailValid = kakaoAccountNode.get("is_email_valid").asBoolean();
-        boolean isEmailVerified = kakaoAccountNode.get("is_email_verified").asBoolean();
+        if (kakaoAccountNode.has("email")) {
+            String email = kakaoAccountNode.get("email").asText();
+            boolean isEmailValid = kakaoAccountNode.get("is_email_valid").asBoolean();
+            boolean isEmailVerified = kakaoAccountNode.get("is_email_verified").asBoolean();
 
-        if (isEmailValid && isEmailVerified) {
-            return new KakaoAccountResponse(uniqueId, nickname, profileImage, email);
+            if (isEmailValid && isEmailVerified) {
+                return new KakaoAccountResponse(uniqueId, nickname, profileImage, email);
+            }
         }
 
         return new KakaoAccountResponse(uniqueId, nickname, profileImage, null);

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/domain/Email.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/domain/Email.java
@@ -5,10 +5,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.persistence.Embeddable;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
 @Embeddable
 public class Email {
 
@@ -16,6 +14,10 @@ public class Email {
 
     @javax.validation.constraints.Email
     private String email;
+
+    public Email() {
+        this.email = "";
+    }
 
     public Email(String email) {
         if (!isValidEmailForm(email)) throw new InvalidUserEmailException();

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/domain/Email.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/domain/Email.java
@@ -12,7 +12,6 @@ public class Email {
 
     private static final String EMAIL_REGEX = "^[_a-z0-9-]+(.[_a-z0-9-]+)*@(?:\\w+\\.)+\\w+$";
 
-    @javax.validation.constraints.Email
     private String email;
 
     public Email() {

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/domain/User.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/domain/User.java
@@ -2,6 +2,7 @@ package com.jjikmuk.sikdorak.user.user.domain;
 
 import com.jjikmuk.sikdorak.common.domain.BaseTimeEntity;
 import java.util.Set;
+import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
@@ -49,7 +50,7 @@ public class User extends BaseTimeEntity {
         this.uniqueId = uniqueId;
         this.nickname = new Nickname(nickname);
         this.profileImage = new ProfileImage(profileImage);
-        this.email = new Email(email);
+        this.email = Objects.isNull(email) ? new Email() : new Email(email);
         this.followings = new Followings();
         this.followers = new Followers();
     }

--- a/be/src/test/java/com/jjikmuk/sikdorak/common/mock/OAuthMocks.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/common/mock/OAuthMocks.java
@@ -6,6 +6,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED;
 import static java.nio.charset.Charset.defaultCharset;
 import static org.springframework.util.StreamUtils.copyToString;
 
@@ -19,6 +20,7 @@ public class OAuthMocks {
     public static void setUpResponses() throws IOException {
         setupMockTokenResponse();
         setupMockUserInfoResponse();
+        setupMockUserInfoWithNoEmailReponse();
     }
 
     public static void setupMockTokenResponse() throws IOException {
@@ -33,12 +35,27 @@ public class OAuthMocks {
 
     public static void setupMockUserInfoResponse() throws IOException {
         stubFor(get(urlEqualTo("/v2/user/me"))
+            .inScenario("Email Not Null")
+            .whenScenarioStateIs(STARTED)
                 .withHeader("Authorization", equalTo("bearer accessToken"))
                 .willReturn(aResponse()
                         .withStatus(HttpStatus.OK.value())
                         .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
                         .withBody(getMockResponseBodyByPath("payload/get-user-info-response.json"))
                 )
+        );
+    }
+
+    public static void setupMockUserInfoWithNoEmailReponse() throws IOException{
+        stubFor(get(urlEqualTo("/v2/user/me"))
+            .inScenario("Email Null")
+            .whenScenarioStateIs(STARTED)
+            .withHeader("Authorization", equalTo("bearer accessToken"))
+            .willReturn(aResponse()
+                .withStatus(HttpStatus.OK.value())
+                .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+                .withBody(getMockResponseBodyByPath("payload/get-user-info-with-no-email-response.json"))
+            )
         );
     }
 

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/user/auth/OAuthLoginIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/user/auth/OAuthLoginIntegrationTest.java
@@ -1,0 +1,76 @@
+package com.jjikmuk.sikdorak.integration.user.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.jjikmuk.sikdorak.common.mock.OAuthMocks;
+import com.jjikmuk.sikdorak.integration.InitIntegrationTest;
+import com.jjikmuk.sikdorak.user.auth.domain.JwtProvider;
+import com.jjikmuk.sikdorak.user.auth.domain.JwtTokenPair;
+import com.jjikmuk.sikdorak.user.auth.service.OAuthService;
+import com.jjikmuk.sikdorak.user.user.domain.User;
+import com.jjikmuk.sikdorak.user.user.domain.UserRespository;
+import java.io.IOException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.contract.wiremock.AutoConfigureWireMock;
+import org.springframework.test.context.TestPropertySource;
+
+@AutoConfigureWireMock(port = 0)
+@TestPropertySource(properties = {
+    "oauth.kakao.service.token_url=http://localhost:${wiremock.server.port}",
+    "oauth.kakao.service.api_url=http://localhost:${wiremock.server.port}"
+})
+@DisplayName("OAuth 로그인 통합테스트")
+public class OAuthLoginIntegrationTest extends InitIntegrationTest {
+
+    @Autowired
+    private OAuthService oAuthService;
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    @Autowired
+    private UserRespository userRespository;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        OAuthMocks.setUpResponses();
+    }
+
+    @Test
+    @DisplayName("이메일 정보를 가진 유저일 경우 이메일을 저장하고 로그인에 성공한다.")
+    public void oauth_login_success_with_user_email() {
+
+        WireMock.setScenarioState("Email Not Null", "Started");
+
+        JwtTokenPair code = oAuthService.login("code");
+        String userId = jwtProvider.decodeToken(code.getAccessToken());
+        User user = userRespository.findById(Long.parseLong(userId)).orElseThrow();
+
+        assertThat(code.getAccessToken()).isNotNull();
+        assertThat(user).isNotNull();
+        assertThat(user.getEmail()).isNotNull();
+
+    }
+
+    @Test
+    @DisplayName("이메일 정보가 없는 유저일 경우 이메일은 빈칸으로 저장하고 로그인에 성공한다.")
+    public void oauth_login_success_without_user_email() {
+
+        WireMock.setScenarioState("Email Null", "Started");
+
+        JwtTokenPair code = oAuthService.login("code");
+        String userId = jwtProvider.decodeToken(code.getAccessToken());
+
+        User user = userRespository.findById(Long.parseLong(userId)).orElseThrow();
+
+        assertThat(code.getAccessToken()).isNotNull();
+        assertThat(user).isNotNull();
+        assertThat(user.getEmail()).isEmpty();
+
+    }
+}

--- a/be/src/test/resources/payload/get-user-info-response.json
+++ b/be/src/test/resources/payload/get-user-info-response.json
@@ -4,8 +4,8 @@
     "profile_needs_agreement": false,
     "profile": {
       "nickname": "홍길동",
-      "thumbnail_image_url": "http://yyy.kakao.com/.../img_110x110.jpg",
-      "profile_image_url": "http://yyy.kakao.com/dn/.../img_640x640.jpg",
+      "thumbnail_image_url": "http://yyy.kakao.com/img_110x110.jpg",
+      "profile_image_url": "http://yyy.kakao.com/dn/img_640x640.jpg",
       "is_default_image": false
     },
     "name_needs_agreement": false,

--- a/be/src/test/resources/payload/get-user-info-with-no-email-response.json
+++ b/be/src/test/resources/payload/get-user-info-with-no-email-response.json
@@ -1,0 +1,20 @@
+{
+  "id": 123456789,
+  "kakao_account": {
+    "profile_needs_agreement": false,
+    "profile": {
+      "nickname": "홍길동",
+      "thumbnail_image_url": "http://yyy.kakao.com/.../img_110x110.jpg",
+      "profile_image_url": "http://yyy.kakao.com/dn/.../img_640x640.jpg",
+      "is_default_image": false
+    },
+    "name_needs_agreement": false,
+    "name": "홍길동",
+    "email_needs_agreement": false,
+    "is_email_valid": true,
+    "is_email_verified": true,
+    "age_range_needs_agreement": false,
+    "birthday_needs_agreement": false,
+    "gender_needs_agreement": false
+  }
+}

--- a/be/src/test/resources/payload/get-user-info-with-no-email-response.json
+++ b/be/src/test/resources/payload/get-user-info-with-no-email-response.json
@@ -4,8 +4,8 @@
     "profile_needs_agreement": false,
     "profile": {
       "nickname": "홍길동",
-      "thumbnail_image_url": "http://yyy.kakao.com/.../img_110x110.jpg",
-      "profile_image_url": "http://yyy.kakao.com/dn/.../img_640x640.jpg",
+      "thumbnail_image_url": "http://yyy.kakao.com/img_110x110.jpg",
+      "profile_image_url": "http://yyy.kakao.com/dn/img_640x640.jpg",
       "is_default_image": false
     },
     "name_needs_agreement": false,


### PR DESCRIPTION
### ❗️ 이슈 번호

[SDR-174]

<br><br>

### 📝 구현 내용

- OAuth 통합 테스트 작성
- 유저 생성 시 Email이 null이면 비어있는 Email 객체 생성하도록 수정
- 응답값에 email이 없는 경우 추가



[SDR-174]: https://jjikmuk.atlassian.net/browse/SDR-174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ