### PR TITLE
SDR-170 AccessToken 발급 시 Refresh Token 재발급

### DIFF
--- a/be/src/main/java/com/jjikmuk/sikdorak/common/exception/ExceptionCodeAndMessages.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/exception/ExceptionCodeAndMessages.java
@@ -15,6 +15,7 @@ import com.jjikmuk.sikdorak.store.exception.InvalidContactNumberException;
 import com.jjikmuk.sikdorak.store.exception.InvalidStoreLocationException;
 import com.jjikmuk.sikdorak.store.exception.InvalidStoreNameException;
 import com.jjikmuk.sikdorak.store.exception.NotFoundStoreException;
+import com.jjikmuk.sikdorak.user.auth.exception.ExpiredTokenException;
 import com.jjikmuk.sikdorak.user.auth.exception.InvalidTokenException;
 import com.jjikmuk.sikdorak.user.auth.exception.NeedLoginException;
 import com.jjikmuk.sikdorak.user.auth.exception.OAuthServerException;
@@ -70,7 +71,8 @@ public enum ExceptionCodeAndMessages implements CodeAndMessages {
     //OAuth
     FAILED_CONNECTION_WITH_OAUTH_SERVER("F-O001", "OAuth 서버와의 통신이 원할하지 않습니다.", OAuthServerException.class),
     INVALID_TOKEN("F-O002", "유효하지 않은 토큰입니다.", InvalidTokenException.class),
-    NEED_LOGIN("F-O003", "로그인이 필요한 서비스입니다.", NeedLoginException.class);
+    EXPIRED_TOKEN("F-O003", "만료된 토큰입니다.", ExpiredTokenException.class),
+    NEED_LOGIN("F-O004", "로그인이 필요한 서비스입니다.", NeedLoginException.class);
 
     private final String code;
 

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/auth/controller/OAuthController.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/auth/controller/OAuthController.java
@@ -39,11 +39,13 @@ public class OAuthController {
     }
 
     @GetMapping("/api/oauth/refresh")
-    public CommonResponseEntity<AccessTokenResponse> updateAccessToken(@CookieValue("refreshToken") Cookie cookie) {
+    public CommonResponseEntity<AccessTokenResponse> updateAccessToken(@CookieValue("refreshToken") Cookie cookie,  HttpServletResponse response) {
         String refreshToken = cookie.getValue();
+        JwtTokenPair jwtTokenPair = oAuthService.updateAccessAndRefreshToken(refreshToken);
+        setCookie(response, jwtTokenPair.getRefreshToken());
 
         return new CommonResponseEntity<>(ResponseCodeAndMessages.UPDATE_ACCESS_TOKEN_SUCCESS,
-            oAuthService.updateAccessToken(refreshToken),
+            new AccessTokenResponse(jwtTokenPair.getAccessToken()),
             HttpStatus.OK);
     }
 

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/auth/domain/JwtProvider.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/auth/domain/JwtProvider.java
@@ -24,30 +24,26 @@ public class JwtProvider {
     }
 
     public JwtTokenPair createTokenResponse(String payload) {
-        String accessToken = createAccessToken(payload);
-        String refreshToken = createRefreshToken(payload);
+
+        Date accessTokenExpiredDate = new Date(
+            new Date().getTime() + jwtProperties.getAccessTokenExpiredMillisecond());
+        Date refreshTokeExpiredDate = new Date(
+            new Date().getTime() + jwtProperties.getRefreshTokenExpiredMillisecond());
+
+
+        String accessToken = createAccessToken(payload, accessTokenExpiredDate);
+        String refreshToken = createRefreshToken(payload, refreshTokeExpiredDate);
 
         return new JwtTokenPair(accessToken, refreshToken);
     }
 
-    public String createAccessToken(String payload) {
-        Date accessTokenExpiredDate = new Date(
-            new Date().getTime() + jwtProperties.getAccessTokenExpiredMillisecond());
-
+    public String createAccessToken(String payload, Date accessTokenExpiredDate) {
         return buildToken(payload, accessTokenExpiredDate);
     }
 
-    public String createRefreshToken(String payload) {
-        Date refreshTokeExpiredDate = new Date(
-            new Date().getTime() + jwtProperties.getRefreshTokenExpiredMillisecond());
-
-        return buildToken(payload, refreshTokeExpiredDate);
+    public String createRefreshToken(String payload, Date refreshTokenExpiredDate) {
+        return buildToken(payload, refreshTokenExpiredDate);
     }
-
-    public String createRefreshToken(String payload, Date refreshTokeExpiredDate) {
-        return buildToken(payload, refreshTokeExpiredDate);
-    }
-
 
     public void validateToken(String token) {
         try {

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/auth/domain/JwtProvider.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/auth/domain/JwtProvider.java
@@ -1,8 +1,10 @@
 package com.jjikmuk.sikdorak.user.auth.domain;
 
 import com.jjikmuk.sikdorak.common.properties.JwtProperties;
+import com.jjikmuk.sikdorak.user.auth.exception.ExpiredTokenException;
 import com.jjikmuk.sikdorak.user.auth.exception.InvalidTokenException;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
@@ -49,7 +51,9 @@ public class JwtProvider {
                 .setSigningKey(secretKey)
                 .build()
                 .parseClaimsJws(token);
-        }catch (JwtException e) {
+        } catch (ExpiredJwtException e) {
+            throw new ExpiredTokenException();
+        }catch (IllegalArgumentException | JwtException e) {
             throw new InvalidTokenException();
         }
     }

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/auth/domain/JwtProvider.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/auth/domain/JwtProvider.java
@@ -44,7 +44,6 @@ public class JwtProvider {
         return buildToken(payload, refreshTokeExpiredDate);
     }
 
-    // INFO: token값에 대한 null 예외처리는 parseClaimsJws에서 모두 하기 때문에 별도로 작성하지 않았습니다.
     public void validateToken(String token) {
         try {
             Jwts.parserBuilder()

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/auth/domain/JwtProvider.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/auth/domain/JwtProvider.java
@@ -44,6 +44,11 @@ public class JwtProvider {
         return buildToken(payload, refreshTokeExpiredDate);
     }
 
+    public String createRefreshToken(String payload, Date refreshTokeExpiredDate) {
+        return buildToken(payload, refreshTokeExpiredDate);
+    }
+
+
     public void validateToken(String token) {
         try {
             Jwts.parserBuilder()
@@ -57,11 +62,11 @@ public class JwtProvider {
         }
     }
 
-    public String decodeToken(String refreshToken) {
+    public String decodeToken(String token) {
         Claims claim = Jwts.parserBuilder()
             .setSigningKey(secretKey)
             .build()
-            .parseClaimsJws(refreshToken)
+            .parseClaimsJws(token)
             .getBody();
 
         return claim.get("id", String.class);

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/auth/exception/ExpiredTokenException.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/auth/exception/ExpiredTokenException.java
@@ -1,0 +1,12 @@
+package com.jjikmuk.sikdorak.user.auth.exception;
+
+import com.jjikmuk.sikdorak.common.exception.SikdorakRuntimeException;
+import org.springframework.http.HttpStatus;
+
+public class ExpiredTokenException extends SikdorakRuntimeException {
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return HttpStatus.UNAUTHORIZED;
+    }
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/auth/service/OAuthService.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/auth/service/OAuthService.java
@@ -1,7 +1,6 @@
 package com.jjikmuk.sikdorak.user.auth.service;
 
 import com.jjikmuk.sikdorak.common.properties.KakaoProperties;
-import com.jjikmuk.sikdorak.user.auth.controller.response.AccessTokenResponse;
 import com.jjikmuk.sikdorak.user.auth.controller.response.KakaoAccountResponse;
 import com.jjikmuk.sikdorak.user.auth.controller.response.OAuthTokenResponse;
 import com.jjikmuk.sikdorak.user.auth.domain.JwtProvider;
@@ -45,14 +44,16 @@ public class OAuthService{
     }
 
     @Transactional(readOnly = true)
-    public AccessTokenResponse updateAccessToken(String refreshToken) {
+    public JwtTokenPair updateAccessAndRefreshToken(String refreshToken) {
 
         jwtProvider.validateToken(refreshToken);
         String userId = jwtProvider.decodeToken(refreshToken);
+
         if (!userService.isExistingById(Long.parseLong(userId))) {
             throw new NotFoundUserException();
         }
-        return new AccessTokenResponse(jwtProvider.createAccessToken(userId));
+
+        return jwtProvider.createTokenResponse(userId);
     }
 
     private OAuthTokenResponse getOAuthAccessToken(String code) {

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/auth/OAuthUpdateTokenAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/auth/OAuthUpdateTokenAcceptanceTest.java
@@ -5,36 +5,29 @@ import static com.jjikmuk.sikdorak.acceptance.user.auth.OAuthSnippet.UPDATE_ACCE
 import static com.jjikmuk.sikdorak.acceptance.user.auth.OAuthSnippet.UPDATE_ACCESS_TOKEN_SUCCESS_RESPONSE_SNIPPET;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
 
 import com.jjikmuk.sikdorak.acceptance.InitAcceptanceTest;
 import com.jjikmuk.sikdorak.common.exception.ExceptionCodeAndMessages;
-import com.jjikmuk.sikdorak.user.auth.domain.JwtProvider;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
 @DisplayName("OAuth 토큰 재발급 인수테스트")
 class OAuthUpdateTokenAcceptanceTest extends InitAcceptanceTest {
 
-    @Autowired
-    private JwtProvider jwtProvider;
-
     @Test
     @DisplayName("유저로부터 액세스 토큰 갱신 요청이 올 경우 새로운 액세스 토큰을 발급한다")
     void update_access_token_success() {
-
-        String refreshToken = jwtProvider.createRefreshToken(
-            testData.user1.getId().toString());
 
         given(this.spec)
             .filter(document(DEFAULT_RESTDOC_PATH,
                 UPDATE_ACCESS_TOKEN_REQUEST_SNIPPET,
                 UPDATE_ACCESS_TOKEN_SUCCESS_RESPONSE_SNIPPET))
-            .header("Cookie", "refreshToken=" + refreshToken)
+            .header("Cookie", "refreshToken=" + testData.user1RefreshToken)
             .accept(MediaType.APPLICATION_JSON_VALUE)
 
         .when()
@@ -42,29 +35,8 @@ class OAuthUpdateTokenAcceptanceTest extends InitAcceptanceTest {
 
         .then()
             .statusCode(HttpStatus.OK.value())
+            .cookie("refreshToken", not(equalTo(testData.user1RefreshToken)))
             .body("data.accessToken", notNullValue());
-    }
-
-    @Test
-    @DisplayName("유저로부터 액세스 토큰 갱신 요청의 리프레쉬 토큰이 유효하지 않을 경우 실패 메세지를 전송한다.")
-    void update_access_token_fail_expired_token() {
-
-        String invalidToken = "eyJhbGciOiJIUzI1NiJ9.eyJpZCI6IjIzNjgyMjM2MzgiLCJleHAiOjE2MzA2MzkzNTF9.SnT_Nxgspg3cUomCieDyBRH9TowtWh21YIfAKntuguA";
-
-        given(this.spec)
-            .filter(document(DEFAULT_RESTDOC_PATH,
-                UPDATE_ACCESS_TOKEN_REQUEST_SNIPPET,
-                UPDATE_ACCESS_TOKEN_FAIL_RESPONSE_SNIPPET))
-            .header("Cookie", "refreshToken=" + invalidToken)
-            .accept(MediaType.APPLICATION_JSON_VALUE)
-
-        .when()
-            .get("/api/oauth/refresh")
-
-        .then()
-            .statusCode(HttpStatus.BAD_REQUEST.value())
-            .body("code", equalTo(ExceptionCodeAndMessages.INVALID_TOKEN.getCode()))
-            .body("message", equalTo(ExceptionCodeAndMessages.INVALID_TOKEN.getMessage()));
     }
 
     @Test

--- a/be/src/test/java/com/jjikmuk/sikdorak/common/DatabaseConfigurator.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/common/DatabaseConfigurator.java
@@ -51,7 +51,6 @@ public class DatabaseConfigurator implements InitializingBean {
     public String followSendUserValidAuthorizationHeader;
     public String followAcceptUserValidAuthorizationHeader;
     public String user1RefreshToken;
-    public String userInvalidAuthorizationHeader;
     public String user1ExpiredRefreshToken;
     public String user1InvalidRefreshToken;
     public Review review;
@@ -99,7 +98,7 @@ public class DatabaseConfigurator implements InitializingBean {
                 statement.executeUpdate("TRUNCATE TABLE " + tableName);
             }
 
-            statement.executeUpdate("성SET FOREIGN_KEY_CHECKS = 1");
+            statement.executeUpdate("SET FOREIGN_KEY_CHECKS = 1");
         }
     }
 
@@ -134,16 +133,22 @@ public class DatabaseConfigurator implements InitializingBean {
     }
 
     private void initUserAuthorizationData() {
+        String user1Payload = String.valueOf(this.user1.getId());
+        String user2Payload = String.valueOf(this.user2.getId());
+        String followSendUserPayload = String.valueOf(this.followSendUser.getId());
+
+        Date now = new Date();
+        Date accessTokenExpiredTime = new Date(now.getTime() + 1800000);
+
         this.user1ValidAuthorizationHeader =
-            "Bearer " + jwtProvider.createAccessToken(String.valueOf(this.user1.getId()));
+            "Bearer " + jwtProvider.createAccessToken(user1Payload, accessTokenExpiredTime);
         this.user2ValidAuthorizationHeader =
-            "Bearer " + jwtProvider.createAccessToken(String.valueOf(this.user2.getId()));
+            "Bearer " + jwtProvider.createAccessToken(user2Payload,accessTokenExpiredTime);
         this.followSendUserValidAuthorizationHeader =
-            "Bearer " + jwtProvider.createAccessToken(String.valueOf(this.followSendUser.getId()));
-        this.user1RefreshToken = jwtProvider.createRefreshToken(String.valueOf(this.user1.getId()), new Date(new Date().getTime()+8000000));
-        this.user1ExpiredRefreshToken = jwtProvider.createRefreshToken(String.valueOf(this.user1.getId()), new Date(new Date().getTime()+100));
-        this.user1InvalidRefreshToken = jwtProvider.createRefreshToken(String.valueOf(this.user1.getId())) + "invalid";
-        this.userInvalidAuthorizationHeader = "Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6IjIzNjgyMjM2MzgiLCJleHAiOjE2MzA2MzkzNTF9.SnT_Nxgspg3cUomCieDyBRH9TowtWh21YIfAKntuguA";
+            "Bearer " + jwtProvider.createAccessToken(followSendUserPayload, accessTokenExpiredTime);
+        this.user1RefreshToken = jwtProvider.createRefreshToken(user1Payload, new Date(now.getTime()+8000000));
+        this.user1ExpiredRefreshToken = jwtProvider.createRefreshToken(user1Payload, new Date(now.getTime() + 100));
+        this.user1InvalidRefreshToken = jwtProvider.createRefreshToken(user1Payload, new Date(now.getTime() - 1000)) + "invalid";
     }
 
     private void initReviewData() {

--- a/be/src/test/java/com/jjikmuk/sikdorak/common/DatabaseConfigurator.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/common/DatabaseConfigurator.java
@@ -136,6 +136,7 @@ public class DatabaseConfigurator implements InitializingBean {
         String user1Payload = String.valueOf(this.user1.getId());
         String user2Payload = String.valueOf(this.user2.getId());
         String followSendUserPayload = String.valueOf(this.followSendUser.getId());
+        String followAcceptUserPayload = String.valueOf(this.followAcceptUser.getId());
 
         Date now = new Date();
         Date accessTokenExpiredTime = new Date(now.getTime() + 1800000);
@@ -146,6 +147,8 @@ public class DatabaseConfigurator implements InitializingBean {
             "Bearer " + jwtProvider.createAccessToken(user2Payload,accessTokenExpiredTime);
         this.followSendUserValidAuthorizationHeader =
             "Bearer " + jwtProvider.createAccessToken(followSendUserPayload, accessTokenExpiredTime);
+        this.followAcceptUserValidAuthorizationHeader =
+            "Bearer " + jwtProvider.createAccessToken(followAcceptUserPayload, accessTokenExpiredTime);
         this.user1RefreshToken = jwtProvider.createRefreshToken(user1Payload, new Date(now.getTime()+8000000));
         this.user1ExpiredRefreshToken = jwtProvider.createRefreshToken(user1Payload, new Date(now.getTime() + 100));
         this.user1InvalidRefreshToken = jwtProvider.createRefreshToken(user1Payload, new Date(now.getTime() - 1000)) + "invalid";

--- a/be/src/test/java/com/jjikmuk/sikdorak/common/DatabaseConfigurator.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/common/DatabaseConfigurator.java
@@ -13,6 +13,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
@@ -49,7 +50,10 @@ public class DatabaseConfigurator implements InitializingBean {
     public String user2ValidAuthorizationHeader;
     public String followSendUserValidAuthorizationHeader;
     public String followAcceptUserValidAuthorizationHeader;
+    public String user1RefreshToken;
     public String userInvalidAuthorizationHeader;
+    public String user1ExpiredRefreshToken;
+    public String user1InvalidRefreshToken;
     public Review review;
 
     public void initDataSource() {
@@ -95,7 +99,7 @@ public class DatabaseConfigurator implements InitializingBean {
                 statement.executeUpdate("TRUNCATE TABLE " + tableName);
             }
 
-            statement.executeUpdate("SET FOREIGN_KEY_CHECKS = 1");
+            statement.executeUpdate("성SET FOREIGN_KEY_CHECKS = 1");
         }
     }
 
@@ -136,8 +140,9 @@ public class DatabaseConfigurator implements InitializingBean {
             "Bearer " + jwtProvider.createAccessToken(String.valueOf(this.user2.getId()));
         this.followSendUserValidAuthorizationHeader =
             "Bearer " + jwtProvider.createAccessToken(String.valueOf(this.followSendUser.getId()));
-        this.followAcceptUserValidAuthorizationHeader =
-            "Bearer " + jwtProvider.createAccessToken(String.valueOf(this.followAcceptUser.getId()));
+        this.user1RefreshToken = jwtProvider.createRefreshToken(String.valueOf(this.user1.getId()), new Date(new Date().getTime()+8000000));
+        this.user1ExpiredRefreshToken = jwtProvider.createRefreshToken(String.valueOf(this.user1.getId()), new Date(new Date().getTime()+100));
+        this.user1InvalidRefreshToken = jwtProvider.createRefreshToken(String.valueOf(this.user1.getId())) + "invalid";
         this.userInvalidAuthorizationHeader = "Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6IjIzNjgyMjM2MzgiLCJleHAiOjE2MzA2MzkzNTF9.SnT_Nxgspg3cUomCieDyBRH9TowtWh21YIfAKntuguA";
     }
 

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/user/auth/OAuthArgumentResolverIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/user/auth/OAuthArgumentResolverIntegrationTest.java
@@ -39,9 +39,8 @@ class OAuthArgumentResolverIntegrationTest extends InitIntegrationTest {
 	}
 
 	@Test
-	@DisplayName("유효하지 않은 유저 Id가 넘어오는 경우 Anonymous 로그인 유저 객체를 반환한다.")
+	@DisplayName("토큰이 존재하지 않는 경우 Anonymous 로그인 유저 객체를 반환한다.")
 	void oAuth_argument_resolver_fail() {
-		mockHttpServletRequest.addHeader("Authorization", testData.userInvalidAuthorizationHeader);
 
 		LoginUser loginUser = (LoginUser) oAuthUserArgumentResolver.resolveArgument(null, null,
 			new ServletWebRequest(mockHttpServletRequest), null);

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/user/auth/OAuthArgumentResolverIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/user/auth/OAuthArgumentResolverIntegrationTest.java
@@ -41,7 +41,6 @@ class OAuthArgumentResolverIntegrationTest extends InitIntegrationTest {
 	@Test
 	@DisplayName("토큰이 존재하지 않는 경우 Anonymous 로그인 유저 객체를 반환한다.")
 	void oAuth_argument_resolver_fail() {
-
 		LoginUser loginUser = (LoginUser) oAuthUserArgumentResolver.resolveArgument(null, null,
 			new ServletWebRequest(mockHttpServletRequest), null);
 

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/user/auth/OAuthLoginIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/user/auth/OAuthLoginIntegrationTest.java
@@ -44,7 +44,6 @@ public class OAuthLoginIntegrationTest extends InitIntegrationTest {
     @Test
     @DisplayName("이메일 정보를 가진 유저일 경우 이메일을 저장하고 로그인에 성공한다.")
     public void oauth_login_success_with_user_email() {
-
         WireMock.setScenarioState("Email Not Null", "Started");
 
         JwtTokenPair code = oAuthService.login("code");
@@ -54,13 +53,11 @@ public class OAuthLoginIntegrationTest extends InitIntegrationTest {
         assertThat(code.getAccessToken()).isNotNull();
         assertThat(user).isNotNull();
         assertThat(user.getEmail()).isNotNull();
-
     }
 
     @Test
     @DisplayName("이메일 정보가 없는 유저일 경우 이메일은 빈칸으로 저장하고 로그인에 성공한다.")
     public void oauth_login_success_without_user_email() {
-
         WireMock.setScenarioState("Email Null", "Started");
 
         JwtTokenPair code = oAuthService.login("code");
@@ -71,6 +68,5 @@ public class OAuthLoginIntegrationTest extends InitIntegrationTest {
         assertThat(code.getAccessToken()).isNotNull();
         assertThat(user).isNotNull();
         assertThat(user.getEmail()).isEmpty();
-
     }
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/user/auth/OAuthUpdateTokenIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/user/auth/OAuthUpdateTokenIntegrationTest.java
@@ -14,38 +14,32 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 @DisplayName("OAuth 토큰 재발급 통합 테스트")
-public class OAuthUpdateTokenIntegrationTest extends InitIntegrationTest {
+class OAuthUpdateTokenIntegrationTest extends InitIntegrationTest {
 
     @Autowired
     private OAuthService oAuthService;
 
     @Test
     @DisplayName("유효한 refresh token이 전달될 경우 새로운 access/refresh 토큰을 발급한다.")
-    public void update_access_refresh_token_success() {
-
+    void update_access_refresh_token_success() {
         JwtTokenPair jwtTokenPair = oAuthService.updateAccessAndRefreshToken(testData.user1RefreshToken);
 
         assertThat(jwtTokenPair.getAccessToken()).isNotNull();
         assertThat(jwtTokenPair.getRefreshToken()).isNotEqualTo(testData.user1RefreshToken);
-
     }
 
     @Test
     @DisplayName("만료된 refresh token이 전달될 경우 예외를 반환한다.")
-    public void update_access_refresh_token_with_expired_token() {
-
+    void update_access_refresh_token_with_expired_token() {
         assertThatThrownBy(() -> oAuthService.updateAccessAndRefreshToken(testData.user1ExpiredRefreshToken))
             .isInstanceOf(ExpiredTokenException.class);
-
     }
 
     @Test
     @DisplayName("유효하지 않은 refresh token이 전달될 경우 예외를 반환한다.")
-    public void update_access_refresh_token_with_invalid_token() {
-
+    void update_access_refresh_token_with_invalid_token() {
         assertThatThrownBy(() -> oAuthService.updateAccessAndRefreshToken(testData.user1InvalidRefreshToken))
             .isInstanceOf(InvalidTokenException.class);
-
     }
 
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/user/auth/OAuthUpdateTokenIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/user/auth/OAuthUpdateTokenIntegrationTest.java
@@ -1,0 +1,51 @@
+package com.jjikmuk.sikdorak.integration.user.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.jjikmuk.sikdorak.integration.InitIntegrationTest;
+import com.jjikmuk.sikdorak.user.auth.domain.JwtTokenPair;
+import com.jjikmuk.sikdorak.user.auth.exception.ExpiredTokenException;
+import com.jjikmuk.sikdorak.user.auth.exception.InvalidTokenException;
+import com.jjikmuk.sikdorak.user.auth.service.OAuthService;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayName("OAuth 토큰 재발급 통합 테스트")
+public class OAuthUpdateTokenIntegrationTest extends InitIntegrationTest {
+
+    @Autowired
+    private OAuthService oAuthService;
+
+    @Test
+    @DisplayName("유효한 refresh token이 전달될 경우 새로운 access/refresh 토큰을 발급한다.")
+    public void update_access_refresh_token_success() {
+
+        JwtTokenPair jwtTokenPair = oAuthService.updateAccessAndRefreshToken(testData.user1RefreshToken);
+
+        assertThat(jwtTokenPair.getAccessToken()).isNotNull();
+        assertThat(jwtTokenPair.getRefreshToken()).isNotEqualTo(testData.user1RefreshToken);
+
+    }
+
+    @Test
+    @DisplayName("만료된 refresh token이 전달될 경우 예외를 반환한다.")
+    public void update_access_refresh_token_with_expired_token() {
+
+        assertThatThrownBy(() -> oAuthService.updateAccessAndRefreshToken(testData.user1ExpiredRefreshToken))
+            .isInstanceOf(ExpiredTokenException.class);
+
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 refresh token이 전달될 경우 예외를 반환한다.")
+    public void update_access_refresh_token_with_invalid_token() {
+
+        assertThatThrownBy(() -> oAuthService.updateAccessAndRefreshToken(testData.user1InvalidRefreshToken))
+            .isInstanceOf(InvalidTokenException.class);
+
+    }
+
+}

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserFollowUnfollowIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserFollowUnfollowIntegrationTest.java
@@ -65,7 +65,6 @@ class UserFollowUnfollowIntegrationTest extends InitIntegrationTest {
 
         assertThatThrownBy(() -> userService.followUser(loginUser, request))
             .isInstanceOf(NotFoundUserException.class);
-
     }
 
     @Test
@@ -78,7 +77,6 @@ class UserFollowUnfollowIntegrationTest extends InitIntegrationTest {
 
         assertThatThrownBy(() -> userService.followUser(loginUser, request))
             .isInstanceOf(DuplicateFollowingException.class);
-
     }
 
 
@@ -97,7 +95,6 @@ class UserFollowUnfollowIntegrationTest extends InitIntegrationTest {
 
         assertThat(sendUserFollowings).doesNotContain(testData.user2.getId());
         assertThat(acceptUserFollowers).doesNotContain(testData.followSendUser.getId());
-
     }
 
     @Test
@@ -121,7 +118,6 @@ class UserFollowUnfollowIntegrationTest extends InitIntegrationTest {
 
         assertThatThrownBy(() -> userService.unfollowUser(loginUser, request))
             .isInstanceOf(NotFoundUserException.class);
-
     }
 
     @Test
@@ -134,7 +130,6 @@ class UserFollowUnfollowIntegrationTest extends InitIntegrationTest {
 
         assertThatThrownBy(() -> userService.unfollowUser(loginUser, unfollowRequest))
             .isInstanceOf(NotFoundFollowException.class);
-
     }
 
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/user/auth/domain/JwtProviderTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/user/auth/domain/JwtProviderTest.java
@@ -1,0 +1,61 @@
+package com.jjikmuk.sikdorak.user.auth.domain;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.jjikmuk.sikdorak.common.properties.JwtProperties;
+import com.jjikmuk.sikdorak.user.auth.exception.ExpiredTokenException;
+import com.jjikmuk.sikdorak.user.auth.exception.InvalidTokenException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class JwtProviderTest {
+
+    private JwtProperties jwtProperties;
+    private JwtProvider jwtProvider;
+
+    @BeforeEach
+    void setUp() {
+        jwtProperties = new JwtProperties("secretKeysecretKeysecretKeysecretKey", 7200000, 604800000);
+        jwtProvider = new JwtProvider(jwtProperties);
+    }
+
+    @Nested
+    @DisplayName("유틸 메서드")
+    class Describe_util_method {
+
+        @Nested
+        @DisplayName("만약 만료된 토큰이 들어올 경우")
+        class Args_with_expired_token {
+
+            @ParameterizedTest
+            @ValueSource(strings = {"eyJhbGciOiJIUzI1NiJ9.eyJpZCI6IjEiLCJleHAiOjE2NDExNTk5NTh9.yHZkUQs0c-an5wWogvOcZEw6j_rM33gZpnCR9RSSvjk"})
+            @DisplayName("예외를 반환한다.")
+            void throw_Exception(String token) {
+                assertThatThrownBy(() -> jwtProvider.validateToken(token))
+                    .isInstanceOf(ExpiredTokenException.class);
+            }
+
+        }
+
+        @Nested
+        @DisplayName("만약 변조된 토큰이 들어올 경우")
+        class Args_with_invalid_token {
+
+            @ParameterizedTest
+            @NullAndEmptySource
+            @ValueSource(strings = {"eyJhbGciOiJIUzI1NiJ9.eyJsdpZCI6IjIiLCJleHAiOjE2NDExNTk5NTh9.p40Wz-_BYcVt2YJJIdjLNxuUvdn92B2VTrQSo2YGwJc"})
+            @DisplayName("예외를 반환한다.")
+            void throw_Exception(String token) {
+                assertThatThrownBy(() -> jwtProvider.validateToken(token))
+                    .isInstanceOf(InvalidTokenException.class);
+            }
+
+        }
+
+    }
+
+}

--- a/be/src/test/java/com/jjikmuk/sikdorak/user/user/domain/EmailTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/user/user/domain/EmailTest.java
@@ -1,4 +1,4 @@
-package com.jjikmuk.sikdorak.user.domain;
+package com.jjikmuk.sikdorak.user.user.domain;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 

--- a/be/src/test/java/com/jjikmuk/sikdorak/user/user/domain/NicknameTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/user/user/domain/NicknameTest.java
@@ -1,4 +1,4 @@
-package com.jjikmuk.sikdorak.user.domain;
+package com.jjikmuk.sikdorak.user.user.domain;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 

--- a/be/src/test/java/com/jjikmuk/sikdorak/user/user/domain/ProfileImageTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/user/user/domain/ProfileImageTest.java
@@ -1,4 +1,4 @@
-package com.jjikmuk.sikdorak.user.domain;
+package com.jjikmuk.sikdorak.user.user.domain;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 

--- a/be/src/test/java/com/jjikmuk/sikdorak/user/user/domain/UserTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/user/user/domain/UserTest.java
@@ -1,4 +1,4 @@
-package com.jjikmuk.sikdorak.user.domain;
+package com.jjikmuk.sikdorak.user.user.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 


### PR DESCRIPTION
### ❗️ 이슈 번호

[SDR-170]

<br><br>

### 📝 구현 내용

- 액세스 토큰 재발급 시 리프레쉬 토큰도 함께 재발급 하도록 로직 수정
- JwtProvider 단위 테스트 및 OAuth 토큰 재발급 통합 테스트 작성




[SDR-170]: https://jjikmuk.atlassian.net/browse/SDR-170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ