### PR TITLE
SDR-183 리뷰 디테일 조회 API 기능, 테스트, API 문서  / 배포 후 Health-Check 

### DIFF
--- a/.github/workflows/CD-BE.yml
+++ b/.github/workflows/CD-BE.yml
@@ -55,6 +55,19 @@ jobs:
         run: |
           ./gradlew jib
           heroku container:release web -a sikdorak-test
+  server-health-check:
+    needs: be-build-test
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Check the deployed service URL
+        uses: jtalk/url-health-check-action@v2
+        with:
+          url: https://sikdorak-test.herokuapp.com/docs/index.html|http://sikdorak-test.herokuapp.com/docs/index.html
+          follow-redirect: false
+          max-attempts: 3
+          retry-delay: 10s
+          retry-all: false
 
       - name: Noti Discord - Test Success
         uses: rjstone/discord-webhook-notify@v1

--- a/be/src/docs/asciidoc/review/review.adoc
+++ b/be/src/docs/asciidoc/review/review.adoc
@@ -1,3 +1,29 @@
+=== 리뷰 디테일 조회
+
+API : `GET /api/review/{reviewId}`
+
+=== `200 OK`
+
+==== `Request`
+
+operation::review_search_acceptance_test/search_review_detail_success[snippets='http-request,path-parameters']
+
+==== `Response`
+
+operation::review_search_acceptance_test/search_review_detail_success[snippets='http-response,response-fields']
+
+=== `401 Unauthorized`
+
+비회원 유저가 private review 조회한 경우
+
+==== `Request`
+
+operation::review_search_acceptance_test/search_review_detail_failed[snippets='http-request,path-parameters']
+
+==== `Response`
+
+operation::review_search_acceptance_test/search_review_detail_failed[snippets='http-response,response-fields']
+
 === 리뷰 생성
 
 API : `POST /api/reviews`

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/ResponseCodeAndMessages.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/ResponseCodeAndMessages.java
@@ -6,6 +6,7 @@ public enum ResponseCodeAndMessages implements CodeAndMessages {
     REVIEW_CREATE_SUCCESS("T-R001", "리뷰 생성 성공했습니다."),
     REVIEW_MODIFY_SUCCESS("T-R002", "리뷰 수정 성공했습니다."),
     REVIEW_REMOVE_SUCCESS("T-R003", "리뷰 삭제 성공했습니다."),
+    REVIEW_SEARCH_DETAIL_SUCCESS("T-R004", "리뷰 상세 조회 성공했습니다."),
 
     // OAuth
     LOGIN_SUCCESS("T-O001", "로그인에 성공했습니다."),

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/controller/ReviewController.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/controller/ReviewController.java
@@ -5,12 +5,14 @@ import com.jjikmuk.sikdorak.common.aop.UserOnly;
 import com.jjikmuk.sikdorak.common.response.CommonResponseEntity;
 import com.jjikmuk.sikdorak.review.controller.request.ReviewCreateRequest;
 import com.jjikmuk.sikdorak.review.controller.request.ReviewModifyRequest;
+import com.jjikmuk.sikdorak.review.controller.response.reviewdetail.ReviewDetailResponse;
 import com.jjikmuk.sikdorak.review.service.ReviewService;
 import com.jjikmuk.sikdorak.user.auth.controller.LoginUser;
 import com.jjikmuk.sikdorak.user.auth.domain.AuthenticatedUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -21,12 +23,25 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/reviews")
-@UserOnly
 public class ReviewController {
 
 	private final ReviewService reviewService;
 
+	@GetMapping("/{reviewId}")
+	public CommonResponseEntity<ReviewDetailResponse> searchReviewDetail(
+		@AuthenticatedUser LoginUser loginUser,
+		@PathVariable Long reviewId) {
+		ReviewDetailResponse reviewDetailResponse = reviewService.searchReviewDetail(loginUser,
+			reviewId);
+
+		return new CommonResponseEntity<>(
+			ResponseCodeAndMessages.REVIEW_SEARCH_DETAIL_SUCCESS,
+			reviewDetailResponse,
+			HttpStatus.OK);
+	}
+
 	@PostMapping
+	@UserOnly
 	public CommonResponseEntity<Void> createReview(
 		@AuthenticatedUser LoginUser loginUser,
 		@RequestBody ReviewCreateRequest reviewCreateRequest) {
@@ -37,6 +52,7 @@ public class ReviewController {
 	}
 
 	@PutMapping("/{reviewId}")
+	@UserOnly
 	public CommonResponseEntity<Void> modifyReview(
 		@PathVariable Long reviewId,
 		@AuthenticatedUser LoginUser loginUser,
@@ -48,6 +64,7 @@ public class ReviewController {
 	}
 
 	@DeleteMapping("/{reviewId}")
+	@UserOnly
 	public CommonResponseEntity<Void> removeReview(
 		@PathVariable Long reviewId,
 		@AuthenticatedUser LoginUser loginUser) {

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/controller/response/reviewdetail/ReviewDetailResponse.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/controller/response/reviewdetail/ReviewDetailResponse.java
@@ -1,0 +1,42 @@
+package com.jjikmuk.sikdorak.review.controller.response.reviewdetail;
+
+import com.jjikmuk.sikdorak.review.domain.Review;
+import com.jjikmuk.sikdorak.store.domain.Store;
+import com.jjikmuk.sikdorak.user.user.domain.User;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+
+public record ReviewDetailResponse(
+	ReviewDetailUserResponse user,
+	ReviewDetailStoreResponse store,
+	long reviewId,
+	String reviewContent,
+	float reviewScore,
+	String reviewVisibility,
+	LocalDate visitedDate,
+	Set<String> tags,
+	List<String> images,
+	LocalDateTime createdAt,
+	LocalDateTime updatedAt
+) {
+
+	public static ReviewDetailResponse of(Review review, Store store, User user) {
+		return new ReviewDetailResponse(
+			new ReviewDetailUserResponse(user),
+			new ReviewDetailStoreResponse(store),
+			review.getId(),
+			review.getReviewContent(),
+			review.getReviewScore(),
+			review.getReviewVisibility(),
+			review.getVisitedDate(),
+			review.getTags(),
+			review.getImages(),
+			review.getCreatedAt(),
+			review.getUpdatedAt()
+		);
+
+	}
+
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/controller/response/reviewdetail/ReviewDetailResponse.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/controller/response/reviewdetail/ReviewDetailResponse.java
@@ -7,18 +7,50 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.PastOrPresent;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
+import org.hibernate.validator.constraints.URL;
 
 public record ReviewDetailResponse(
 	ReviewDetailUserResponse user,
 	ReviewDetailStoreResponse store,
+
+	@NotNull
 	long reviewId,
+
+	@NotBlank
+	@Size(min = 1, max = 500)
 	String reviewContent,
+
+	@NotNull
+	@Pattern(regexp = "1-5")
 	float reviewScore,
+
+	@NotNull
+	@Pattern(regexp = "public\\|protected\\|private")
 	String reviewVisibility,
+
+	@NotNull
+	@PastOrPresent
+	@Pattern(regexp = "yyyy-MM-dd")
 	LocalDate visitedDate,
+
+	@Size(max = 30)
 	Set<String> tags,
+
+	@URL
+	@Size(max = 10)
 	List<String> images,
+
+	@NotNull
+	@Pattern(regexp = "yyyy-MM-dd")
 	LocalDateTime createdAt,
+
+	@NotNull
+	@Pattern(regexp = "yyyy-MM-dd")
 	LocalDateTime updatedAt
 ) {
 

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/controller/response/reviewdetail/ReviewDetailStoreResponse.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/controller/response/reviewdetail/ReviewDetailStoreResponse.java
@@ -1,14 +1,26 @@
 package com.jjikmuk.sikdorak.review.controller.response.reviewdetail;
 
 import com.jjikmuk.sikdorak.store.domain.Store;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 
 /**
  * - [ ] TODO : Store 대표 이미지 추가
  */
 public record ReviewDetailStoreResponse(
+	@NotNull
 	long storeId,
+
+	@NotBlank
+	@Size(min = 1, max = 500)
 	String storeName,
+
+	@NotNull
+	@Size(min = 1, max = 255)
 	String storeAddress
+
+	// String storeImage
 ) {
 
 	public ReviewDetailStoreResponse(Store store) {

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/controller/response/reviewdetail/ReviewDetailStoreResponse.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/controller/response/reviewdetail/ReviewDetailStoreResponse.java
@@ -1,0 +1,20 @@
+package com.jjikmuk.sikdorak.review.controller.response.reviewdetail;
+
+import com.jjikmuk.sikdorak.store.domain.Store;
+
+/**
+ * - [ ] TODO : Store 대표 이미지 추가
+ */
+public record ReviewDetailStoreResponse(
+	long storeId,
+	String storeName,
+	String storeAddress
+) {
+
+	public ReviewDetailStoreResponse(Store store) {
+		this(store.getId(),
+			store.getStoreName(),
+			store.getBaseAddress());
+	}
+}
+

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/controller/response/reviewdetail/ReviewDetailUserResponse.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/controller/response/reviewdetail/ReviewDetailUserResponse.java
@@ -1,0 +1,15 @@
+package com.jjikmuk.sikdorak.review.controller.response.reviewdetail;
+
+import com.jjikmuk.sikdorak.user.user.domain.User;
+
+public record ReviewDetailUserResponse(
+	long userId,
+	String userNickname,
+	String userProfileImage
+) {
+	public ReviewDetailUserResponse(User user) {
+		this(user.getId(),
+			user.getNickname(),
+			user.getProfileImage());
+	}
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/controller/response/reviewdetail/ReviewDetailUserResponse.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/controller/response/reviewdetail/ReviewDetailUserResponse.java
@@ -1,10 +1,19 @@
 package com.jjikmuk.sikdorak.review.controller.response.reviewdetail;
 
 import com.jjikmuk.sikdorak.user.user.domain.User;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import org.hibernate.validator.constraints.URL;
 
 public record ReviewDetailUserResponse(
+	@NotNull
 	long userId,
+
+	@NotNull
+	@Size(min = 1, max = 30)
 	String userNickname,
+
+	@URL
 	String userProfileImage
 ) {
 	public ReviewDetailUserResponse(User user) {

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/domain/Review.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/domain/Review.java
@@ -133,7 +133,7 @@ public class Review extends BaseTimeEntity {
 		this.deleted = true;
 	}
 
-	public boolean isRead(RelationType relationType) {
+	public boolean isReadable(RelationType relationType) {
 		return reviewVisibility.isRead(relationType);
 	}
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/domain/Review.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/domain/Review.java
@@ -1,6 +1,7 @@
 package com.jjikmuk.sikdorak.review.domain;
 
 import com.jjikmuk.sikdorak.common.domain.BaseTimeEntity;
+import com.jjikmuk.sikdorak.user.user.domain.RelationType;
 import com.jjikmuk.sikdorak.user.user.domain.User;
 import java.time.LocalDate;
 import java.util.List;
@@ -132,4 +133,7 @@ public class Review extends BaseTimeEntity {
 		this.deleted = true;
 	}
 
+	public boolean isRead(RelationType relationType) {
+		return reviewVisibility.isRead(relationType);
+	}
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/domain/ReviewVisibility.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/domain/ReviewVisibility.java
@@ -1,6 +1,7 @@
 package com.jjikmuk.sikdorak.review.domain;
 
 import com.jjikmuk.sikdorak.review.exception.InvalidReviewVisibilityException;
+import com.jjikmuk.sikdorak.user.user.domain.RelationType;
 
 public enum ReviewVisibility {
     PUBLIC ,PROTECTED, PRIVATE;
@@ -12,4 +13,16 @@ public enum ReviewVisibility {
             throw new InvalidReviewVisibilityException(e);
         }
     }
+
+	public boolean isRead(RelationType relationType) {
+		if (relationType.equals(RelationType.SELF)) {
+			return true;
+		} else if (relationType.equals(RelationType.CONNECTION)) {
+			return this.equals(PUBLIC) || this.equals(PROTECTED);
+		} else if (relationType.equals(RelationType.DISCONNECTION)) {
+			return this.equals(PUBLIC);
+		} else {
+			return false;
+		}
+	}
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/service/ReviewService.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/service/ReviewService.java
@@ -39,7 +39,7 @@ public class ReviewService {
 
 		RelationType relationType = reviewOwner.relationTypeTo(loginUser);
 
-		if (!review.isRead(relationType)) {
+		if (!review.isReadable(relationType)) {
 			throw new UnauthorizedUserException();
 		}
 

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/comment/CommentCreateAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/comment/CommentCreateAcceptanceTest.java
@@ -19,7 +19,7 @@ class CommentCreateAcceptanceTest extends InitAcceptanceTest {
 	@Test
 	@DisplayName("댓글 생성 요청이 정상적인 경우라면 댓글 생성 후 정상 상태 코드를 반환한다")
 	void create_comment_success() {
-		Long reviewId = testData.review.getId();
+		Long reviewId = testData.user1PublicReview.getId();
 
 		CommentCreateRequest commentCreateRequest = new CommentCreateRequest(
 			"좋은 리뷰 감사합니다"

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/comment/CommentSnippet.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/comment/CommentSnippet.java
@@ -1,7 +1,8 @@
 package com.jjikmuk.sikdorak.acceptance.comment;
 
-import static com.jjikmuk.sikdorak.acceptance.DocumentFormatGenerator.commonRequestFieldsWithValidConstraints;
-import static com.jjikmuk.sikdorak.acceptance.DocumentFormatGenerator.commonResponseNonFields;
+import static com.jjikmuk.sikdorak.acceptance.DocumentFormatGenerator.createResponseSnippetWithFields;
+import static com.jjikmuk.sikdorak.acceptance.DocumentFormatGenerator.requestSnippetWithConstraintsAndFields;
+import static com.jjikmuk.sikdorak.acceptance.DocumentFormatGenerator.responseFieldsOfCommonNonData;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
@@ -16,10 +17,10 @@ interface CommentSnippet {
 		parameterWithName("reviewId").description("리뷰 아이디")
 	);
 
-	Snippet COMMENT_CREATE_REQUEST_SNIPPET = commonRequestFieldsWithValidConstraints(
+	Snippet COMMENT_CREATE_REQUEST_SNIPPET = requestSnippetWithConstraintsAndFields(
 		CommentCreateRequest.class,
 		fieldWithPath("content").type(JsonFieldType.STRING).description("댓글 내용")
 	);
 
-	Snippet COMMENT_CREATE_RESPONSE_SNIPPET = commonResponseNonFields();
+	Snippet COMMENT_CREATE_RESPONSE_SNIPPET = createResponseSnippetWithFields(responseFieldsOfCommonNonData());
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/review/ReviewModifyAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/review/ReviewModifyAcceptanceTest.java
@@ -50,7 +50,7 @@ class ReviewModifyAcceptanceTest extends InitAcceptanceTest {
 			.body(reviewModifyRequest)
 
 		.when()
-			.put("/api/reviews/{reviewId}", testData.review.getId())
+			.put("/api/reviews/{reviewId}", testData.user1PublicReview.getId())
 
 		.then()
 			.statusCode(HttpStatus.OK.value())
@@ -83,7 +83,7 @@ class ReviewModifyAcceptanceTest extends InitAcceptanceTest {
 			.body(reviewModifyRequest)
 
 		.when()
-			.put("/api/reviews/{reviewId}", testData.review.getId())
+			.put("/api/reviews/{reviewId}", testData.user1PublicReview.getId())
 
 		.then()
 			.statusCode(HttpStatus.UNAUTHORIZED.value())

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/review/ReviewRemoveAccecptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/review/ReviewRemoveAccecptanceTest.java
@@ -35,7 +35,7 @@ class ReviewRemoveAccecptanceTest extends InitAcceptanceTest {
 			.header("Authorization", testData.user1ValidAuthorizationHeader)
 
 		.when()
-			.delete("/api/reviews/{reviewId}", testData.review.getId())
+			.delete("/api/reviews/{reviewId}", testData.user1PublicReview.getId())
 
 		.then()
 			.statusCode(HttpStatus.OK.value())
@@ -56,7 +56,7 @@ class ReviewRemoveAccecptanceTest extends InitAcceptanceTest {
 			.header("Content-type", "application/json")
 
 		.when()
-			.delete("/api/reviews/{reviewId}", testData.review.getId())
+			.delete("/api/reviews/{reviewId}", testData.user1PublicReview.getId())
 
 		.then()
 			.statusCode(HttpStatus.UNAUTHORIZED.value())

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/review/ReviewSearchAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/review/ReviewSearchAcceptanceTest.java
@@ -35,7 +35,7 @@ class ReviewSearchAcceptanceTest extends InitAcceptanceTest {
 			.header("Authorization", testData.followAcceptUserValidAuthorizationHeader)
 
 		.when()
-			.get("/api/reviews/{reviewId}", testData.follwAcceptUserPublicReview.getId())
+			.get("/api/reviews/{reviewId}", testData.followAcceptUserPublicReview.getId())
 
 		.then()
 			.statusCode(HttpStatus.OK.value())
@@ -58,7 +58,7 @@ class ReviewSearchAcceptanceTest extends InitAcceptanceTest {
 			.header("Content-type", "application/json")
 
 		.when()
-			.get("/api/reviews/{reviewId}", testData.follwAcceptUserPrivateReview.getId())
+			.get("/api/reviews/{reviewId}", testData.followAcceptUserPrivateReview.getId())
 
 		.then()
 			.statusCode(HttpStatus.UNAUTHORIZED.value())

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/review/ReviewSearchAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/review/ReviewSearchAcceptanceTest.java
@@ -32,7 +32,7 @@ class ReviewSearchAcceptanceTest extends InitAcceptanceTest {
 			.header("Authorization", testData.user1ValidAuthorizationHeader)
 
 		.when()
-			.get("/api/reviews/{reviewId}", testData.review.getId())
+			.get("/api/reviews/{reviewId}", testData.user1PublicReview.getId())
 
 		.then()
 			.log().all()

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/review/ReviewSearchAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/review/ReviewSearchAcceptanceTest.java
@@ -1,9 +1,14 @@
 package com.jjikmuk.sikdorak.acceptance.review;
 
+import static com.jjikmuk.sikdorak.acceptance.review.ReviewSnippet.REVIEW_DETAIL_SEARCH_REQUEST_PARAM_SNIPPET;
+import static com.jjikmuk.sikdorak.acceptance.review.ReviewSnippet.REVIEW_DETAIL_SEARCH_RESPONSE_FAILED_SNIPPET;
+import static com.jjikmuk.sikdorak.acceptance.review.ReviewSnippet.REVIEW_DETAIL_SEARCH_RESPONSE_SUCESS_SNIPPET;
 import static io.restassured.RestAssured.given;
+import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
 
 import com.jjikmuk.sikdorak.acceptance.InitAcceptanceTest;
 import com.jjikmuk.sikdorak.common.ResponseCodeAndMessages;
+import com.jjikmuk.sikdorak.common.exception.ExceptionCodeAndMessages;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,31 +24,47 @@ class ReviewSearchAcceptanceTest extends InitAcceptanceTest {
 
 	@Test
 	@DisplayName("유저가 본인 리뷰를 조회한 경우 디테일 리뷰를 보여준다.")
-	void modify_review_success() {
+	void search_review_detail_success() {
 		given(this.spec)
-			.log().all()
-//			.filter(
-//				document(DEFAULT_RESTDOC_PATH,
-//					REVIEW_MODIFY_REQUEST_PARAM_SNIPPET,
-//					REVIEW_MODIFY_REQUEST_SNIPPET,
-//					REVIEW_MODIFY_RESPONSE_SNIPPET))
+			.filter(
+				document(DEFAULT_RESTDOC_PATH,
+					REVIEW_DETAIL_SEARCH_REQUEST_PARAM_SNIPPET,
+					REVIEW_DETAIL_SEARCH_RESPONSE_SUCESS_SNIPPET))
 			.accept(MediaType.APPLICATION_JSON_VALUE)
 			.header("Content-type", "application/json")
-			.header("Authorization", testData.user1ValidAuthorizationHeader)
+			.header("Authorization", testData.followAcceptUserValidAuthorizationHeader)
 
 		.when()
-			.get("/api/reviews/{reviewId}", testData.user1PublicReview.getId())
+			.get("/api/reviews/{reviewId}", testData.follwAcceptUserPublicReview.getId())
 
 		.then()
-			.log().all()
 			.statusCode(HttpStatus.OK.value())
 			.body("code", Matchers.equalTo(ResponseCodeAndMessages.REVIEW_SEARCH_DETAIL_SUCCESS.getCode()))
 			.body("message",
-				Matchers.equalTo(ResponseCodeAndMessages.REVIEW_SEARCH_DETAIL_SUCCESS.getMessage()));
+				Matchers.equalTo(ResponseCodeAndMessages.REVIEW_SEARCH_DETAIL_SUCCESS.getMessage()))
+			.body("data.reviewVisibility", Matchers.equalTo("PUBLIC"));
 	}
 
 
+	@Test
+	@DisplayName("게스트가 읽을 권한없는 리뷰를 조회한 경우 예외 문구를 보낸다.")
+	void search_review_detail_failed() {
+		given(this.spec)
+			.filter(
+				document(DEFAULT_RESTDOC_PATH,
+					REVIEW_DETAIL_SEARCH_REQUEST_PARAM_SNIPPET,
+					REVIEW_DETAIL_SEARCH_RESPONSE_FAILED_SNIPPET))
+			.accept(MediaType.APPLICATION_JSON_VALUE)
+			.header("Content-type", "application/json")
 
+		.when()
+			.get("/api/reviews/{reviewId}", testData.follwAcceptUserPrivateReview.getId())
 
+		.then()
+			.statusCode(HttpStatus.UNAUTHORIZED.value())
+			.body("code", Matchers.equalTo(ExceptionCodeAndMessages.UNAUTHORIZED_USER.getCode()))
+			.body("message",
+				Matchers.equalTo(ExceptionCodeAndMessages.UNAUTHORIZED_USER.getMessage()));
+	}
 
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/review/ReviewSearchAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/review/ReviewSearchAcceptanceTest.java
@@ -1,0 +1,49 @@
+package com.jjikmuk.sikdorak.acceptance.review;
+
+import static io.restassured.RestAssured.given;
+
+import com.jjikmuk.sikdorak.acceptance.InitAcceptanceTest;
+import com.jjikmuk.sikdorak.common.ResponseCodeAndMessages;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+/**
+ * 디테일 조회 가능한 사람이 조회한 경우 : public 글
+ * 조회 불가능한 사람이 조회한 경우 : 게스트/친구관계가 protected, private 조회 , 친구관계가 private 조회
+ */
+@DisplayName("리뷰조회 인수테스트")
+class ReviewSearchAcceptanceTest extends InitAcceptanceTest {
+
+	@Test
+	@DisplayName("유저가 본인 리뷰를 조회한 경우 디테일 리뷰를 보여준다.")
+	void modify_review_success() {
+		given(this.spec)
+			.log().all()
+//			.filter(
+//				document(DEFAULT_RESTDOC_PATH,
+//					REVIEW_MODIFY_REQUEST_PARAM_SNIPPET,
+//					REVIEW_MODIFY_REQUEST_SNIPPET,
+//					REVIEW_MODIFY_RESPONSE_SNIPPET))
+			.accept(MediaType.APPLICATION_JSON_VALUE)
+			.header("Content-type", "application/json")
+			.header("Authorization", testData.user1ValidAuthorizationHeader)
+
+		.when()
+			.get("/api/reviews/{reviewId}", testData.review.getId())
+
+		.then()
+			.log().all()
+			.statusCode(HttpStatus.OK.value())
+			.body("code", Matchers.equalTo(ResponseCodeAndMessages.REVIEW_SEARCH_DETAIL_SUCCESS.getCode()))
+			.body("message",
+				Matchers.equalTo(ResponseCodeAndMessages.REVIEW_SEARCH_DETAIL_SUCCESS.getMessage()));
+	}
+
+
+
+
+
+}

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/review/ReviewSnippet.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/review/ReviewSnippet.java
@@ -1,18 +1,24 @@
 package com.jjikmuk.sikdorak.acceptance.review;
 
-import static com.jjikmuk.sikdorak.acceptance.DocumentFormatGenerator.commonRequestFieldsWithValidConstraints;
-import static com.jjikmuk.sikdorak.acceptance.DocumentFormatGenerator.commonResponseNonFields;
+import static com.jjikmuk.sikdorak.acceptance.DocumentFormatGenerator.createResponseSnippetWithFields;
+import static com.jjikmuk.sikdorak.acceptance.DocumentFormatGenerator.requestSnippetWithConstraintsAndFields;
+import static com.jjikmuk.sikdorak.acceptance.DocumentFormatGenerator.responseFieldsOfCommon;
+import static com.jjikmuk.sikdorak.acceptance.DocumentFormatGenerator.responseFieldsOfCommonNonData;
+import static com.jjikmuk.sikdorak.acceptance.DocumentFormatGenerator.responseFieldsOfObjectWithConstraintsAndFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 
 import com.jjikmuk.sikdorak.review.controller.request.ReviewCreateRequest;
+import com.jjikmuk.sikdorak.review.controller.response.reviewdetail.ReviewDetailResponse;
+import com.jjikmuk.sikdorak.review.controller.response.reviewdetail.ReviewDetailStoreResponse;
+import com.jjikmuk.sikdorak.review.controller.response.reviewdetail.ReviewDetailUserResponse;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.restdocs.snippet.Snippet;
 
 interface ReviewSnippet {
 
-	Snippet REVIEW_CREATE_REQUEST_SNIPPET = commonRequestFieldsWithValidConstraints(
+	Snippet REVIEW_CREATE_REQUEST_SNIPPET = requestSnippetWithConstraintsAndFields(
 		ReviewCreateRequest.class,
 		fieldWithPath("reviewContent")
 			.type(JsonFieldType.STRING)
@@ -37,11 +43,11 @@ interface ReviewSnippet {
 			.description("리뷰를 위한 사진 URL")
 	);
 
-	Snippet REVIEW_CREATE_RESPONSE_SNIPPET = commonResponseNonFields();
+	Snippet REVIEW_CREATE_RESPONSE_SNIPPET = createResponseSnippetWithFields(responseFieldsOfCommonNonData());
 
 	Snippet REVIEW_MODIFY_REQUEST_SNIPPET = REVIEW_CREATE_REQUEST_SNIPPET;
 
-	Snippet REVIEW_MODIFY_RESPONSE_SNIPPET = commonResponseNonFields();
+	Snippet REVIEW_MODIFY_RESPONSE_SNIPPET = createResponseSnippetWithFields(responseFieldsOfCommonNonData());
 
 	Snippet REVIEW_MODIFY_REQUEST_PARAM_SNIPPET = pathParameters(
 		parameterWithName("reviewId").description("리뷰 아이디")
@@ -51,6 +57,36 @@ interface ReviewSnippet {
 		parameterWithName("reviewId").description("리뷰 아이디")
 	);
 
-	Snippet REVIEW_REMOVE_RESPONSE_SNIPPET = commonResponseNonFields();
+	Snippet REVIEW_REMOVE_RESPONSE_SNIPPET = createResponseSnippetWithFields(responseFieldsOfCommonNonData());
 
+	Snippet REVIEW_DETAIL_SEARCH_REQUEST_PARAM_SNIPPET = pathParameters(
+		parameterWithName("reviewId").description("리뷰 아이디")
+	);
+
+	Snippet test_test = createResponseSnippetWithFields(
+		responseFieldsOfCommon(),
+
+		responseFieldsOfObjectWithConstraintsAndFields(ReviewDetailUserResponse.class,
+			fieldWithPath("user").type(JsonFieldType.OBJECT).description("유저 정보"),
+			fieldWithPath("user.userId").type(JsonFieldType.NUMBER).description("유저 아이디"),
+			fieldWithPath("user.userNickname").type(JsonFieldType.STRING).description("유저 이름"),
+			fieldWithPath("user.userProfileImage").type(JsonFieldType.STRING)
+				.description("유저 프로필 이미지")),
+
+		responseFieldsOfObjectWithConstraintsAndFields(ReviewDetailStoreResponse.class,
+			fieldWithPath("store").type(JsonFieldType.OBJECT).description("가게 정보"),
+			fieldWithPath("store.storeId").type(JsonFieldType.NUMBER).description("가게 아이디"),
+			fieldWithPath("store.storeName").type(JsonFieldType.STRING).description("가게 이름"),
+			fieldWithPath("store.storeAddress").type(JsonFieldType.STRING).description("가게 주소")),
+
+		responseFieldsOfObjectWithConstraintsAndFields(ReviewDetailResponse.class,
+			fieldWithPath("reviewId").type(JsonFieldType.NUMBER).description("리뷰 아이디"),
+			fieldWithPath("reviewContent").type(JsonFieldType.STRING).description("리뷰 내용"),
+			fieldWithPath("reviewScore").type(JsonFieldType.NUMBER).description("리뷰 점수"),
+			fieldWithPath("reviewVisibility").type(JsonFieldType.STRING).description("리뷰 게시물의 공개 범위"),
+			fieldWithPath("visitedDate").type(JsonFieldType.STRING).description("가게 방문일"),
+			fieldWithPath("tags").type(JsonFieldType.ARRAY).description("리뷰를 표현하는 태그들"),
+			fieldWithPath("images").type(JsonFieldType.ARRAY).description("리뷰를 위한 사진 URL"),
+			fieldWithPath("createdAt").type(JsonFieldType.STRING).description("리뷰 생성 시간"),
+			fieldWithPath("updatedAt").type(JsonFieldType.STRING).description("리뷰 수정 시간")));
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/review/ReviewSnippet.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/review/ReviewSnippet.java
@@ -63,7 +63,7 @@ interface ReviewSnippet {
 		parameterWithName("reviewId").description("리뷰 아이디")
 	);
 
-	Snippet test_test = createResponseSnippetWithFields(
+	Snippet REVIEW_DETAIL_SEARCH_RESPONSE_SUCESS_SNIPPET = createResponseSnippetWithFields(
 		responseFieldsOfCommon(),
 
 		responseFieldsOfObjectWithConstraintsAndFields(ReviewDetailUserResponse.class,
@@ -89,4 +89,8 @@ interface ReviewSnippet {
 			fieldWithPath("images").type(JsonFieldType.ARRAY).description("리뷰를 위한 사진 URL"),
 			fieldWithPath("createdAt").type(JsonFieldType.STRING).description("리뷰 생성 시간"),
 			fieldWithPath("updatedAt").type(JsonFieldType.STRING).description("리뷰 수정 시간")));
+
+	Snippet REVIEW_DETAIL_SEARCH_RESPONSE_FAILED_SNIPPET = createResponseSnippetWithFields(
+		responseFieldsOfCommonNonData());
+
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/store/StoreSnippet.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/store/StoreSnippet.java
@@ -1,7 +1,9 @@
 package com.jjikmuk.sikdorak.acceptance.store;
 
-import static com.jjikmuk.sikdorak.acceptance.DocumentFormatGenerator.commonListResponseFieldsWithValidConstraints;
-import static com.jjikmuk.sikdorak.acceptance.DocumentFormatGenerator.commonResponseNonFields;
+import static com.jjikmuk.sikdorak.acceptance.DocumentFormatGenerator.createResponseSnippetWithFields;
+import static com.jjikmuk.sikdorak.acceptance.DocumentFormatGenerator.responseFieldsOfCommon;
+import static com.jjikmuk.sikdorak.acceptance.DocumentFormatGenerator.responseFieldsOfCommonNonData;
+import static com.jjikmuk.sikdorak.acceptance.DocumentFormatGenerator.responseFieldsOfListWithConstraintsAndFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
@@ -15,45 +17,70 @@ import org.springframework.restdocs.snippet.Snippet;
 public interface StoreSnippet {
 
 	Snippet STORE_SEARCH_REQUEST = requestParameters(
-			parameterWithName("storeName").description("가게 이름 검색 키워드")
+		parameterWithName("storeName").description("가게 이름 검색 키워드")
 	);
 
-	Snippet STORE_SEARCH_RESPONSE = commonListResponseFieldsWithValidConstraints(
+	Snippet STORE_SEARCH_RESPONSE = createResponseSnippetWithFields(
+		responseFieldsOfCommon(),
+
+		responseFieldsOfListWithConstraintsAndFields(
 			StoreSearchResponse.class,
-			 fieldWithPath("id").type(JsonFieldType.NUMBER).description(Constants.ID_DESCRIPTION),
-			fieldWithPath("storeName").type(JsonFieldType.STRING).description(Constants.STORENAME_DESCRIPTION),
-			fieldWithPath("contactNumber").type(JsonFieldType.STRING).description(Constants.CONTACTNUMBER_DESCRIPTION),
-			fieldWithPath("baseAddress").type(JsonFieldType.STRING).description(Constants.BASEADDRESS_DESCRIPTION),
-			fieldWithPath("detailAddress").type(JsonFieldType.STRING).description(Constants.DETAILADDRESS_DESCRIPTION).optional(),
-			fieldWithPath("latitude").type(JsonFieldType.NUMBER).description(Constants.LATITUDE_DESCRIPTION),
-			fieldWithPath("longitude").type(JsonFieldType.NUMBER).description(Constants.LONGITUDE_DESCRIPTION)
+			fieldWithPath("id").type(JsonFieldType.NUMBER).description(Constants.ID_DESCRIPTION),
+			fieldWithPath("storeName").type(JsonFieldType.STRING)
+				.description(Constants.STORENAME_DESCRIPTION),
+			fieldWithPath("contactNumber").type(JsonFieldType.STRING)
+				.description(Constants.CONTACTNUMBER_DESCRIPTION),
+			fieldWithPath("baseAddress").type(JsonFieldType.STRING)
+				.description(Constants.BASEADDRESS_DESCRIPTION),
+			fieldWithPath("detailAddress").type(JsonFieldType.STRING)
+				.description(Constants.DETAILADDRESS_DESCRIPTION).optional(),
+			fieldWithPath("latitude").type(JsonFieldType.NUMBER)
+				.description(Constants.LATITUDE_DESCRIPTION),
+			fieldWithPath("longitude").type(JsonFieldType.NUMBER)
+				.description(Constants.LONGITUDE_DESCRIPTION)
+
+		)
 	);
 
 	Snippet STORE_CREATE_REQUEST_SNIPPET = requestFields(
-		fieldWithPath("storeName").type(JsonFieldType.STRING).description(Constants.STORENAME_DESCRIPTION),
-		fieldWithPath("contactNumber").type(JsonFieldType.STRING).description(Constants.CONTACTNUMBER_DESCRIPTION),
-		fieldWithPath("baseAddress").type(JsonFieldType.STRING).description(Constants.BASEADDRESS_DESCRIPTION),
-		fieldWithPath("detailAddress").type(JsonFieldType.STRING).description(Constants.DETAILADDRESS_DESCRIPTION).optional(),
-		fieldWithPath("latitude").type(JsonFieldType.NUMBER).description(Constants.LATITUDE_DESCRIPTION),
-		fieldWithPath("longitude").type(JsonFieldType.NUMBER).description(Constants.LONGITUDE_DESCRIPTION)
+		fieldWithPath("storeName").type(JsonFieldType.STRING)
+			.description(Constants.STORENAME_DESCRIPTION),
+		fieldWithPath("contactNumber").type(JsonFieldType.STRING)
+			.description(Constants.CONTACTNUMBER_DESCRIPTION),
+		fieldWithPath("baseAddress").type(JsonFieldType.STRING)
+			.description(Constants.BASEADDRESS_DESCRIPTION),
+		fieldWithPath("detailAddress").type(JsonFieldType.STRING)
+			.description(Constants.DETAILADDRESS_DESCRIPTION).optional(),
+		fieldWithPath("latitude").type(JsonFieldType.NUMBER)
+			.description(Constants.LATITUDE_DESCRIPTION),
+		fieldWithPath("longitude").type(JsonFieldType.NUMBER)
+			.description(Constants.LONGITUDE_DESCRIPTION)
 	);
 
-	Snippet STORE_CREATE_RESPONSE_SNIPPET = commonResponseNonFields();
+	Snippet STORE_CREATE_RESPONSE_SNIPPET = createResponseSnippetWithFields(
+		responseFieldsOfCommonNonData());
 
 	Snippet STORE_MODIFY_REQUEST_PARAM_SNIPPET = pathParameters(
 		parameterWithName("storeId").description(Constants.ID_DESCRIPTION)
 	);
 
 	Snippet STORE_MODIFY_REQUEST_SNIPPET = requestFields(
-		fieldWithPath("storeName").type(JsonFieldType.STRING).description(Constants.STORENAME_DESCRIPTION),
-		fieldWithPath("contactNumber").type(JsonFieldType.STRING).description(Constants.CONTACTNUMBER_DESCRIPTION),
-		fieldWithPath("baseAddress").type(JsonFieldType.STRING).description(Constants.BASEADDRESS_DESCRIPTION),
-		fieldWithPath("detailAddress").type(JsonFieldType.STRING).description(Constants.DETAILADDRESS_DESCRIPTION).optional(),
-		fieldWithPath("latitude").type(JsonFieldType.NUMBER).description(Constants.LATITUDE_DESCRIPTION),
-		fieldWithPath("longitude").type(JsonFieldType.NUMBER).description(Constants.LONGITUDE_DESCRIPTION)
+		fieldWithPath("storeName").type(JsonFieldType.STRING)
+			.description(Constants.STORENAME_DESCRIPTION),
+		fieldWithPath("contactNumber").type(JsonFieldType.STRING)
+			.description(Constants.CONTACTNUMBER_DESCRIPTION),
+		fieldWithPath("baseAddress").type(JsonFieldType.STRING)
+			.description(Constants.BASEADDRESS_DESCRIPTION),
+		fieldWithPath("detailAddress").type(JsonFieldType.STRING)
+			.description(Constants.DETAILADDRESS_DESCRIPTION).optional(),
+		fieldWithPath("latitude").type(JsonFieldType.NUMBER)
+			.description(Constants.LATITUDE_DESCRIPTION),
+		fieldWithPath("longitude").type(JsonFieldType.NUMBER)
+			.description(Constants.LONGITUDE_DESCRIPTION)
 	);
 
-	Snippet STORE_MODIFY_RESPONSE_SNIPPET = commonResponseNonFields();
+	Snippet STORE_MODIFY_RESPONSE_SNIPPET = createResponseSnippetWithFields(
+		responseFieldsOfCommonNonData());
 
 	Snippet STORE_REMOVE_REQUEST_PARAM_SNIPPET = pathParameters(
 		parameterWithName("storeId").description(Constants.ID_DESCRIPTION)
@@ -62,6 +89,7 @@ public interface StoreSnippet {
 	Snippet STORE_REMOVE_RESPONSE_SNIPPET = commonResponseNonFields();
 
 	class Constants {
+
 		private static final String ID_DESCRIPTION = "가게 아이디";
 		private static final String STORENAME_DESCRIPTION = "가게 이름";
 		private static final String CONTACTNUMBER_DESCRIPTION = "가게 연락처";

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/store/StoreSnippet.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/store/StoreSnippet.java
@@ -86,7 +86,8 @@ public interface StoreSnippet {
 		parameterWithName("storeId").description(Constants.ID_DESCRIPTION)
 	);
 
-	Snippet STORE_REMOVE_RESPONSE_SNIPPET = commonResponseNonFields();
+	Snippet STORE_REMOVE_RESPONSE_SNIPPET =  createResponseSnippetWithFields(
+		responseFieldsOfCommonNonData());
 
 	class Constants {
 

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/auth/OAuthSnippet.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/auth/OAuthSnippet.java
@@ -1,7 +1,7 @@
 package com.jjikmuk.sikdorak.acceptance.user.auth;
 
-import static com.jjikmuk.sikdorak.acceptance.DocumentFormatGenerator.commonResponseNonFields;
-import static com.jjikmuk.sikdorak.acceptance.DocumentFormatGenerator.commonSingleResponseFieldsWithValidConstraints;
+import static com.jjikmuk.sikdorak.acceptance.DocumentFormatGenerator.responseSnippetOfCommonNonData;
+import static com.jjikmuk.sikdorak.acceptance.DocumentFormatGenerator.responseSnippetOfCommonWithConstraints;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
@@ -19,7 +19,7 @@ public interface OAuthSnippet {
             parameterWithName("code").description("Kakao Authorization Code")
     );
 
-    Snippet LOGIN_SUCCESS_RESPONSE_SNIPPET = commonSingleResponseFieldsWithValidConstraints(
+    Snippet LOGIN_SUCCESS_RESPONSE_SNIPPET = responseSnippetOfCommonWithConstraints(
             JwtTokenPair.class,
             fieldWithPath("accessToken").type(JsonFieldType.STRING).description("액세스 토큰")
     );
@@ -29,10 +29,10 @@ public interface OAuthSnippet {
     );
 
 
-    Snippet UPDATE_ACCESS_TOKEN_SUCCESS_RESPONSE_SNIPPET = commonSingleResponseFieldsWithValidConstraints(
+    Snippet UPDATE_ACCESS_TOKEN_SUCCESS_RESPONSE_SNIPPET = responseSnippetOfCommonWithConstraints(
         AccessTokenResponse.class,
         fieldWithPath("accessToken").type(JsonFieldType.STRING).description("액세스 토큰")
     );
 
-    Snippet UPDATE_ACCESS_TOKEN_FAIL_RESPONSE_SNIPPET = commonResponseNonFields();
+    Snippet UPDATE_ACCESS_TOKEN_FAIL_RESPONSE_SNIPPET = responseSnippetOfCommonNonData();
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/user/UserSnippet.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/user/UserSnippet.java
@@ -1,9 +1,11 @@
 package com.jjikmuk.sikdorak.acceptance.user.user;
 
-import static com.jjikmuk.sikdorak.acceptance.DocumentFormatGenerator.commonListResponseFieldsWithValidConstraints;
-import static com.jjikmuk.sikdorak.acceptance.DocumentFormatGenerator.commonRequestFieldsWithValidConstraints;
-import static com.jjikmuk.sikdorak.acceptance.DocumentFormatGenerator.commonResponseNonFields;
-import static com.jjikmuk.sikdorak.acceptance.DocumentFormatGenerator.commonSingleResponseFieldsWithValidConstraints;
+import static com.jjikmuk.sikdorak.acceptance.DocumentFormatGenerator.createResponseSnippetWithFields;
+import static com.jjikmuk.sikdorak.acceptance.DocumentFormatGenerator.requestSnippetWithConstraintsAndFields;
+import static com.jjikmuk.sikdorak.acceptance.DocumentFormatGenerator.responseFieldsOfCommon;
+import static com.jjikmuk.sikdorak.acceptance.DocumentFormatGenerator.responseFieldsOfCommonNonData;
+import static com.jjikmuk.sikdorak.acceptance.DocumentFormatGenerator.responseFieldsOfListWithConstraintsAndFields;
+import static com.jjikmuk.sikdorak.acceptance.DocumentFormatGenerator.responseFieldsOfObjectWithConstraintsAndFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
@@ -17,56 +19,64 @@ import org.springframework.restdocs.snippet.Snippet;
 
 public interface UserSnippet {
 
-    Snippet USER_MODIFY_REQUEST_SNIPPET = commonRequestFieldsWithValidConstraints(
+    Snippet USER_MODIFY_REQUEST_SNIPPET = requestSnippetWithConstraintsAndFields(
         UserModifyRequest.class,
         fieldWithPath("nickname").type(JsonFieldType.STRING).description("nickname"),
         fieldWithPath("email").type(JsonFieldType.STRING).description("email"),
         fieldWithPath("profileImage").type(JsonFieldType.STRING).description("프로필 이미지")
     );
 
-    Snippet USER_MODIFY_RESPONSE_SNIPPET = commonResponseNonFields();
+    Snippet USER_MODIFY_RESPONSE_SNIPPET = createResponseSnippetWithFields(responseFieldsOfCommonNonData());
 
-    Snippet USER_FOLLOW_REQUEST_SNIPPET = commonRequestFieldsWithValidConstraints(
+    Snippet USER_FOLLOW_REQUEST_SNIPPET = requestSnippetWithConstraintsAndFields(
         UserFollowAndUnfollowRequest.class,
         fieldWithPath("userId").type(JsonFieldType.NUMBER).description("팔로우 할 유저 아이디")
     );
 
-    Snippet USER_FOLLOW_RESPONSE_SNIPPET = commonResponseNonFields();
+    Snippet USER_FOLLOW_RESPONSE_SNIPPET = createResponseSnippetWithFields(responseFieldsOfCommonNonData());
 
     Snippet USER_SEARCH_REVIEWS_REQUEST_PARAM_SNIPPET = pathParameters(
         parameterWithName("userId").description("리뷰를 조회할 유저 아이디")
     );
 
-    Snippet USER_SEARCH_REVIEWS_RESPONSE_SNIPPET = commonListResponseFieldsWithValidConstraints(
-        UserReviewResponse.class,
-        fieldWithPath("id").type(JsonFieldType.NUMBER).description("리뷰 아이디"),
-        fieldWithPath("userId").type(JsonFieldType.NUMBER).description("리뷰를 작성한 유저 아이디"),
-        fieldWithPath("storeId").type(JsonFieldType.NUMBER).description("리뷰 작성 대상 가게 아이디"),
-        fieldWithPath("reviewContent").type(JsonFieldType.STRING).description("리뷰 내용"),
-        fieldWithPath("reviewScore").type(JsonFieldType.NUMBER).description("리뷰 평점"),
-        fieldWithPath("reviewVisibility").type(JsonFieldType.STRING).description("리뷰 보기 권한"),
-        fieldWithPath("visitedDate").type(JsonFieldType.STRING).description("가게 방문 날짜"),
-        fieldWithPath("tags").type(JsonFieldType.ARRAY).description("리뷰 태그들"),
-        fieldWithPath("images").type(JsonFieldType.ARRAY).description("리뷰 이미지"),
-        fieldWithPath("createdAt").type(JsonFieldType.STRING).description("리뷰 생성 시간"),
-        fieldWithPath("updatedAt").type(JsonFieldType.STRING).description("리뷰 수정 시간")
+    Snippet USER_SEARCH_REVIEWS_RESPONSE_SNIPPET = createResponseSnippetWithFields(
+        responseFieldsOfCommon(),
+
+        responseFieldsOfListWithConstraintsAndFields(
+            UserReviewResponse.class,
+            fieldWithPath("id").type(JsonFieldType.NUMBER).description("리뷰 아이디"),
+            fieldWithPath("userId").type(JsonFieldType.NUMBER).description("리뷰를 작성한 유저 아이디"),
+            fieldWithPath("storeId").type(JsonFieldType.NUMBER).description("리뷰 작성 대상 가게 아이디"),
+            fieldWithPath("reviewContent").type(JsonFieldType.STRING).description("리뷰 내용"),
+            fieldWithPath("reviewScore").type(JsonFieldType.NUMBER).description("리뷰 평점"),
+            fieldWithPath("reviewVisibility").type(JsonFieldType.STRING).description("리뷰 보기 권한"),
+            fieldWithPath("visitedDate").type(JsonFieldType.STRING).description("가게 방문 날짜"),
+            fieldWithPath("tags").type(JsonFieldType.ARRAY).description("리뷰 태그들"),
+            fieldWithPath("images").type(JsonFieldType.ARRAY).description("리뷰 이미지"),
+            fieldWithPath("createdAt").type(JsonFieldType.STRING).description("리뷰 생성 시간"),
+            fieldWithPath("updatedAt").type(JsonFieldType.STRING).description("리뷰 수정 시간")
+        )
     );
 
     Snippet USER_SEARCH_REQUEST_SNIPPET = pathParameters(
         parameterWithName("userId").description("프로필을 조회할 유저 아이디")
     );
 
-    Snippet USER_SEARCH_RESPONSE_SNIPPET = commonSingleResponseFieldsWithValidConstraints(
-        UserProfileResponse.class,
-        fieldWithPath("id").type(JsonFieldType.NUMBER).description("유저 아이디"),
-        fieldWithPath("nickname").type(JsonFieldType.STRING).description("유저 닉네임"),
-        fieldWithPath("email").type(JsonFieldType.STRING).description("유저 이메일"),
-        fieldWithPath("profileImage").type(JsonFieldType.STRING).description("유저 프로필 이미지"),
-        fieldWithPath("relationStatus.isViewer").type(JsonFieldType.BOOLEAN).description("자신의 프로필 조회 여부"),
-        fieldWithPath("relationStatus.followStatus").type(JsonFieldType.BOOLEAN).description("요청 유저와의 관계"),
-        fieldWithPath("followersCount").type(JsonFieldType.NUMBER).description("유저 팔로워 수"),
-        fieldWithPath("followingCount").type(JsonFieldType.NUMBER).description("유저 팔로잉 수"),
-        fieldWithPath("reviewCount").type(JsonFieldType.NUMBER).description("유저 게시물 수")
+    Snippet USER_SEARCH_RESPONSE_SNIPPET = createResponseSnippetWithFields(
+        responseFieldsOfCommon(),
+
+        responseFieldsOfObjectWithConstraintsAndFields(
+            UserProfileResponse.class,
+            fieldWithPath("id").type(JsonFieldType.NUMBER).description("유저 아이디"),
+            fieldWithPath("nickname").type(JsonFieldType.STRING).description("유저 닉네임"),
+            fieldWithPath("email").type(JsonFieldType.STRING).description("유저 이메일"),
+            fieldWithPath("profileImage").type(JsonFieldType.STRING).description("유저 프로필 이미지"),
+            fieldWithPath("relationStatus.isViewer").type(JsonFieldType.BOOLEAN).description("자신의 프로필 조회 여부"),
+            fieldWithPath("relationStatus.followStatus").type(JsonFieldType.BOOLEAN).description("요청 유저와의 관계"),
+            fieldWithPath("followersCount").type(JsonFieldType.NUMBER).description("유저 팔로워 수"),
+            fieldWithPath("followingCount").type(JsonFieldType.NUMBER).description("유저 팔로잉 수"),
+            fieldWithPath("reviewCount").type(JsonFieldType.NUMBER).description("유저 게시물 수")
+        )
     );
 
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/common/DatabaseConfigurator.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/common/DatabaseConfigurator.java
@@ -54,9 +54,9 @@ public class DatabaseConfigurator implements InitializingBean {
     public String user1ExpiredRefreshToken;
     public String user1InvalidRefreshToken;
     public Review user1PublicReview;
-    public Review follwAcceptUserPublicReview;
-    public Review follwAcceptUserProtectedReview;
-    public Review follwAcceptUserPrivateReview;
+    public Review followAcceptUserPublicReview;
+    public Review followAcceptUserProtectedReview;
+    public Review followAcceptUserPrivateReview;
 
     public void initDataSource() {
         initStoreData();
@@ -167,7 +167,7 @@ public class DatabaseConfigurator implements InitializingBean {
             List.of("tag1", "tag2"),
             List.of("https://s3.ap-northeast-2.amazonaws.com/sikdorak/test.jpg")));
 
-        this.follwAcceptUserPublicReview = reviewRepository.save(new Review(this.followAcceptUser.getId(),
+        this.followAcceptUserPublicReview = reviewRepository.save(new Review(this.followAcceptUser.getId(),
             this.store.getId(),
             "전체 공개된 리뷰 게시물",
             3.f,
@@ -176,7 +176,7 @@ public class DatabaseConfigurator implements InitializingBean {
             List.of("tag1", "tag2"),
             List.of("https://s3.ap-northeast-2.amazonaws.com/sikdorak/test.jpg")));
 
-        this.follwAcceptUserProtectedReview = reviewRepository.save(new Review(this.followAcceptUser.getId(),
+        this.followAcceptUserProtectedReview = reviewRepository.save(new Review(this.followAcceptUser.getId(),
             this.store.getId(),
             "친구 공개된 리뷰 게시물",
             3.f,
@@ -185,7 +185,7 @@ public class DatabaseConfigurator implements InitializingBean {
             List.of("tag1", "tag2"),
             List.of("https://s3.ap-northeast-2.amazonaws.com/sikdorak/test.jpg")));
 
-        this.follwAcceptUserPrivateReview = reviewRepository.save(new Review(this.followAcceptUser.getId(),
+        this.followAcceptUserPrivateReview = reviewRepository.save(new Review(this.followAcceptUser.getId(),
             this.store.getId(),
             "비공개된 리뷰 게시물",
             3.f,

--- a/be/src/test/java/com/jjikmuk/sikdorak/common/DatabaseConfigurator.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/common/DatabaseConfigurator.java
@@ -53,7 +53,10 @@ public class DatabaseConfigurator implements InitializingBean {
     public String user1RefreshToken;
     public String user1ExpiredRefreshToken;
     public String user1InvalidRefreshToken;
-    public Review review;
+    public Review user1PublicReview;
+    public Review follwAcceptUserPublicReview;
+    public Review follwAcceptUserProtectedReview;
+    public Review follwAcceptUserPrivateReview;
 
     public void initDataSource() {
         initStoreData();
@@ -155,7 +158,7 @@ public class DatabaseConfigurator implements InitializingBean {
     }
 
     private void initReviewData() {
-        this.review = reviewRepository.save(new Review(this.user1.getId(),
+        this.user1PublicReview = reviewRepository.save(new Review(this.user1.getId(),
             this.store.getId(),
             "Test review contents",
             3.f,
@@ -164,7 +167,7 @@ public class DatabaseConfigurator implements InitializingBean {
             List.of("tag1", "tag2"),
             List.of("https://s3.ap-northeast-2.amazonaws.com/sikdorak/test.jpg")));
 
-        reviewRepository.save(new Review(this.followAcceptUser.getId(),
+        this.follwAcceptUserPublicReview = reviewRepository.save(new Review(this.followAcceptUser.getId(),
             this.store.getId(),
             "전체 공개된 리뷰 게시물",
             3.f,
@@ -173,7 +176,7 @@ public class DatabaseConfigurator implements InitializingBean {
             List.of("tag1", "tag2"),
             List.of("https://s3.ap-northeast-2.amazonaws.com/sikdorak/test.jpg")));
 
-        reviewRepository.save(new Review(this.followAcceptUser.getId(),
+        this.follwAcceptUserProtectedReview = reviewRepository.save(new Review(this.followAcceptUser.getId(),
             this.store.getId(),
             "친구 공개된 리뷰 게시물",
             3.f,
@@ -182,7 +185,7 @@ public class DatabaseConfigurator implements InitializingBean {
             List.of("tag1", "tag2"),
             List.of("https://s3.ap-northeast-2.amazonaws.com/sikdorak/test.jpg")));
 
-        reviewRepository.save(new Review(this.followAcceptUser.getId(),
+        this.follwAcceptUserPrivateReview = reviewRepository.save(new Review(this.followAcceptUser.getId(),
             this.store.getId(),
             "비공개된 리뷰 게시물",
             3.f,

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/comment/CommentCreateIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/comment/CommentCreateIntegrationTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.jjikmuk.sikdorak.comment.controller.request.CommentCreateRequest;
 import com.jjikmuk.sikdorak.comment.domain.Comment;
-import com.jjikmuk.sikdorak.comment.repository.CommentRepository;
 import com.jjikmuk.sikdorak.comment.service.CommentService;
 import com.jjikmuk.sikdorak.integration.InitIntegrationTest;
 import com.jjikmuk.sikdorak.review.exception.NotFoundReviewException;
@@ -30,7 +29,7 @@ class CommentCreateIntegrationTest extends InitIntegrationTest {
 		@DisplayName("정상적인 댓글 작성 요청이 주어진다면, 댓글이 생성된다.")
 		void create_store_success() {
 			// given
-			long reviewId = testData.review.getId();
+			long reviewId = testData.user1PublicReview.getId();
 			LoginUser loginUser = new LoginUser(testData.user1.getId(), Authority.USER);
 			CommentCreateRequest createRequest = new CommentCreateRequest(
 				"맛집이네요!"
@@ -65,7 +64,7 @@ class CommentCreateIntegrationTest extends InitIntegrationTest {
 		@DisplayName("존재하지 않는 유저가 댓글 생성 요청을 한다면 예외를 발생시킨다")
 		void create_comment_with_not_existing_user_will_failed() {
 			// given
-			long reviewId = testData.review.getId();
+			long reviewId = testData.user1PublicReview.getId();
 			long notExistingUserId = Long.MIN_VALUE;
 			LoginUser loginUser = new LoginUser(notExistingUserId, Authority.USER);
 			CommentCreateRequest createRequest = new CommentCreateRequest(

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/review/ReviewModifyIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/review/ReviewModifyIntegrationTest.java
@@ -39,7 +39,7 @@ class ReviewModifyIntegrationTest extends InitIntegrationTest {
 			List.of("tag1", "tag2"),
 			List.of("https://s3.ap-northeast-2.amazonaws.com/sikdorak/test.jpg"));
 
-		Review modifyReview = reviewService.modifyReview(loginUser, testData.review.getId(),
+		Review modifyReview = reviewService.modifyReview(loginUser, testData.user1PublicReview.getId(),
 			reviewModifyRequest);
 
 		assertThat(modifyReview.getReviewContent()).isEqualTo(
@@ -81,7 +81,7 @@ class ReviewModifyIntegrationTest extends InitIntegrationTest {
 			List.of("https://s3.ap-northeast-2.amazonaws.com/sikdorak/test.jpg"));
 
 		assertThatThrownBy(() ->
-			reviewService.modifyReview(loginUser, testData.review.getId(), reviewModifyRequest))
+			reviewService.modifyReview(loginUser, testData.user1PublicReview.getId(), reviewModifyRequest))
 			.isInstanceOf(NotFoundStoreException.class);
 	}
 
@@ -100,7 +100,7 @@ class ReviewModifyIntegrationTest extends InitIntegrationTest {
 			List.of("https://s3.ap-northeast-2.amazonaws.com/sikdorak/test.jpg"));
 
 		assertThatThrownBy(() ->
-			reviewService.modifyReview(loginUser, testData.review.getId(), reviewModifyRequest))
+			reviewService.modifyReview(loginUser, testData.user1PublicReview.getId(), reviewModifyRequest))
 			.isInstanceOf(NotFoundUserException.class);
 	}
 

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/review/ReviewRemoveIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/review/ReviewRemoveIntegrationTest.java
@@ -26,7 +26,7 @@ class ReviewRemoveIntegrationTest extends InitIntegrationTest {
 	void remove_review_valid() {
 		LoginUser loginUser = new LoginUser(testData.user1.getId(), Authority.USER);
 
-		Review removeReview = reviewService.removeReview(loginUser, testData.review.getId());
+		Review removeReview = reviewService.removeReview(loginUser, testData.user1PublicReview.getId());
 
 		assertThat(removeReview.isDeleted()).isTrue();
 	}
@@ -46,9 +46,9 @@ class ReviewRemoveIntegrationTest extends InitIntegrationTest {
 	@DisplayName("만약 유저가 이미 삭제된 리뷰에 대한 삭제 요청이 주어진다면 예외를 발생시킨다")
 	void remove_review_invalid_exist2() {
 		LoginUser loginUser = new LoginUser(testData.user1.getId(), Authority.USER);
-		reviewService.removeReview(loginUser, testData.review.getId());
+		reviewService.removeReview(loginUser, testData.user1PublicReview.getId());
 
-		assertThatThrownBy(() -> reviewService.removeReview(loginUser, testData.review.getId()))
+		assertThatThrownBy(() -> reviewService.removeReview(loginUser, testData.user1PublicReview.getId()))
 			.isInstanceOf(NotFoundReviewException.class);
 	}
 
@@ -58,7 +58,7 @@ class ReviewRemoveIntegrationTest extends InitIntegrationTest {
 		long invalidUserId = Long.MAX_VALUE;
 		LoginUser loginUser = new LoginUser(invalidUserId, Authority.USER);
 
-		assertThatThrownBy(() -> reviewService.removeReview(loginUser, testData.review.getId()))
+		assertThatThrownBy(() -> reviewService.removeReview(loginUser, testData.user1PublicReview.getId()))
 			.isInstanceOf(NotFoundUserException.class);
 	}
 
@@ -67,7 +67,7 @@ class ReviewRemoveIntegrationTest extends InitIntegrationTest {
 	void remove_review_invalid_authorized() {
 		LoginUser loginUser = new LoginUser(testData.user2.getId(), Authority.USER);
 
-		assertThatThrownBy(() -> reviewService.removeReview(loginUser, testData.review.getId()))
+		assertThatThrownBy(() -> reviewService.removeReview(loginUser, testData.user1PublicReview.getId()))
 			.isInstanceOf(UnauthorizedUserException.class);
 	}
 

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/review/ReviewSearchIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/review/ReviewSearchIntegrationTest.java
@@ -1,0 +1,91 @@
+package com.jjikmuk.sikdorak.integration.review;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.jjikmuk.sikdorak.integration.InitIntegrationTest;
+import com.jjikmuk.sikdorak.review.controller.response.reviewdetail.ReviewDetailResponse;
+import com.jjikmuk.sikdorak.review.exception.NotFoundReviewException;
+import com.jjikmuk.sikdorak.review.service.ReviewService;
+import com.jjikmuk.sikdorak.user.auth.controller.Authority;
+import com.jjikmuk.sikdorak.user.auth.controller.LoginUser;
+import com.jjikmuk.sikdorak.user.user.exception.UnauthorizedUserException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayName("리뷰 디테일 조회 통합 테스트")
+class ReviewSearchIntegrationTest extends InitIntegrationTest {
+
+	@Autowired
+	ReviewService reviewService;
+
+	@Test
+	@DisplayName("유저가 본인의 전체 공개 리뷰를 조회한 경우 디테일 리뷰응답 객체를 반환한다.")
+	void search_public_review_detail_with_owner_user() {
+		LoginUser reviewOwnerUser = new LoginUser(testData.followAcceptUser.getId(),
+			Authority.USER);
+		Long searchReviewId = testData.follwAcceptUserPublicReview.getId();
+
+		ReviewDetailResponse reviewDetailResponse = reviewService.searchReviewDetail(
+			reviewOwnerUser, searchReviewId);
+
+		assertThat(reviewDetailResponse.reviewId()).isEqualTo(searchReviewId);
+		assertThat(reviewDetailResponse.user().userId()).isEqualTo(reviewOwnerUser.getId());
+		assertThat(reviewDetailResponse.reviewVisibility()).isEqualTo("PUBLIC");
+	}
+
+	@Test
+	@DisplayName("유저가 본인의 비공개 리뷰를 조회한 경우 디테일 리뷰응답 객체를 반환한다.")
+	void search_private_review_detail_with_owner_user() {
+		LoginUser reviewOwnerUser = new LoginUser(testData.followAcceptUser.getId(),
+			Authority.USER);
+		Long searchReviewId = testData.follwAcceptUserPrivateReview.getId();
+
+		ReviewDetailResponse reviewDetailResponse = reviewService.searchReviewDetail(
+			reviewOwnerUser, searchReviewId);
+
+		assertThat(reviewDetailResponse.reviewId()).isEqualTo(searchReviewId);
+		assertThat(reviewDetailResponse.user().userId()).isEqualTo(reviewOwnerUser.getId());
+		assertThat(reviewDetailResponse.reviewVisibility()).isEqualTo("PRIVATE");
+	}
+
+
+	@Test
+	@DisplayName("유저가 친구의 친구 공개 리뷰를 조회한 경우 리뷰응답 객체를 반환한다")
+	void search_protected_review_detail_with_friend_User() {
+		LoginUser reviewFriendUser = new LoginUser(testData.followSendUser.getId(), Authority.USER);
+		Long searchReviewId = testData.follwAcceptUserProtectedReview.getId();
+
+		ReviewDetailResponse reviewDetailResponse = reviewService.searchReviewDetail(
+			reviewFriendUser, searchReviewId);
+
+		assertThat(reviewDetailResponse.reviewId()).isEqualTo(searchReviewId);
+		assertThat(reviewDetailResponse.user().userId()).isEqualTo(testData.followAcceptUser.getId());
+		assertThat(reviewDetailResponse.reviewVisibility()).isEqualTo("PROTECTED");
+	}
+
+	@Test
+	@DisplayName("존재하지않는 리뷰를 조회한 경우 예외를 발생시킨다")
+	void search_not_exist_review_with_guest() {
+		LoginUser guestUser = new LoginUser(Authority.ANONYMOUS);
+		Long searchReviewId = Long.MAX_VALUE;
+
+		assertThatThrownBy(() ->  reviewService.searchReviewDetail(
+			guestUser, searchReviewId))
+			.isInstanceOf(NotFoundReviewException.class);
+	}
+
+	@Test
+	@DisplayName("유저가 읽을 권한이 없는 리뷰를 조회한 경우 예외를 발생시킨다")
+	void search_private_review_detail_with_guest() {
+		LoginUser guestUser = new LoginUser(Authority.ANONYMOUS);
+		Long searchReviewId = testData.follwAcceptUserPrivateReview.getId();
+
+		assertThatThrownBy(() ->  reviewService.searchReviewDetail(
+			guestUser, searchReviewId))
+			.isInstanceOf(UnauthorizedUserException.class);
+	}
+
+}

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/review/ReviewSearchIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/review/ReviewSearchIntegrationTest.java
@@ -26,7 +26,7 @@ class ReviewSearchIntegrationTest extends InitIntegrationTest {
 	void search_public_review_detail_with_owner_user() {
 		LoginUser reviewOwnerUser = new LoginUser(testData.followAcceptUser.getId(),
 			Authority.USER);
-		Long searchReviewId = testData.follwAcceptUserPublicReview.getId();
+		Long searchReviewId = testData.followAcceptUserPublicReview.getId();
 
 		ReviewDetailResponse reviewDetailResponse = reviewService.searchReviewDetail(
 			reviewOwnerUser, searchReviewId);
@@ -41,7 +41,7 @@ class ReviewSearchIntegrationTest extends InitIntegrationTest {
 	void search_private_review_detail_with_owner_user() {
 		LoginUser reviewOwnerUser = new LoginUser(testData.followAcceptUser.getId(),
 			Authority.USER);
-		Long searchReviewId = testData.follwAcceptUserPrivateReview.getId();
+		Long searchReviewId = testData.followAcceptUserPrivateReview.getId();
 
 		ReviewDetailResponse reviewDetailResponse = reviewService.searchReviewDetail(
 			reviewOwnerUser, searchReviewId);
@@ -56,7 +56,7 @@ class ReviewSearchIntegrationTest extends InitIntegrationTest {
 	@DisplayName("유저가 친구의 친구 공개 리뷰를 조회한 경우 리뷰응답 객체를 반환한다")
 	void search_protected_review_detail_with_friend_User() {
 		LoginUser reviewFriendUser = new LoginUser(testData.followSendUser.getId(), Authority.USER);
-		Long searchReviewId = testData.follwAcceptUserProtectedReview.getId();
+		Long searchReviewId = testData.followAcceptUserProtectedReview.getId();
 
 		ReviewDetailResponse reviewDetailResponse = reviewService.searchReviewDetail(
 			reviewFriendUser, searchReviewId);
@@ -81,7 +81,7 @@ class ReviewSearchIntegrationTest extends InitIntegrationTest {
 	@DisplayName("유저가 읽을 권한이 없는 리뷰를 조회한 경우 예외를 발생시킨다")
 	void search_private_review_detail_with_guest() {
 		LoginUser guestUser = new LoginUser(Authority.ANONYMOUS);
-		Long searchReviewId = testData.follwAcceptUserPrivateReview.getId();
+		Long searchReviewId = testData.followAcceptUserPrivateReview.getId();
 
 		assertThatThrownBy(() ->  reviewService.searchReviewDetail(
 			guestUser, searchReviewId))

--- a/be/src/test/java/com/jjikmuk/sikdorak/review/domain/ReviewVisibilityTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/review/domain/ReviewVisibilityTest.java
@@ -1,30 +1,67 @@
 package com.jjikmuk.sikdorak.review.domain;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.jjikmuk.sikdorak.user.user.domain.RelationType;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 class ReviewVisibilityTest {
 
-    @Nested
-    @DisplayName("생성자")
-    class Describe_constructor {
+	@Nested
+	@DisplayName("생성자")
+	class Describe_constructor {
 
-        @Nested
-        @DisplayName("만약 유효한 값이 들어온다면")
-        class Context_with_valid_reviewVisibility {
+		@Nested
+		@DisplayName("만약 유효한 값이 들어온다면")
+		class Context_with_valid_reviewVisibility {
 
-            @ParameterizedTest
-            @ValueSource(strings = {"PUBLIC", "PROTECTED", "PRIVATE", "puBlic", "Protected", "privatE"})
-            @DisplayName("ReviewVisibility enum 을 반환한다")
-            void It_returns_a_object(String visibility) {
-                ReviewVisibility reviewVisibility = ReviewVisibility.create(visibility);
+			@ParameterizedTest
+			@ValueSource(strings = {"PUBLIC", "PROTECTED", "PRIVATE", "puBlic", "Protected",
+				"privatE"})
+			@DisplayName("ReviewVisibility enum 을 반환한다")
+			void It_returns_a_object(String visibility) {
+				ReviewVisibility reviewVisibility = ReviewVisibility.create(visibility);
 
-                assertThat(reviewVisibility.name()).isEqualTo(visibility.toUpperCase());
-            }
-        }
-    }
+				assertThat(reviewVisibility.name()).isEqualTo(visibility.toUpperCase());
+			}
+		}
+	}
+
+	@Nested
+	@DisplayName("isRead 메서드")
+	class Describe_isRead {
+
+		@Nested
+		@DisplayName("만약 visibility의 모든 경우와 RelationType의 모든 경우가 주어진다면")
+		class Context_with_relationType_with_public {
+
+			@ParameterizedTest(name = "visibility = {0}, relationType = {1}, expected = {2}")
+			@MethodSource("provideContentAllCase")
+			void It_returns_a_true(ReviewVisibility visibility, RelationType relationType, boolean expected) {
+				assertThat(visibility.isRead(relationType)).isEqualTo(expected);
+			}
+
+			private static Stream<Arguments> provideContentAllCase() {
+				return Stream.of(
+					Arguments.of(ReviewVisibility.PUBLIC, RelationType.SELF, true),
+					Arguments.of(ReviewVisibility.PROTECTED, RelationType.SELF, true),
+					Arguments.of(ReviewVisibility.PRIVATE, RelationType.SELF, true),
+					Arguments.of(ReviewVisibility.PUBLIC, RelationType.CONNECTION, true),
+					Arguments.of(ReviewVisibility.PROTECTED, RelationType.CONNECTION, true),
+					Arguments.of(ReviewVisibility.PRIVATE, RelationType.CONNECTION, false),
+					Arguments.of(ReviewVisibility.PUBLIC, RelationType.DISCONNECTION, true),
+					Arguments.of(ReviewVisibility.PROTECTED, RelationType.DISCONNECTION, false),
+					Arguments.of(ReviewVisibility.PRIVATE, RelationType.DISCONNECTION, false)
+				);
+			}
+		}
+
+	}
+
 }


### PR DESCRIPTION
### ❗️ 이슈 번호

[SDR-183] 
[SDR-187]

<br><br>

### 📝 구현 내용
`GET /api/reviews/{reviewId}`

- 리뷰 디테일 조회 API 입니다.
- 게스트, 친구, 본인에 따라 리뷰 디테일 조회여부가 달라집니다.
- Response 객체의 하위 Response 객체들의 제약조건 annotation도 RestDocs에서 인식할 수 있도록 메서드 기능을 확장하였습니다.
- ResponseSnippet 생성 메서드들은 `@Deprecated` 처리하였습니다. 
- 배포 후 서브모듈에 문제가 발생함 -> 컴파일 단에서 확인할 수 없는 에러(런타임) => 서버 배포 후 health-check 테스트 추가 (BE-cd.yml)

<br><br>

### 🙇🏻‍♂️ 리뷰어에게 부탁합니다!

- 기존 RestDocs 중 Response 객체를 새로운 코드로 변경하였습니다.  `createResponseSnippetWithFields()` 메서드 사용
- 앞으로 RestDocs 만들 때 해당 메서드를 사용해 만들어주세요 (다른 코드 참고)
- 기존 코드는 일괄적으로 제가 변경하였습니다. (혹시 빠진부분이 있다면 직접 구현하신 코드 참고해보시면 좋을 거 같아요)
- 공용으로 사용하는 DocumentFormatGenerator 인터페이스의 리팩토링이 함께 PR 된 점 양해바라요..(넘 많이 바뀌었네요)

<br><br>


[SDR-183]: https://jjikmuk.atlassian.net/browse/SDR-183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[SDR-187]: https://jjikmuk.atlassian.net/browse/SDR-187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ