### PR TITLE
SDR-157 유저 조회 API

### DIFF
--- a/be/src/docs/asciidoc/user/user.adoc
+++ b/be/src/docs/asciidoc/user/user.adoc
@@ -77,3 +77,17 @@ operation::user_reviews_search_by_user_id_acceptance_test/self_user_search_user_
 ==== `Response`
 
 operation::user_reviews_search_by_user_id_acceptance_test/self_user_search_user_reviews_success[snippets='http-response']
+
+=== 유저 프로필 조회
+
+API : `GET /api/user/{userId}`
+
+=== `200 OK`
+
+==== `Request`
+
+operation::user_search_acceptance_test/search_user_profile_success[snippets='http-request,path-parameters']
+
+==== `Response`
+
+operation::user_search_acceptance_test/search_user_profile_success[snippets='http-response,response-fields']

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/ResponseCodeAndMessages.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/ResponseCodeAndMessages.java
@@ -21,6 +21,7 @@ public enum ResponseCodeAndMessages implements CodeAndMessages {
     USER_FOLLOW_SUCCESS("T-U002", "유저 팔로우에 성공했습니다."),
     USER_UNFOLLOW_SUCCESS("T-U003", "유저 언팔로우에 성공했습니다."),
     USER_SEARCH_REVIEWS_SUCCESS("T-U004", "유저 리뷰 검색 성공했습니다."),
+    USER_SEARCH_PROFILE_SUCCESS("T-U005", "유저 프로필 조회에 성공했습니다."),
 
     // ETC
     SYSTEMINFO_SEARCH_API_DOCS_INFO("T-S001", "API 문서 코드/메세지 검색 성공했습니다.");

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/repository/ReviewRepository.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/repository/ReviewRepository.java
@@ -14,4 +14,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
 	@Query("select r from Review as r where r.userId = :userId and r.reviewVisibility = 'PUBLIC'")
 	List<Review> findByUserIdAndDisconnection(Long userId);
+
+	Integer countByUserId(Long userId);
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/repository/ReviewRepository.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/repository/ReviewRepository.java
@@ -4,16 +4,17 @@ import com.jjikmuk.sikdorak.review.domain.Review;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
 	List<Review> findByUserId(Long userId);
 
 	@Query("select r from Review as r where r.userId = :userId and not r.reviewVisibility = 'PRIVATE'")
-	List<Review> findByUserIdAndConnection(Long userId);
+	List<Review> findByUserIdAndConnection(@Param("userId")Long userId);
 
 	@Query("select r from Review as r where r.userId = :userId and r.reviewVisibility = 'PUBLIC'")
-	List<Review> findByUserIdAndDisconnection(Long userId);
+	List<Review> findByUserIdAndDisconnection(@Param("userId")Long userId);
 
 	Integer countByUserId(Long userId);
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/controller/UserController.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/controller/UserController.java
@@ -7,6 +7,7 @@ import com.jjikmuk.sikdorak.user.auth.controller.LoginUser;
 import com.jjikmuk.sikdorak.user.auth.domain.AuthenticatedUser;
 import com.jjikmuk.sikdorak.user.user.controller.request.UserFollowAndUnfollowRequest;
 import com.jjikmuk.sikdorak.user.user.controller.request.UserModifyRequest;
+import com.jjikmuk.sikdorak.user.user.controller.response.UserProfileResponse;
 import com.jjikmuk.sikdorak.user.user.controller.response.UserReviewResponse;
 import com.jjikmuk.sikdorak.user.user.service.UserService;
 import java.util.List;
@@ -29,11 +30,23 @@ public class UserController {
         @PathVariable Long userId,
         @AuthenticatedUser LoginUser loginUser) {
 
-        List<UserReviewResponse> userReviewRespons = userService.searchUserReviewsByUserIdAndRelationType(userId, loginUser);
+        List<UserReviewResponse> userReviewResponse = userService.searchUserReviewsByUserIdAndRelationType(userId, loginUser);
 
         return new CommonResponseEntity<>(
             ResponseCodeAndMessages.USER_SEARCH_REVIEWS_SUCCESS,
-            userReviewRespons,
+            userReviewResponse,
+            HttpStatus.OK);
+    }
+
+    @GetMapping("/api/users/{userId}")
+    public CommonResponseEntity<UserProfileResponse> searchUserProfileByUserID(@AuthenticatedUser LoginUser loginUser,
+        @PathVariable Long userId
+    ) {
+
+        UserProfileResponse userProfileResponse = userService.searchUserProfile(userId, loginUser);
+
+        return new CommonResponseEntity<>(ResponseCodeAndMessages.USER_SEARCH_PROFILE_SUCCESS,
+            userProfileResponse,
             HttpStatus.OK);
     }
 

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/controller/UserController.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/controller/UserController.java
@@ -17,28 +17,30 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/users")
 public class UserController {
 
     private final UserService userService;
 
-    @GetMapping("/api/users/{userId}/reviews")
+    @GetMapping("/{userId}/reviews")
     public CommonResponseEntity<List<UserReviewResponse>> searchReviewsByUserId(
         @PathVariable Long userId,
         @AuthenticatedUser LoginUser loginUser) {
 
-        List<UserReviewResponse> userReviewResponse = userService.searchUserReviewsByUserIdAndRelationType(userId, loginUser);
+        List<UserReviewResponse> userReviewResponses = userService.searchUserReviewsByUserIdAndRelationType(userId, loginUser);
 
         return new CommonResponseEntity<>(
             ResponseCodeAndMessages.USER_SEARCH_REVIEWS_SUCCESS,
-            userReviewResponse,
+            userReviewResponses,
             HttpStatus.OK);
     }
 
-    @GetMapping("/api/users/{userId}")
+    @GetMapping("/{userId}")
     public CommonResponseEntity<UserProfileResponse> searchUserProfileByUserID(@AuthenticatedUser LoginUser loginUser,
         @PathVariable Long userId
     ) {
@@ -51,7 +53,7 @@ public class UserController {
     }
 
     @UserOnly
-    @PutMapping("/api/user")
+    @PutMapping("")
     public CommonResponseEntity<Void> modifyUserProfile(@AuthenticatedUser LoginUser loginUser,
         @RequestBody UserModifyRequest userModifyRequest) {
 
@@ -63,7 +65,7 @@ public class UserController {
     }
 
     @UserOnly
-    @PutMapping("/api/user/follow")
+    @PutMapping("/follow")
     public CommonResponseEntity<Void> follow(@AuthenticatedUser LoginUser loginUser,
         @RequestBody UserFollowAndUnfollowRequest userFollowAndUnfollowRequest) {
 
@@ -74,7 +76,7 @@ public class UserController {
     }
 
     @UserOnly
-    @PutMapping("/api/user/unfollow")
+    @PutMapping("/unfollow")
     public CommonResponseEntity<Void> unfollow(@AuthenticatedUser LoginUser loginUser,
         @RequestBody UserFollowAndUnfollowRequest userFollowAndUnfollowRequest) {
 

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/controller/response/UserProfileRelationStatusResponse.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/controller/response/UserProfileRelationStatusResponse.java
@@ -1,0 +1,18 @@
+package com.jjikmuk.sikdorak.user.user.controller.response;
+
+import com.jjikmuk.sikdorak.user.user.domain.RelationType;
+
+public record UserProfileRelationStatusResponse (
+
+    boolean isViewer,
+    boolean followStatus
+
+) {
+
+    public static UserProfileRelationStatusResponse of(RelationType relationType) {
+        boolean isViewer = relationType.equals(RelationType.SELF);
+        boolean followStatus = relationType.equals(RelationType.CONNECTION);
+
+        return new UserProfileRelationStatusResponse(isViewer, followStatus);
+    }
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/controller/response/UserProfileResponse.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/controller/response/UserProfileResponse.java
@@ -1,0 +1,45 @@
+package com.jjikmuk.sikdorak.user.user.controller.response;
+
+import com.jjikmuk.sikdorak.user.user.domain.User;
+import javax.validation.constraints.NotNull;
+import org.hibernate.validator.constraints.Length;
+import org.hibernate.validator.constraints.URL;
+
+public record UserProfileResponse(
+
+    @NotNull
+    long id,
+
+    @NotNull
+    @Length(min = 1, max = 30)
+    String nickname,
+
+    @NotNull
+    @URL
+    String profileImage,
+
+    String email,
+
+    boolean isViewer,
+
+    boolean followStatus,
+
+    @NotNull
+    int followingCount,
+
+    @NotNull
+    int followersCount) {
+
+    public static UserProfileResponse from(User user, boolean isViewer, boolean followStatus) {
+        return new UserProfileResponse(
+            user.getId(),
+            user.getNickname(),
+            user.getProfileImage(),
+            user.getEmail(),
+            isViewer,
+            followStatus,
+            user.getFollowers().size(),
+            user.getFollowings().size()
+        );
+    }
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/controller/response/UserProfileResponse.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/controller/response/UserProfileResponse.java
@@ -21,9 +21,7 @@ public record UserProfileResponse(
 
     String email,
 
-    boolean isViewer,
-
-    boolean followStatus,
+    UserProfileRelationStatusResponse relationStatus,
 
     @NotNull
     @Min(0)
@@ -39,14 +37,13 @@ public record UserProfileResponse(
 
 ) {
 
-    public static UserProfileResponse from(User user, boolean isViewer, boolean followStatus, int reviewCount) {
+    public static UserProfileResponse of(User user, UserProfileRelationStatusResponse userProfileRelationStatusResponse, int reviewCount) {
         return new UserProfileResponse(
             user.getId(),
             user.getNickname(),
             user.getProfileImage(),
             user.getEmail(),
-            isViewer,
-            followStatus,
+            userProfileRelationStatusResponse,
             user.getFollowers().size(),
             user.getFollowings().size(),
             reviewCount

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/controller/response/UserProfileResponse.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/controller/response/UserProfileResponse.java
@@ -1,6 +1,7 @@
 package com.jjikmuk.sikdorak.user.user.controller.response;
 
 import com.jjikmuk.sikdorak.user.user.domain.User;
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import org.hibernate.validator.constraints.Length;
 import org.hibernate.validator.constraints.URL;
@@ -25,12 +26,20 @@ public record UserProfileResponse(
     boolean followStatus,
 
     @NotNull
+    @Min(0)
     int followingCount,
 
     @NotNull
-    int followersCount) {
+    @Min(0)
+    int followersCount,
 
-    public static UserProfileResponse from(User user, boolean isViewer, boolean followStatus) {
+    @NotNull
+    @Min(0)
+    int reviewCount
+
+) {
+
+    public static UserProfileResponse from(User user, boolean isViewer, boolean followStatus, int reviewCount) {
         return new UserProfileResponse(
             user.getId(),
             user.getNickname(),
@@ -39,7 +48,8 @@ public record UserProfileResponse(
             isViewer,
             followStatus,
             user.getFollowers().size(),
-            user.getFollowings().size()
+            user.getFollowings().size(),
+            reviewCount
         );
     }
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/domain/Followers.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/domain/Followers.java
@@ -22,7 +22,7 @@ public class Followers {
     )
     private Set<Long> follower = new HashSet<>();
 
-    public boolean isConnection(Long userId) {
+    public boolean isConnected(Long userId) {
         return follower.contains(userId);
     }
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/domain/User.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/domain/User.java
@@ -132,7 +132,7 @@ public class User extends BaseTimeEntity {
         else if (loginUser.isAnonymous()) {
             return RelationType.DISCONNECTION;
         }
-        else if (!this.followers.isConnection(loginUser.getId())) { // 위 조건문, loginUser.isAnonymous()와 별도로 나눈 조회를 늦게하기 위해서이다.
+        else if (!this.followers.isConnected(loginUser.getId())) { // 위 조건문, loginUser.isAnonymous()와 별도로 나눈 조회를 늦게하기 위해서이다.
             return RelationType.DISCONNECTION;
         }
         return RelationType.CONNECTION;

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/domain/UserRespository.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/domain/UserRespository.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface UserRespository extends JpaRepository<User, Long> {
 
@@ -14,9 +15,9 @@ public interface UserRespository extends JpaRepository<User, Long> {
     boolean existsByUniqueId(long uniqueId);
 
     @Query("select f from User as u join u.followers.follower f where u.id = :userId")
-    Set<Long> findFollowers(long userId);
+    Set<Long> findFollowers(@Param("userId") long userId);
 
     @Query("select f from User as u join u.followings.following f where u.id = :userId")
-    Set<Long> findFollowings(long userId);
+    Set<Long> findFollowings(@Param("userId")long userId);
 
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/service/UserService.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/service/UserService.java
@@ -4,6 +4,7 @@ import com.jjikmuk.sikdorak.review.repository.ReviewRepository;
 import com.jjikmuk.sikdorak.user.auth.controller.LoginUser;
 import com.jjikmuk.sikdorak.user.user.controller.request.UserFollowAndUnfollowRequest;
 import com.jjikmuk.sikdorak.user.user.controller.request.UserModifyRequest;
+import com.jjikmuk.sikdorak.user.user.controller.response.UserProfileRelationStatusResponse;
 import com.jjikmuk.sikdorak.user.user.controller.response.UserProfileResponse;
 import com.jjikmuk.sikdorak.user.user.controller.response.UserReviewResponse;
 import com.jjikmuk.sikdorak.user.user.domain.RelationType;
@@ -54,31 +55,20 @@ public class UserService {
 
     @Transactional(readOnly = true)
     public UserProfileResponse searchUserProfile(Long userId, LoginUser loginUser) {
-
         User searchUser = userRespository.findById(userId)
             .orElseThrow(NotFoundUserException::new);
+        RelationType relationType = searchUser.relationTypeTo(loginUser);
         int reviewCount = reviewRepository.countByUserId(searchUser.getId());
 
-        RelationType relationType = searchUser.relationTypeTo(loginUser);
-        boolean isViewer = relationType.equals(RelationType.SELF);
-        boolean followStatus = relationType.equals(RelationType.CONNECTION);
-
-        return new UserProfileResponse(
-            searchUser.getId(),
-            searchUser.getNickname(),
-            searchUser.getProfileImage(),
-            searchUser.getEmail(),
-            isViewer,
-            followStatus,
-            searchUser.getFollowers().size(),
-            searchUser.getFollowings().size(),
+        return UserProfileResponse.of(
+            searchUser,
+            UserProfileRelationStatusResponse.of(relationType),
             reviewCount
         );
     }
 
     @Transactional
     public long createUser(User user) {
-
         if (isExistingByUniqueId(user.getUniqueId())) {
             throw new DuplicateUserException();
         }
@@ -101,7 +91,6 @@ public class UserService {
 
     @Transactional
     public void followUser(LoginUser loginUser, UserFollowAndUnfollowRequest userFollowAndUnfollowRequest) {
-
         User sendUser = userRespository.findById(loginUser.getId())
             .orElseThrow(NotFoundUserException::new);
         User acceptUser = userRespository.findById(userFollowAndUnfollowRequest.getUserId())
@@ -115,7 +104,6 @@ public class UserService {
 
     @Transactional
     public void unfollowUser(LoginUser loginUser, UserFollowAndUnfollowRequest userFollowAndUnfollowRequest) {
-
         User sendUser = userRespository.findById(loginUser.getId())
             .orElseThrow(NotFoundUserException::new);
         User acceptUser = userRespository.findById(userFollowAndUnfollowRequest.getUserId())

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/service/UserService.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/service/UserService.java
@@ -57,12 +57,12 @@ public class UserService {
         User searchUser = userRespository.findById(userId)
             .orElseThrow(NotFoundUserException::new);
         int reviewCount = reviewRepository.countByUserId(searchUser.getId());
-        boolean isViewer = false, followStatus = false;
+        boolean isViewer = false;
+        boolean followStatus = false;
 
         switch (searchUser.relationTypeTo(loginUser)) {
             case SELF -> isViewer = true;
             case CONNECTION ->  followStatus = true;
-            case DISCONNECTION -> {}
         }
 
         return new UserProfileResponse(

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/service/UserService.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/service/UserService.java
@@ -53,7 +53,28 @@ public class UserService {
 
     @Transactional(readOnly = true)
     public UserProfileResponse searchUserProfile(Long userId, LoginUser loginUser) {
-        return null;
+
+        User searchUser = userRespository.findById(userId)
+            .orElseThrow(NotFoundUserException::new);
+
+        boolean isViewer = false, followStatus = false;
+
+        switch (searchUser.relationTypeTo(loginUser)) {
+            case SELF -> isViewer = true;
+            case CONNECTION ->  followStatus = true;
+            case DISCONNECTION -> {}
+        }
+
+        return new UserProfileResponse(
+            searchUser.getId(),
+            searchUser.getNickname(),
+            searchUser.getProfileImage(),
+            searchUser.getEmail(),
+            isViewer,
+            followStatus,
+            searchUser.getFollowers().size(),
+            searchUser.getFollowings().size()
+        );
     }
 
     @Transactional

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/service/UserService.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/service/UserService.java
@@ -6,6 +6,7 @@ import com.jjikmuk.sikdorak.user.user.controller.request.UserFollowAndUnfollowRe
 import com.jjikmuk.sikdorak.user.user.controller.request.UserModifyRequest;
 import com.jjikmuk.sikdorak.user.user.controller.response.UserProfileResponse;
 import com.jjikmuk.sikdorak.user.user.controller.response.UserReviewResponse;
+import com.jjikmuk.sikdorak.user.user.domain.RelationType;
 import com.jjikmuk.sikdorak.user.user.domain.User;
 import com.jjikmuk.sikdorak.user.user.domain.UserRespository;
 import com.jjikmuk.sikdorak.user.user.exception.DuplicateFollowingException;
@@ -57,13 +58,10 @@ public class UserService {
         User searchUser = userRespository.findById(userId)
             .orElseThrow(NotFoundUserException::new);
         int reviewCount = reviewRepository.countByUserId(searchUser.getId());
-        boolean isViewer = false;
-        boolean followStatus = false;
 
-        switch (searchUser.relationTypeTo(loginUser)) {
-            case SELF -> isViewer = true;
-            case CONNECTION ->  followStatus = true;
-        }
+        RelationType relationType = searchUser.relationTypeTo(loginUser);
+        boolean isViewer = relationType.equals(RelationType.SELF);
+        boolean followStatus = relationType.equals(RelationType.CONNECTION);
 
         return new UserProfileResponse(
             searchUser.getId(),

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/service/UserService.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/service/UserService.java
@@ -4,6 +4,7 @@ import com.jjikmuk.sikdorak.review.repository.ReviewRepository;
 import com.jjikmuk.sikdorak.user.auth.controller.LoginUser;
 import com.jjikmuk.sikdorak.user.user.controller.request.UserFollowAndUnfollowRequest;
 import com.jjikmuk.sikdorak.user.user.controller.request.UserModifyRequest;
+import com.jjikmuk.sikdorak.user.user.controller.response.UserProfileResponse;
 import com.jjikmuk.sikdorak.user.user.controller.response.UserReviewResponse;
 import com.jjikmuk.sikdorak.user.user.domain.User;
 import com.jjikmuk.sikdorak.user.user.domain.UserRespository;
@@ -48,6 +49,11 @@ public class UserService {
                 .map(UserReviewResponse::from)
                 .toList();
         };
+    }
+
+    @Transactional(readOnly = true)
+    public UserProfileResponse searchUserProfile(Long userId, LoginUser loginUser) {
+        return null;
     }
 
     @Transactional

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/service/UserService.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/service/UserService.java
@@ -56,7 +56,7 @@ public class UserService {
 
         User searchUser = userRespository.findById(userId)
             .orElseThrow(NotFoundUserException::new);
-
+        int reviewCount = reviewRepository.countByUserId(searchUser.getId());
         boolean isViewer = false, followStatus = false;
 
         switch (searchUser.relationTypeTo(loginUser)) {
@@ -73,7 +73,8 @@ public class UserService {
             isViewer,
             followStatus,
             searchUser.getFollowers().size(),
-            searchUser.getFollowings().size()
+            searchUser.getFollowings().size(),
+            reviewCount
         );
     }
 

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/user/UserFollowUnfollowAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/user/UserFollowUnfollowAcceptanceTest.java
@@ -37,7 +37,7 @@ class UserFollowUnfollowAcceptanceTest extends InitAcceptanceTest {
             .body(userFollowAndUnfollowRequest)
 
         .when()
-            .put("/api/user/follow")
+            .put("/api/users/follow")
 
         .then()
             .statusCode(HttpStatus.OK.value())
@@ -63,7 +63,7 @@ class UserFollowUnfollowAcceptanceTest extends InitAcceptanceTest {
             .body(userFollowAndUnfollowRequest)
 
         .when()
-            .put("/api/user/unfollow")
+            .put("/api/users/unfollow")
 
         .then()
             .statusCode(HttpStatus.OK.value())
@@ -89,7 +89,7 @@ class UserFollowUnfollowAcceptanceTest extends InitAcceptanceTest {
             .body(userFollowAndUnfollowRequest)
 
         .when()
-            .put("/api/user/follow")
+            .put("/api/users/follow")
 
         .then()
             .statusCode(HttpStatus.UNAUTHORIZED.value())
@@ -116,7 +116,7 @@ class UserFollowUnfollowAcceptanceTest extends InitAcceptanceTest {
             .body(userFollowAndUnfollowRequest)
 
         .when()
-            .put("/api/user/unfollow")
+            .put("/api/users/unfollow")
 
         .then()
             .statusCode(HttpStatus.UNAUTHORIZED.value())

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/user/UserModifyAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/user/UserModifyAcceptanceTest.java
@@ -39,7 +39,7 @@ class UserModifyAcceptanceTest extends InitAcceptanceTest {
             .body(userModifyRequest)
 
         .when()
-            .put("/api/user")
+            .put("/api/users")
 
         .then()
             .statusCode(HttpStatus.OK.value())
@@ -68,7 +68,7 @@ class UserModifyAcceptanceTest extends InitAcceptanceTest {
             .body(userModifyRequest)
 
         .when()
-            .put("/api/user")
+            .put("/api/users")
 
         .then()
             .statusCode(HttpStatus.UNAUTHORIZED.value())

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/user/UserSearchAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/user/UserSearchAcceptanceTest.java
@@ -1,0 +1,63 @@
+package com.jjikmuk.sikdorak.acceptance.user.user;
+
+import static com.jjikmuk.sikdorak.acceptance.user.user.UserSnippet.USER_SEARCH_REQUEST_SNIPPET;
+import static com.jjikmuk.sikdorak.acceptance.user.user.UserSnippet.USER_SEARCH_RESPONSE_SNIPPET;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
+
+import com.jjikmuk.sikdorak.acceptance.InitAcceptanceTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+
+@DisplayName("유저 조회 인수테스트")
+public class UserSearchAcceptanceTest extends InitAcceptanceTest {
+
+    @Test
+    @DisplayName("회원인 유저의 유저 조회 요청이 올바르다면 유저 정보를 반환한다.")
+    void search_user_profile_success() {
+        given(this.spec)
+            .filter(document(
+                DEFAULT_RESTDOC_PATH,
+                USER_SEARCH_REQUEST_SNIPPET,
+                USER_SEARCH_RESPONSE_SNIPPET)
+            )
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+            .header("Authorization", testData.user1ValidAuthorizationHeader)
+
+        .when()
+            .get("/api/users/{userId}", testData.user2.getId())
+
+        .then()
+            .statusCode(HttpStatus.OK.value())
+            .body("data.id", equalTo(testData.user2.getId().intValue()))
+            .body("data.nickname", equalTo(testData.user2.getNickname()))
+            .body("data.email", equalTo(testData.user2.getEmail()))
+            .body("data.followStatus", equalTo(testData.user1.isFollowing(testData.user2)));
+    }
+
+    @Test
+    @DisplayName("비회원인 유저의 유저 조회 요청이 올바르다면 유저 정보를 반환한다.")
+    void anonymous_user_search_user_profile_success() {
+        given(this.spec)
+            .filter(document(
+                    DEFAULT_RESTDOC_PATH,
+                    USER_SEARCH_REQUEST_SNIPPET,
+                    USER_SEARCH_RESPONSE_SNIPPET)
+            )
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+
+        .when()
+            .get("/api/users/{userId}", testData.user2.getId())
+
+        .then()
+            .statusCode(HttpStatus.OK.value())
+            .body("data.id", equalTo(testData.user2.getId().intValue()))
+            .body("data.nickname", equalTo(testData.user2.getNickname()))
+            .body("data.email", equalTo(testData.user2.getEmail()));
+    }
+
+}

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/user/UserSearchAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/user/UserSearchAcceptanceTest.java
@@ -14,7 +14,7 @@ import org.springframework.http.MediaType;
 
 
 @DisplayName("유저 조회 인수테스트")
-public class UserSearchAcceptanceTest extends InitAcceptanceTest {
+class UserSearchAcceptanceTest extends InitAcceptanceTest {
 
     @Test
     @DisplayName("회원인 유저의 유저 조회 요청이 올바르다면 유저 정보를 반환한다.")
@@ -50,10 +50,10 @@ public class UserSearchAcceptanceTest extends InitAcceptanceTest {
             )
             .accept(MediaType.APPLICATION_JSON_VALUE)
 
-            .when()
+        .when()
             .get("/api/users/{userId}", testData.user2.getId())
 
-            .then()
+        .then()
             .statusCode(HttpStatus.OK.value())
             .body("data.id", equalTo(testData.user2.getId().intValue()))
             .body("data.nickname", equalTo(testData.user2.getNickname()))

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/user/UserSearchAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/user/UserSearchAcceptanceTest.java
@@ -44,20 +44,22 @@ public class UserSearchAcceptanceTest extends InitAcceptanceTest {
     void anonymous_user_search_user_profile_success() {
         given(this.spec)
             .filter(document(
-                    DEFAULT_RESTDOC_PATH,
-                    USER_SEARCH_REQUEST_SNIPPET,
-                    USER_SEARCH_RESPONSE_SNIPPET)
+                DEFAULT_RESTDOC_PATH,
+                USER_SEARCH_REQUEST_SNIPPET,
+                USER_SEARCH_RESPONSE_SNIPPET)
             )
             .accept(MediaType.APPLICATION_JSON_VALUE)
 
-        .when()
+            .when()
             .get("/api/users/{userId}", testData.user2.getId())
 
-        .then()
+            .then()
             .statusCode(HttpStatus.OK.value())
             .body("data.id", equalTo(testData.user2.getId().intValue()))
             .body("data.nickname", equalTo(testData.user2.getNickname()))
-            .body("data.email", equalTo(testData.user2.getEmail()));
+            .body("data.email", equalTo(testData.user2.getEmail()))
+            .body("data.followStatus", equalTo(false))
+            .body("data.reviewCount", equalTo(0));
     }
 
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/user/UserSearchAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/user/UserSearchAcceptanceTest.java
@@ -36,7 +36,7 @@ class UserSearchAcceptanceTest extends InitAcceptanceTest {
             .body("data.id", equalTo(testData.user2.getId().intValue()))
             .body("data.nickname", equalTo(testData.user2.getNickname()))
             .body("data.email", equalTo(testData.user2.getEmail()))
-            .body("data.followStatus", equalTo(testData.user1.isFollowing(testData.user2)));
+            .body("data.relationStatus.followStatus", equalTo(testData.user1.isFollowing(testData.user2)));
     }
 
     @Test
@@ -58,7 +58,7 @@ class UserSearchAcceptanceTest extends InitAcceptanceTest {
             .body("data.id", equalTo(testData.user2.getId().intValue()))
             .body("data.nickname", equalTo(testData.user2.getNickname()))
             .body("data.email", equalTo(testData.user2.getEmail()))
-            .body("data.followStatus", equalTo(false))
+            .body("data.relationStatus.followStatus", equalTo(false))
             .body("data.reviewCount", equalTo(0));
     }
 

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/user/UserSnippet.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/user/UserSnippet.java
@@ -3,12 +3,14 @@ package com.jjikmuk.sikdorak.acceptance.user.user;
 import static com.jjikmuk.sikdorak.acceptance.DocumentFormatGenerator.commonListResponseFieldsWithValidConstraints;
 import static com.jjikmuk.sikdorak.acceptance.DocumentFormatGenerator.commonRequestFieldsWithValidConstraints;
 import static com.jjikmuk.sikdorak.acceptance.DocumentFormatGenerator.commonResponseNonFields;
+import static com.jjikmuk.sikdorak.acceptance.DocumentFormatGenerator.commonSingleResponseFieldsWithValidConstraints;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 
 import com.jjikmuk.sikdorak.user.user.controller.request.UserFollowAndUnfollowRequest;
 import com.jjikmuk.sikdorak.user.user.controller.request.UserModifyRequest;
+import com.jjikmuk.sikdorak.user.user.controller.response.UserProfileResponse;
 import com.jjikmuk.sikdorak.user.user.controller.response.UserReviewResponse;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.restdocs.snippet.Snippet;
@@ -48,6 +50,22 @@ public interface UserSnippet {
         fieldWithPath("images").type(JsonFieldType.ARRAY).description("리뷰 이미지"),
         fieldWithPath("createdAt").type(JsonFieldType.STRING).description("리뷰 생성 시간"),
         fieldWithPath("updatedAt").type(JsonFieldType.STRING).description("리뷰 수정 시간")
+    );
+
+    Snippet USER_SEARCH_REQUEST_SNIPPET = pathParameters(
+        parameterWithName("userId").description("프로필을 조회할 유저 아이디")
+    );
+
+    Snippet USER_SEARCH_RESPONSE_SNIPPET = commonSingleResponseFieldsWithValidConstraints(
+        UserProfileResponse.class,
+        fieldWithPath("id").type(JsonFieldType.NUMBER).description("유저 아이디"),
+        fieldWithPath("nickname").type(JsonFieldType.STRING).description("유저 닉네임"),
+        fieldWithPath("email").type(JsonFieldType.STRING).description("유저 이메일"),
+        fieldWithPath("profileImage").type(JsonFieldType.STRING).description("유저 프로필 이미지"),
+        fieldWithPath("isViewer").type(JsonFieldType.BOOLEAN).description("요청자의 프로필 여부"),
+        fieldWithPath("followStatus").type(JsonFieldType.BOOLEAN).description("요청자의 팔로우 상태"),
+        fieldWithPath("followersCount").type(JsonFieldType.NUMBER).description("팔로워 수"),
+        fieldWithPath("followingCount").type(JsonFieldType.NUMBER).description("팔로잉 수")
     );
 
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/user/UserSnippet.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/user/UserSnippet.java
@@ -62,8 +62,8 @@ public interface UserSnippet {
         fieldWithPath("nickname").type(JsonFieldType.STRING).description("유저 닉네임"),
         fieldWithPath("email").type(JsonFieldType.STRING).description("유저 이메일"),
         fieldWithPath("profileImage").type(JsonFieldType.STRING).description("유저 프로필 이미지"),
-        fieldWithPath("relationStatus.isViewer").type(JsonFieldType.BOOLEAN).description("요청자의 프로필 여부"),
-        fieldWithPath("relationStatus.followStatus").type(JsonFieldType.BOOLEAN).description("요청자의 팔로우 상태"),
+        fieldWithPath("relationStatus.isViewer").type(JsonFieldType.BOOLEAN).description("자신의 프로필 조회 여부"),
+        fieldWithPath("relationStatus.followStatus").type(JsonFieldType.BOOLEAN).description("요청 유저와의 관계"),
         fieldWithPath("followersCount").type(JsonFieldType.NUMBER).description("유저 팔로워 수"),
         fieldWithPath("followingCount").type(JsonFieldType.NUMBER).description("유저 팔로잉 수"),
         fieldWithPath("reviewCount").type(JsonFieldType.NUMBER).description("유저 게시물 수")

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/user/UserSnippet.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/user/UserSnippet.java
@@ -64,8 +64,9 @@ public interface UserSnippet {
         fieldWithPath("profileImage").type(JsonFieldType.STRING).description("유저 프로필 이미지"),
         fieldWithPath("isViewer").type(JsonFieldType.BOOLEAN).description("요청자의 프로필 여부"),
         fieldWithPath("followStatus").type(JsonFieldType.BOOLEAN).description("요청자의 팔로우 상태"),
-        fieldWithPath("followersCount").type(JsonFieldType.NUMBER).description("팔로워 수"),
-        fieldWithPath("followingCount").type(JsonFieldType.NUMBER).description("팔로잉 수")
+        fieldWithPath("followersCount").type(JsonFieldType.NUMBER).description("유저 팔로워 수"),
+        fieldWithPath("followingCount").type(JsonFieldType.NUMBER).description("유저 팔로잉 수"),
+        fieldWithPath("reviewCount").type(JsonFieldType.NUMBER).description("유저 게시물 수")
     );
 
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/user/UserSnippet.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/user/UserSnippet.java
@@ -62,8 +62,8 @@ public interface UserSnippet {
         fieldWithPath("nickname").type(JsonFieldType.STRING).description("유저 닉네임"),
         fieldWithPath("email").type(JsonFieldType.STRING).description("유저 이메일"),
         fieldWithPath("profileImage").type(JsonFieldType.STRING).description("유저 프로필 이미지"),
-        fieldWithPath("isViewer").type(JsonFieldType.BOOLEAN).description("요청자의 프로필 여부"),
-        fieldWithPath("followStatus").type(JsonFieldType.BOOLEAN).description("요청자의 팔로우 상태"),
+        fieldWithPath("relationStatus.isViewer").type(JsonFieldType.BOOLEAN).description("요청자의 프로필 여부"),
+        fieldWithPath("relationStatus.followStatus").type(JsonFieldType.BOOLEAN).description("요청자의 팔로우 상태"),
         fieldWithPath("followersCount").type(JsonFieldType.NUMBER).description("유저 팔로워 수"),
         fieldWithPath("followingCount").type(JsonFieldType.NUMBER).description("유저 팔로잉 수"),
         fieldWithPath("reviewCount").type(JsonFieldType.NUMBER).description("유저 게시물 수")

--- a/be/src/test/java/com/jjikmuk/sikdorak/common/DatabaseConfigurator.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/common/DatabaseConfigurator.java
@@ -150,8 +150,8 @@ public class DatabaseConfigurator implements InitializingBean {
         this.followAcceptUserValidAuthorizationHeader =
             "Bearer " + jwtProvider.createAccessToken(followAcceptUserPayload, accessTokenExpiredTime);
         this.user1RefreshToken = jwtProvider.createRefreshToken(user1Payload, new Date(now.getTime()+8000000));
-        this.user1ExpiredRefreshToken = jwtProvider.createRefreshToken(user1Payload, new Date(now.getTime() + 100));
-        this.user1InvalidRefreshToken = jwtProvider.createRefreshToken(user1Payload, new Date(now.getTime() - 1000)) + "invalid";
+        this.user1ExpiredRefreshToken = jwtProvider.createRefreshToken(user1Payload, new Date(now.getTime() - 1000));
+        this.user1InvalidRefreshToken = user1RefreshToken + "invalid";
     }
 
     private void initReviewData() {

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserSearchIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserSearchIntegrationTest.java
@@ -41,7 +41,7 @@ class UserSearchIntegrationTest extends InitIntegrationTest {
     @Test
     @DisplayName("비회원이 유저의 정보를 조회할 경우 유저 정보를 반환한다.")
     void anonymous_user_search_user_profile() {
-        LoginUser loginUser = new LoginUser(null, Authority.ANONYMOUS);
+        LoginUser loginUser = new LoginUser(Authority.ANONYMOUS);
 
         UserProfileResponse userProfileResponse = userService.searchUserProfile(
             testData.user1.getId(), loginUser);

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserSearchIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserSearchIntegrationTest.java
@@ -33,8 +33,8 @@ class UserSearchIntegrationTest extends InitIntegrationTest {
 
         assertThat(userProfileResponse.id()).isEqualTo(testData.user1.getId());
         assertThat(userProfileResponse.nickname()).isEqualTo(testData.user1.getNickname());
-        assertThat(userProfileResponse.isViewer()).isTrue();
-        assertThat(userProfileResponse.followStatus()).isFalse();
+        assertThat(userProfileResponse.relationStatus().isViewer()).isTrue();
+        assertThat(userProfileResponse.relationStatus().followStatus()).isFalse();
         assertThat(userProfileResponse.reviewCount()).isEqualTo(1);
     }
 
@@ -48,8 +48,8 @@ class UserSearchIntegrationTest extends InitIntegrationTest {
 
         assertThat(userProfileResponse.id()).isEqualTo(testData.user1.getId());
         assertThat(userProfileResponse.nickname()).isEqualTo(testData.user1.getNickname());
-        assertThat(userProfileResponse.isViewer()).isFalse();
-        assertThat(userProfileResponse.followStatus()).isFalse();
+        assertThat(userProfileResponse.relationStatus().isViewer()).isFalse();
+        assertThat(userProfileResponse.relationStatus().followStatus()).isFalse();
         assertThat(userProfileResponse.reviewCount()).isEqualTo(1);
     }
 
@@ -63,8 +63,8 @@ class UserSearchIntegrationTest extends InitIntegrationTest {
 
         assertThat(userProfileResponse.id()).isEqualTo(testData.followAcceptUser.getId());
         assertThat(userProfileResponse.nickname()).isEqualTo(testData.followAcceptUser.getNickname());
-        assertThat(userProfileResponse.isViewer()).isFalse();
-        assertThat(userProfileResponse.followStatus()).isTrue();
+        assertThat(userProfileResponse.relationStatus().isViewer()).isFalse();
+        assertThat(userProfileResponse.relationStatus().followStatus()).isTrue();
         assertThat(userProfileResponse.reviewCount()).isEqualTo(3);
     }
 
@@ -78,8 +78,8 @@ class UserSearchIntegrationTest extends InitIntegrationTest {
 
         assertThat(userProfileResponse.id()).isEqualTo(testData.user2.getId());
         assertThat(userProfileResponse.nickname()).isEqualTo(testData.user2.getNickname());
-        assertThat(userProfileResponse.isViewer()).isFalse();
-        assertThat(userProfileResponse.followStatus()).isFalse();
+        assertThat(userProfileResponse.relationStatus().isViewer()).isFalse();
+        assertThat(userProfileResponse.relationStatus().followStatus()).isFalse();
         assertThat(userProfileResponse.reviewCount()).isEqualTo(0);
     }
 

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserSearchIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserSearchIntegrationTest.java
@@ -1,18 +1,20 @@
 package com.jjikmuk.sikdorak.integration.user.user;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.jjikmuk.sikdorak.integration.InitIntegrationTest;
 import com.jjikmuk.sikdorak.user.auth.controller.Authority;
 import com.jjikmuk.sikdorak.user.auth.controller.LoginUser;
 import com.jjikmuk.sikdorak.user.user.controller.response.UserProfileResponse;
+import com.jjikmuk.sikdorak.user.user.exception.NotFoundUserException;
 import com.jjikmuk.sikdorak.user.user.service.UserService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
- * [] 제공해야 하는 정보 : 닉네임, 프로필 이미지, 이메일(있다면), 조회자와 유저의 일치 여부, 팔로잉 상태, 팔로워 수, 팔로잉 수
+ * [] 제공해야 하는 정보 : 닉네임, 프로필 이미지, 이메일(있다면), 게시물 개수, 조회자와 유저의 일치 여부, 팔로잉 상태, 팔로워 수, 팔로잉 수
  */
 
 @DisplayName("유저 프로필 조회 통합 테스트")
@@ -33,6 +35,7 @@ public class UserSearchIntegrationTest extends InitIntegrationTest {
         assertThat(userProfileResponse.nickname()).isEqualTo(testData.user1.getNickname());
         assertThat(userProfileResponse.isViewer()).isTrue();
         assertThat(userProfileResponse.followStatus()).isFalse();
+        assertThat(userProfileResponse.reviewCount()).isEqualTo(1);
     }
 
     @Test
@@ -47,6 +50,7 @@ public class UserSearchIntegrationTest extends InitIntegrationTest {
         assertThat(userProfileResponse.nickname()).isEqualTo(testData.user1.getNickname());
         assertThat(userProfileResponse.isViewer()).isFalse();
         assertThat(userProfileResponse.followStatus()).isFalse();
+        assertThat(userProfileResponse.reviewCount()).isEqualTo(1);
     }
 
     @Test
@@ -61,6 +65,17 @@ public class UserSearchIntegrationTest extends InitIntegrationTest {
         assertThat(userProfileResponse.nickname()).isEqualTo(testData.followAcceptUser.getNickname());
         assertThat(userProfileResponse.isViewer()).isFalse();
         assertThat(userProfileResponse.followStatus()).isTrue();
+        assertThat(userProfileResponse.reviewCount()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 유저의 정보를 조회할 경우 예외를 반환한다.")
+    void not_found_user_search_another_user_profile() {
+        LoginUser loginUser = new LoginUser(testData.user1.getId(), Authority.USER);
+
+        assertThatThrownBy(() -> userService.searchUserProfile(
+            9999L, loginUser))
+            .isInstanceOf(NotFoundUserException.class);
     }
 
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserSearchIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserSearchIntegrationTest.java
@@ -54,8 +54,8 @@ class UserSearchIntegrationTest extends InitIntegrationTest {
     }
 
     @Test
-    @DisplayName("회원이 유저의 정보를 조회할 경우 유저 정보를 반환한다.")
-    void user_search_another_user_profile() {
+    @DisplayName("팔로우 되어 있는 회원이 유저의 정보를 조회할 경우 유저 정보를 반환한다.")
+    void user_search_following_user_profile() {
         LoginUser loginUser = new LoginUser(testData.followSendUser.getId(), Authority.USER);
 
         UserProfileResponse userProfileResponse = userService.searchUserProfile(
@@ -66,6 +66,21 @@ class UserSearchIntegrationTest extends InitIntegrationTest {
         assertThat(userProfileResponse.isViewer()).isFalse();
         assertThat(userProfileResponse.followStatus()).isTrue();
         assertThat(userProfileResponse.reviewCount()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("팔로우 되어 있는 회원이 유저의 정보를 조회할 경우 유저 정보를 반환한다.")
+    void user_search_unfollowing_user_profile() {
+        LoginUser loginUser = new LoginUser(testData.followSendUser.getId(), Authority.USER);
+
+        UserProfileResponse userProfileResponse = userService.searchUserProfile(
+            testData.user2.getId(), loginUser);
+
+        assertThat(userProfileResponse.id()).isEqualTo(testData.user2.getId());
+        assertThat(userProfileResponse.nickname()).isEqualTo(testData.user2.getNickname());
+        assertThat(userProfileResponse.isViewer()).isFalse();
+        assertThat(userProfileResponse.followStatus()).isFalse();
+        assertThat(userProfileResponse.reviewCount()).isEqualTo(0);
     }
 
     @Test

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserSearchIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserSearchIntegrationTest.java
@@ -1,0 +1,66 @@
+package com.jjikmuk.sikdorak.integration.user.user;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.jjikmuk.sikdorak.integration.InitIntegrationTest;
+import com.jjikmuk.sikdorak.user.auth.controller.Authority;
+import com.jjikmuk.sikdorak.user.auth.controller.LoginUser;
+import com.jjikmuk.sikdorak.user.user.controller.response.UserProfileResponse;
+import com.jjikmuk.sikdorak.user.user.service.UserService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * [] 제공해야 하는 정보 : 닉네임, 프로필 이미지, 이메일(있다면), 조회자와 유저의 일치 여부, 팔로잉 상태, 팔로워 수, 팔로잉 수
+ */
+
+@DisplayName("유저 프로필 조회 통합 테스트")
+public class UserSearchIntegrationTest extends InitIntegrationTest {
+
+    @Autowired
+    private UserService userService;
+
+    @Test
+    @DisplayName("유저 본인의 정보를 조회할 경우 유저 정보를 반환한다.")
+    void user_search_self_profile() {
+        LoginUser loginUser = new LoginUser(testData.user1.getId(), Authority.USER);
+
+        UserProfileResponse userProfileResponse = userService.searchUserProfile(
+            testData.user1.getId(), loginUser);
+
+        assertThat(userProfileResponse.id()).isEqualTo(testData.user1.getId());
+        assertThat(userProfileResponse.nickname()).isEqualTo(testData.user1.getNickname());
+        assertThat(userProfileResponse.isViewer()).isTrue();
+        assertThat(userProfileResponse.followStatus()).isFalse();
+    }
+
+    @Test
+    @DisplayName("비회원이 유저의 정보를 조회할 경우 유저 정보를 반환한다.")
+    void anonymous_user_search_user_profile() {
+        LoginUser loginUser = new LoginUser(null, Authority.ANONYMOUS);
+
+        UserProfileResponse userProfileResponse = userService.searchUserProfile(
+            testData.user1.getId(), loginUser);
+
+        assertThat(userProfileResponse.id()).isEqualTo(testData.user1.getId());
+        assertThat(userProfileResponse.nickname()).isEqualTo(testData.user1.getNickname());
+        assertThat(userProfileResponse.isViewer()).isFalse();
+        assertThat(userProfileResponse.followStatus()).isFalse();
+    }
+
+    @Test
+    @DisplayName("회원이 유저의 정보를 조회할 경우 유저 정보를 반환한다.")
+    void user_search_another_user_profile() {
+        LoginUser loginUser = new LoginUser(testData.followSendUser.getId(), Authority.USER);
+
+        UserProfileResponse userProfileResponse = userService.searchUserProfile(
+            testData.followAcceptUser.getId(), loginUser);
+
+        assertThat(userProfileResponse.id()).isEqualTo(testData.followAcceptUser.getId());
+        assertThat(userProfileResponse.nickname()).isEqualTo(testData.followAcceptUser.getNickname());
+        assertThat(userProfileResponse.isViewer()).isFalse();
+        assertThat(userProfileResponse.followStatus()).isTrue();
+    }
+
+}

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserSearchIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserSearchIntegrationTest.java
@@ -18,7 +18,7 @@ import org.springframework.beans.factory.annotation.Autowired;
  */
 
 @DisplayName("유저 프로필 조회 통합 테스트")
-public class UserSearchIntegrationTest extends InitIntegrationTest {
+class UserSearchIntegrationTest extends InitIntegrationTest {
 
     @Autowired
     private UserService userService;


### PR DESCRIPTION
### ❗️ 이슈 번호

[SDR-157]

<br><br>

### 📝 구현 내용

- 유저 조회 인수테스트, 통합테스트 작성
- 유저 조회 기능 구현

<br><br>

### 🙇🏻‍♂️ 리뷰어에게 부탁합니다!

- Followings 클래스 내에 있는 `isConnection` 메서드명을 `isConnected`로 변경했습니다.
- 테스트용 User 객체를 만들어봤었는데 유저 객체를 디비에 저장한 뒤에 (유저 아이디값 때문에) 다시 테스트용 유저객체에 넣는 작업은 오히려 코드양만 늘어나는 느낌이 들어서 제거하고 기능관련 pr만 먼저 올립니다!
지라 이슈로 만들어서 고민해보겠습니다!

[SDR-157]: https://jjikmuk.atlassian.net/browse/SDR-157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ