### PR TITLE
SDR-184 refresh 토큰 응답시 sameSite 옵션 추가

### DIFF
--- a/be/src/main/java/com/jjikmuk/sikdorak/user/auth/controller/OAuthController.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/auth/controller/OAuthController.java
@@ -8,7 +8,10 @@ import com.jjikmuk.sikdorak.user.auth.service.OAuthService;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.web.server.Cookie.SameSite;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -50,8 +53,12 @@ public class OAuthController {
     }
 
     private static void setCookie(HttpServletResponse response, String refreshToken) {
-        Cookie cookie = new Cookie("refreshToken", refreshToken);
-        cookie.setHttpOnly(true);
-        response.addCookie(cookie);
+        ResponseCookie cookieHeader = ResponseCookie.from("refreshToken", refreshToken)
+            .sameSite(SameSite.NONE.attributeValue())
+            .secure(true)
+            .httpOnly(true)
+            .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, cookieHeader.toString());
     }
 }


### PR DESCRIPTION
### ❗️ 이슈 번호

[SDR-184]

<br><br>

### 📝 구현 내용

- RefreshToken 응답 시에 Set-Cookie 옵션에 `samesite` 옵션 추가

<br><br>

### 💡 참고 자료

CORS 때문에 Cookie 를 보내는데 상당히 제약이 많은 것 같습니다
Response Header 에 `Access-Control-Allow-Credentials`  설정도 추가해야하고, 
Set-Cookie 에 `SameSite` 옵션도 추가해줘야 하네요;;

- [브라우저 쿠키와 SameSite 속성](https://seob.dev/posts/%EB%B8%8C%EB%9D%BC%EC%9A%B0%EC%A0%80-%EC%BF%A0%ED%82%A4%EC%99%80-SameSite-%EC%86%8D%EC%84%B1/)
- [SameSite cookies : None - MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite#none)


[SDR-184]: https://jjikmuk.atlassian.net/browse/SDR-184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ