### PR TITLE
SDR-181 CORS Credential 옵션 추가

### DIFF
--- a/be/src/main/java/com/jjikmuk/sikdorak/common/config/WebMvcConfig.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/config/WebMvcConfig.java
@@ -30,6 +30,9 @@ public class WebMvcConfig implements WebMvcConfigurer {
 				HttpMethod.DELETE.name(),
 				HttpMethod.OPTIONS.name()
 			);
+
+		registry.addMapping("/api/oauth/**")
+				.allowCredentials(true);
 	}
 
 	@Override

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/config/WebMvcConfig.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/config/WebMvcConfig.java
@@ -22,6 +22,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
 	@Override
 	public void addCorsMappings(CorsRegistry registry) {
 		registry.addMapping("/**")
+			.allowCredentials(true)
 			.allowedOrigins(allowedOrigins)
 			.allowedMethods(
 				HttpMethod.GET.name(),
@@ -30,9 +31,6 @@ public class WebMvcConfig implements WebMvcConfigurer {
 				HttpMethod.DELETE.name(),
 				HttpMethod.OPTIONS.name()
 			);
-
-		registry.addMapping("/api/oauth/**")
-				.allowCredentials(true);
 	}
 
 	@Override


### PR DESCRIPTION
### ❗️ 이슈 번호

[SDR-181]

<br><br>

### 📝 구현 내용

- CORS 요청 시, Client 에서 Cookie 를 저장할 수 있도록 Credential 옵션 추가

<br><br>

### 💡 참고 자료

- [Access-Control-Allow-Credentials](https://developer.mozilla.org/ko/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials)
- [Credential Request](https://developer.mozilla.org/ko/docs/Web/API/Request/credentials)


[SDR-181]: https://jjikmuk.atlassian.net/browse/SDR-181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ