### PR TITLE
SDR-182 BE 서버 코드/메세지 조회 기능 

### DIFF
--- a/be/src/docs/asciidoc/index.adoc
+++ b/be/src/docs/asciidoc/index.adoc
@@ -10,6 +10,10 @@ notification-api-docs
 :toclevels: 4
 :sectlinks:
 
+== API Response code/message 조회
+
+API : `GET /api/docs/info`
+
 
 == 이슈 API
 

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/ResponseCodeAndMessages.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/ResponseCodeAndMessages.java
@@ -20,8 +20,10 @@ public enum ResponseCodeAndMessages implements CodeAndMessages {
     USER_MODIFY_SUCCESS("T-U001", "유저 프로필 수정에 성공했습니다."),
     USER_FOLLOW_SUCCESS("T-U002", "유저 팔로우에 성공했습니다."),
     USER_UNFOLLOW_SUCCESS("T-U003", "유저 언팔로우에 성공했습니다."),
-    USER_SEARCH_REVIEWS_SUCCESS("T-U004", "유저 리뷰 검색 성공했습니다.");
+    USER_SEARCH_REVIEWS_SUCCESS("T-U004", "유저 리뷰 검색 성공했습니다."),
 
+    // ETC
+    SYSTEMINFO_SEARCH_API_DOCS_INFO("T-S001", "API 문서 코드/메세지 검색 성공했습니다.");
 
     private final String code;
     private final String message;

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/controller/CommonInfoController.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/controller/CommonInfoController.java
@@ -1,0 +1,38 @@
+package com.jjikmuk.sikdorak.common.controller;
+
+import static com.jjikmuk.sikdorak.common.ResponseCodeAndMessages.SYSTEMINFO_SEARCH_API_DOCS_INFO;
+
+import com.jjikmuk.sikdorak.common.ResponseCodeAndMessages;
+import com.jjikmuk.sikdorak.common.controller.response.CodeAndMessageResponse;
+import com.jjikmuk.sikdorak.common.exception.ExceptionCodeAndMessages;
+import com.jjikmuk.sikdorak.common.response.CommonResponseEntity;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class CommonInfoController {
+
+	@GetMapping("/api/docs/info")
+	public CommonResponseEntity<List<CodeAndMessageResponse>> searchAPIDocsInfo() {
+		List<CodeAndMessageResponse> codeAndMessageResponses = Arrays.stream(
+				ResponseCodeAndMessages.values())
+			.map(e -> new CodeAndMessageResponse(e.getCode(), e.getMessage()))
+			.collect(Collectors.toList());
+
+		List<CodeAndMessageResponse> exceptionCodeAndMessageResponses = Arrays.stream(
+				ExceptionCodeAndMessages.values())
+			.map(e -> new CodeAndMessageResponse(e.getCode(), e.getMessage()))
+			.toList();
+
+		codeAndMessageResponses.addAll(exceptionCodeAndMessageResponses);
+
+		return new CommonResponseEntity<>(
+			SYSTEMINFO_SEARCH_API_DOCS_INFO,
+			codeAndMessageResponses,
+			HttpStatus.OK);
+	}
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/controller/response/CodeAndMessageResponse.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/controller/response/CodeAndMessageResponse.java
@@ -1,0 +1,6 @@
+package com.jjikmuk.sikdorak.common.controller.response;
+
+
+public record CodeAndMessageResponse(String code, String message) {
+
+}


### PR DESCRIPTION
### ❗️ 이슈 번호

[SDR-182]

<br><br>

### 📝 구현 내용

- 서버에서 사용하는 CodeAndMessages 객체의 enum 출력
- GET /api/docs/info

<br><br>

### 🙇🏻‍♂️ 리뷰어에게 부탁합니다!

API 문서 적용  릴리즈 1.0.0 나온 이후 리팩토링 하려합니다.
공통 응답 헤더를 맨 위에 빼거나 링크연결 등..
현재는 FE를 위해 아주 단순하게 json으로 응답해줍니다.

```json
{
  "code": "T-S001",
  "message": "API 문서 코드/메세지 검색 성공했습니다.",
  "data": [
    {
      "code": "T-R001",
      "message": "리뷰 생성 성공했습니다."
    },
    {
      "code": "T-R002",
      "message": "리뷰 수정 성공했습니다."
    },
    {
      "code": "T-R003",
      "message": "리뷰 삭제 성공했습니다."
    },
    {
      "code": "T-O001",
      "message": "로그인에 성공했습니다."
    },
    {
      "code": "T-O002",
      "message": "액세스 토큰 재발급에 성공했습니다."
    },
    {
      "code": "T-S001",
      "message": "가게 목록 조회에 성공했습니다."
    },
    {
      "code": "T-S002",
      "message": "가게 등록에 성공했습니다."
    },

// 생략
```

<br><br>



[SDR-182]: https://jjikmuk.atlassian.net/browse/SDR-182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ