### PR TITLE
SDR-202 유저의 팔로워/팔로잉 목록 조회 API

### DIFF
--- a/be/src/docs/asciidoc/user/user.adoc
+++ b/be/src/docs/asciidoc/user/user.adoc
@@ -119,3 +119,31 @@ operation::user_search_self_profile_acceptance_test/search_self_profile_success[
 ==== `Response`
 
 operation::user_search_self_profile_acceptance_test/search_self_profile_success[snippets='http-response,response-fields']
+
+=== 유저 팔로워 목록 조회
+
+API : `GET /api/users/{userId}/followers`
+
+=== `200 OK`
+
+==== `Request`
+
+operation::user_followers_search_by_user_id_acceptance_test/search_user_followers_success[snippets='http-request,path-parameters']
+
+==== `Response`
+
+operation::user_followers_search_by_user_id_acceptance_test/search_user_followers_success[snippets='http-response,response-fields']
+
+=== 유저 팔로잉 목록 조회
+
+API : `GET /api/users/{userId}/followings`
+
+=== `200 OK`
+
+==== `Request`
+
+operation::user_followings_search_by_user_id_acceptance_test/search_user_followings_success[snippets='http-request,path-parameters']
+
+==== `Response`
+
+operation::user_followings_search_by_user_id_acceptance_test/search_user_followings_success[snippets='http-response,response-fields']

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/ResponseCodeAndMessages.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/ResponseCodeAndMessages.java
@@ -25,12 +25,14 @@ public enum ResponseCodeAndMessages implements CodeAndMessages {
     USER_SEARCH_REVIEWS_SUCCESS("T-U004", "유저 리뷰 검색 성공했습니다."),
     USER_SEARCH_PROFILE_SUCCESS("T-U005", "유저 프로필 조회에 성공했습니다."),
     USER_DELETE_SUCCESS("T-U006", "유저 정보 삭제에 성공했습니다."),
+    USER_SEARCH_FOLLOWERS_SUCCESS("T-007", "유저 팔로워 목록 조회에 성공했습니다."),
 
     // Comment
     COMMENT_CREATE_SUCCESS("T-C001", "댓글 작성에 성공했습니다."),
 
     // ETC
     SYSTEMINFO_SEARCH_API_DOCS_INFO("T-S001", "API 문서 코드/메세지 검색 성공했습니다.");
+
 
     private final String code;
     private final String message;

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/ResponseCodeAndMessages.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/ResponseCodeAndMessages.java
@@ -26,6 +26,7 @@ public enum ResponseCodeAndMessages implements CodeAndMessages {
     USER_SEARCH_PROFILE_SUCCESS("T-U005", "유저 프로필 조회에 성공했습니다."),
     USER_DELETE_SUCCESS("T-U006", "유저 정보 삭제에 성공했습니다."),
     USER_SEARCH_FOLLOWERS_SUCCESS("T-007", "유저 팔로워 목록 조회에 성공했습니다."),
+    USER_SEARCH_FOLLOWINGS_SUCCESS("T-008", "유저 팔로잉 목록 조회에 성공했습니다."),
 
     // Comment
     COMMENT_CREATE_SUCCESS("T-C001", "댓글 작성에 성공했습니다."),

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/controller/UserController.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/controller/UserController.java
@@ -110,10 +110,13 @@ public class UserController {
     }
 
     @GetMapping("/{userId}/followers")
-    public CommonResponseEntity<Void> searchUserFollowers(@AuthenticatedUser LoginUser loginUser,
+    public CommonResponseEntity<List<UserSimpleProfileResponse>> searchUserFollowers(@AuthenticatedUser LoginUser loginUser,
         @PathVariable Long userId) {
 
+        List<UserSimpleProfileResponse> followersResponse = userService.searchFollowersByUserId(
+            userId, loginUser);
+
         return new CommonResponseEntity<>(ResponseCodeAndMessages.USER_SEARCH_FOLLOWERS_SUCCESS,
-            null, HttpStatus.OK);
+            followersResponse, HttpStatus.OK);
     }
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/controller/UserController.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/controller/UserController.java
@@ -108,4 +108,12 @@ public class UserController {
         return new CommonResponseEntity<>(ResponseCodeAndMessages.USER_DELETE_SUCCESS,
             HttpStatus.OK);
     }
+
+    @GetMapping("/{userId}/followers")
+    public CommonResponseEntity<Void> searchUserFollowers(@AuthenticatedUser LoginUser loginUser,
+        @PathVariable Long userId) {
+
+        return new CommonResponseEntity<>(ResponseCodeAndMessages.USER_SEARCH_FOLLOWERS_SUCCESS,
+            null, HttpStatus.OK);
+    }
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/controller/UserController.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/controller/UserController.java
@@ -7,6 +7,7 @@ import com.jjikmuk.sikdorak.user.auth.controller.LoginUser;
 import com.jjikmuk.sikdorak.user.auth.domain.AuthenticatedUser;
 import com.jjikmuk.sikdorak.user.user.controller.request.UserFollowAndUnfollowRequest;
 import com.jjikmuk.sikdorak.user.user.controller.request.UserModifyRequest;
+import com.jjikmuk.sikdorak.user.user.controller.response.FollowUserProfile;
 import com.jjikmuk.sikdorak.user.user.controller.response.UserDetailProfileResponse;
 import com.jjikmuk.sikdorak.user.user.controller.response.UserReviewResponse;
 import com.jjikmuk.sikdorak.user.user.controller.response.UserSimpleProfileResponse;
@@ -110,13 +111,25 @@ public class UserController {
     }
 
     @GetMapping("/{userId}/followers")
-    public CommonResponseEntity<List<UserSimpleProfileResponse>> searchUserFollowers(@AuthenticatedUser LoginUser loginUser,
+    public CommonResponseEntity<List<FollowUserProfile>> searchUserFollowers(@AuthenticatedUser LoginUser loginUser,
         @PathVariable Long userId) {
 
-        List<UserSimpleProfileResponse> followersResponse = userService.searchFollowersByUserId(
+        List<FollowUserProfile> followersResponse = userService.searchFollowersByUserId(
             userId, loginUser);
 
         return new CommonResponseEntity<>(ResponseCodeAndMessages.USER_SEARCH_FOLLOWERS_SUCCESS,
             followersResponse, HttpStatus.OK);
     }
+
+    @GetMapping("/{userId}/followings")
+    public CommonResponseEntity<List<FollowUserProfile>> searchUserFollowings(@AuthenticatedUser LoginUser loginUser,
+        @PathVariable Long userId) {
+
+        List<FollowUserProfile> followingsResponse = userService.searchFollowingsByUserId(
+            userId, loginUser);
+
+        return new CommonResponseEntity<>(ResponseCodeAndMessages.USER_SEARCH_FOLLOWINGS_SUCCESS,
+            followingsResponse, HttpStatus.OK);
+    }
+
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/controller/response/FollowUserProfile.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/controller/response/FollowUserProfile.java
@@ -1,0 +1,35 @@
+package com.jjikmuk.sikdorak.user.user.controller.response;
+
+import javax.validation.constraints.NotNull;
+import org.hibernate.validator.constraints.Length;
+import org.hibernate.validator.constraints.URL;
+
+public record FollowUserProfile(
+
+    @NotNull
+    long id,
+
+    @NotNull
+    @Length(min = 1, max = 30)
+    String nickname,
+
+    @NotNull
+    @URL
+    String profileImage,
+
+    boolean isViewer,
+    boolean followStatus
+
+
+) {
+
+    public static FollowUserProfile of(UserSimpleProfileResponse userProfile,
+        UserProfileRelationStatusResponse relationStatus) {
+        return new FollowUserProfile(
+            userProfile.id(),
+            userProfile.nickname(),
+            userProfile.profileImage(),
+            relationStatus.isViewer(),
+            relationStatus.followStatus());
+    }
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/controller/response/UserDetailProfileResponse.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/controller/response/UserDetailProfileResponse.java
@@ -37,15 +37,15 @@ public record UserDetailProfileResponse(
 
 ) {
 
-    public static UserDetailProfileResponse of(User user, UserProfileRelationStatusResponse userProfileRelationStatusResponse, int reviewCount) {
+    public static UserDetailProfileResponse of(User user, UserProfileRelationStatusResponse userProfileRelationStatusResponse,  int followingCount, int followersCount, int reviewCount) {
         return new UserDetailProfileResponse(
             user.getId(),
             user.getNickname(),
             user.getProfileImage(),
             user.getEmail(),
             userProfileRelationStatusResponse,
-            user.getFollowers().size(),
-            user.getFollowings().size(),
+            followingCount,
+            followersCount,
             reviewCount
         );
     }

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/domain/User.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/domain/User.java
@@ -10,7 +10,6 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
@@ -18,7 +17,6 @@ import org.hibernate.annotations.Where;
 
 @Entity
 @NoArgsConstructor
-@EqualsAndHashCode(callSuper = false)
 @SQLDelete(sql = "update user set deleted = true where user_id = ?")
 @Where(clause = "deleted = false")
 public class User extends BaseTimeEntity {
@@ -136,6 +134,24 @@ public class User extends BaseTimeEntity {
 
     private void removeFollowing(User acceptUser) {
         this.getFollowings().remove(acceptUser.getId());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        User user = (User) o;
+        return id.equals(user.id) && uniqueId.equals(user.uniqueId)
+            && nickname.equals(user.nickname);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, uniqueId, nickname);
     }
 
     /**

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/domain/UserRepository.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/domain/UserRepository.java
@@ -1,7 +1,7 @@
 package com.jjikmuk.sikdorak.user.user.domain;
 
+import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -14,16 +14,16 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByUniqueId(long uniqueId);
 
-    @Query(value = "select f.follower_id "
+    @Query(value = "select u.* "
         + "from (select uf.follower_id from user_followers as uf where uf.user_id = :userId) as f "
         + "join user u on f.follower_id = u.user_id "
         + "where u.deleted = false", nativeQuery = true)
-    Set<Long> findFollowers(@Param("userId") long userId);
+    List<User> findFollowersByUserId(@Param("userId") long userId);
 
-    @Query(value = "select f.following_id "
+    @Query(value = "select u.* "
         + "from (select uf.following_id from user_following as uf where uf.user_id = :userId) as f "
         + "join user u on f.following_id = u.user_id "
         + "where u.deleted = false", nativeQuery = true)
-    Set<Long> findFollowings(@Param("userId")long userId);
+    List<User> findFollowingsByUserId(@Param("userId")long userId);
 
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/service/UserService.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/service/UserService.java
@@ -70,10 +70,15 @@ public class UserService {
             .orElseThrow(NotFoundUserException::new);
         RelationType relationType = searchUser.relationTypeTo(loginUser);
         int reviewCount = reviewRepository.countByUserId(searchUser.getId());
+        int followerCount = userRepository.findFollowingsByUserId(userId).size();
+        int followingCount = userRepository.findFollowingsByUserId(userId).size();
+
 
         return UserDetailProfileResponse.of(
             searchUser,
             UserProfileRelationStatusResponse.of(relationType),
+            followerCount,
+            followingCount,
             reviewCount
         );
     }
@@ -136,6 +141,18 @@ public class UserService {
     }
 
     @Transactional(readOnly = true)
+    public List<UserSimpleProfileResponse> searchFollowersByUserId(long userId, LoginUser loginUser) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(NotFoundUserException::new);
+
+        List<User> followers = userRepository.findFollowersByUserId(user.getId());
+        
+        return followers.stream()
+            .map(UserSimpleProfileResponse::from)
+            .toList();
+    }
+
+    @Transactional(readOnly = true)
     public User searchById(Long userId) {
         if (Objects.isNull(userId)) {
             throw new NotFoundUserException();
@@ -183,4 +200,5 @@ public class UserService {
             throw new DuplicateSendAcceptUserException();
         }
     }
+
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/user/UserFollowersSearchByUserIdAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/user/UserFollowersSearchByUserIdAcceptanceTest.java
@@ -14,7 +14,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
 @DisplayName("유저 팔로워 목록 조회 인수 테스트")
-public class UserFollowersSearchByUserIdAcceptanceTest extends InitAcceptanceTest {
+class UserFollowersSearchByUserIdAcceptanceTest extends InitAcceptanceTest {
 
     @Test
     @DisplayName("회원의 특정 유저에 대한 팔로워 조회 요청이 올바를 경우 성공 상태코드를 반환한다.")

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/user/UserFollowersSearchByUserIdAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/user/UserFollowersSearchByUserIdAcceptanceTest.java
@@ -1,0 +1,38 @@
+package com.jjikmuk.sikdorak.acceptance.user.user;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+import com.jjikmuk.sikdorak.acceptance.InitAcceptanceTest;
+import com.jjikmuk.sikdorak.common.ResponseCodeAndMessages;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+@DisplayName("유저 팔로워 목록 조회 인수 테스트")
+public class UserFollowersSearchByUserIdAcceptanceTest extends InitAcceptanceTest {
+
+    @Test
+    @DisplayName("특정 유저에 대한 팔로워 조회 요청이 올바를 경우 성공 상태코드를 반환한다.")
+    void search_user_followers_success() {
+        given(this.spec)
+//            .filter(document(
+//                DEFAULT_RESTDOC_PATH,
+//                USER_SEARCH_FOLLOWERS_REQUEST_SNIPPET,
+//                USER_SEARCH_FOLLOWERS_RESPONSE_SNIPPET
+//            ))
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+            .header("Authorization", testData.user1ValidAuthorizationHeader)
+
+        .when()
+            .get("/api/users/{userId}/followers", testData.rumka.getId())
+
+        .then()
+            .statusCode(HttpStatus.OK.value())
+            .body("code", equalTo(ResponseCodeAndMessages.USER_SEARCH_FOLLOWERS_SUCCESS.getCode()))
+            .body("message", equalTo(ResponseCodeAndMessages.USER_SEARCH_FOLLOWERS_SUCCESS.getMessage()))
+            .body("data.size()", equalTo(2));
+    }
+
+}

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/user/UserFollowersSearchByUserIdAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/user/UserFollowersSearchByUserIdAcceptanceTest.java
@@ -1,7 +1,10 @@
 package com.jjikmuk.sikdorak.acceptance.user.user;
 
+import static com.jjikmuk.sikdorak.acceptance.user.user.UserSnippet.USER_SEARCH_FOLLOWERS_FOLLOWINGS_REQUEST_SNIPPET;
+import static com.jjikmuk.sikdorak.acceptance.user.user.UserSnippet.USER_SEARCH_FOLLOWERS_FOLLOWINGS_RESPONSE_SNIPPET;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
+import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
 
 import com.jjikmuk.sikdorak.acceptance.InitAcceptanceTest;
 import com.jjikmuk.sikdorak.common.ResponseCodeAndMessages;
@@ -14,16 +17,37 @@ import org.springframework.http.MediaType;
 public class UserFollowersSearchByUserIdAcceptanceTest extends InitAcceptanceTest {
 
     @Test
-    @DisplayName("특정 유저에 대한 팔로워 조회 요청이 올바를 경우 성공 상태코드를 반환한다.")
+    @DisplayName("회원의 특정 유저에 대한 팔로워 조회 요청이 올바를 경우 성공 상태코드를 반환한다.")
     void search_user_followers_success() {
         given(this.spec)
-//            .filter(document(
-//                DEFAULT_RESTDOC_PATH,
-//                USER_SEARCH_FOLLOWERS_REQUEST_SNIPPET,
-//                USER_SEARCH_FOLLOWERS_RESPONSE_SNIPPET
-//            ))
+            .filter(document(
+                DEFAULT_RESTDOC_PATH,
+                USER_SEARCH_FOLLOWERS_FOLLOWINGS_REQUEST_SNIPPET,
+                USER_SEARCH_FOLLOWERS_FOLLOWINGS_RESPONSE_SNIPPET
+            ))
             .accept(MediaType.APPLICATION_JSON_VALUE)
             .header("Authorization", testData.user1ValidAuthorizationHeader)
+
+        .when()
+            .get("/api/users/{userId}/followers", testData.rumka.getId())
+
+        .then()
+            .statusCode(HttpStatus.OK.value())
+            .body("code", equalTo(ResponseCodeAndMessages.USER_SEARCH_FOLLOWERS_SUCCESS.getCode()))
+            .body("message", equalTo(ResponseCodeAndMessages.USER_SEARCH_FOLLOWERS_SUCCESS.getMessage()))
+            .body("data.size()", equalTo(2));
+    }
+
+    @Test
+    @DisplayName("비회원의 특정 유저에 대한 팔로워 조회 요청이 올바를 경우 성공 상태코드를 반환한다.")
+    void search_user_followers_by_anonymous_success() {
+        given(this.spec)
+            .filter(document(
+                DEFAULT_RESTDOC_PATH,
+                USER_SEARCH_FOLLOWERS_FOLLOWINGS_REQUEST_SNIPPET,
+                USER_SEARCH_FOLLOWERS_FOLLOWINGS_RESPONSE_SNIPPET
+            ))
+            .accept(MediaType.APPLICATION_JSON_VALUE)
 
         .when()
             .get("/api/users/{userId}/followers", testData.rumka.getId())

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/user/UserFollowingsSearchByUserIdAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/user/UserFollowingsSearchByUserIdAcceptanceTest.java
@@ -50,7 +50,7 @@ public class UserFollowingsSearchByUserIdAcceptanceTest extends InitAcceptanceTe
             .accept(MediaType.APPLICATION_JSON_VALUE)
 
             .when()
-            .get("/api/users/{userId}/followings", testData.rumka.getId())
+            .get("/api/users/{userId}/followings", testData.forky.getId())
 
             .then()
             .statusCode(HttpStatus.OK.value())

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/user/UserFollowingsSearchByUserIdAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/user/UserFollowingsSearchByUserIdAcceptanceTest.java
@@ -1,0 +1,62 @@
+package com.jjikmuk.sikdorak.acceptance.user.user;
+
+import static com.jjikmuk.sikdorak.acceptance.user.user.UserSnippet.USER_SEARCH_FOLLOWERS_FOLLOWINGS_REQUEST_SNIPPET;
+import static com.jjikmuk.sikdorak.acceptance.user.user.UserSnippet.USER_SEARCH_FOLLOWERS_FOLLOWINGS_RESPONSE_SNIPPET;
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
+
+import com.jjikmuk.sikdorak.acceptance.InitAcceptanceTest;
+import com.jjikmuk.sikdorak.common.ResponseCodeAndMessages;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+@DisplayName("유저 팔로잉 목록 조회 인수 테스트")
+public class UserFollowingsSearchByUserIdAcceptanceTest extends InitAcceptanceTest {
+
+    @Test
+    @DisplayName("특정 유저에 대한 팔로잉 조회 요청이 올바를 경우 성공 상태코드를 반환한다.")
+    void search_user_followings_success() {
+        given(this.spec)
+            .filter(document(
+                DEFAULT_RESTDOC_PATH,
+                USER_SEARCH_FOLLOWERS_FOLLOWINGS_REQUEST_SNIPPET,
+                USER_SEARCH_FOLLOWERS_FOLLOWINGS_RESPONSE_SNIPPET
+            ))
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+            .header("Authorization", testData.user1ValidAuthorizationHeader)
+
+        .when()
+            .get("/api/users/{userId}/followings", testData.forky.getId())
+
+        .then()
+            .statusCode(HttpStatus.OK.value())
+            .body("code", equalTo(ResponseCodeAndMessages.USER_SEARCH_FOLLOWINGS_SUCCESS.getCode()))
+            .body("message", equalTo(ResponseCodeAndMessages.USER_SEARCH_FOLLOWINGS_SUCCESS.getMessage()))
+            .body("data.size()", equalTo(2));
+    }
+
+    @Test
+    @DisplayName("비회원의 특정 유저에 대한 팔로잉 조회 요청이 올바를 경우 성공 상태코드를 반환한다.")
+    void search_user_followings_by_anonymous_success() {
+        given(this.spec)
+            .filter(document(
+                DEFAULT_RESTDOC_PATH,
+                USER_SEARCH_FOLLOWERS_FOLLOWINGS_REQUEST_SNIPPET,
+                USER_SEARCH_FOLLOWERS_FOLLOWINGS_RESPONSE_SNIPPET
+            ))
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+
+            .when()
+            .get("/api/users/{userId}/followings", testData.rumka.getId())
+
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .body("code", equalTo(ResponseCodeAndMessages.USER_SEARCH_FOLLOWINGS_SUCCESS.getCode()))
+            .body("message", equalTo(ResponseCodeAndMessages.USER_SEARCH_FOLLOWINGS_SUCCESS.getMessage()))
+            .body("data.size()", equalTo(2));
+    }
+
+}

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/user/UserFollowingsSearchByUserIdAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/user/UserFollowingsSearchByUserIdAcceptanceTest.java
@@ -14,7 +14,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
 @DisplayName("유저 팔로잉 목록 조회 인수 테스트")
-public class UserFollowingsSearchByUserIdAcceptanceTest extends InitAcceptanceTest {
+class UserFollowingsSearchByUserIdAcceptanceTest extends InitAcceptanceTest {
 
     @Test
     @DisplayName("특정 유저에 대한 팔로잉 조회 요청이 올바를 경우 성공 상태코드를 반환한다.")

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/user/UserSnippet.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/user/UserSnippet.java
@@ -105,5 +105,5 @@ public interface UserSnippet {
 //
 //        )
 //    );
-    
+
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/user/UserSnippet.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/user/UserSnippet.java
@@ -94,4 +94,16 @@ public interface UserSnippet {
         )
     );
 
+    Snippet USER_SEARCH_FOLLOWERS_REQUEST_SNIPPET = pathParameters(
+        parameterWithName("userId").description("팔로워 목록을 조회할 유저 아이디")
+    );
+
+//    Snippet USER_SEARCH_FOLLOWERS_RESPONSE_SNIPPET = createResponseSnippetWithFields(
+//        responseFieldsOfCommon(),
+//
+//        responseFieldsOfListWithConstraintsAndFields(
+//
+//        )
+//    );
+    
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/user/UserSnippet.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/user/user/UserSnippet.java
@@ -12,6 +12,7 @@ import static org.springframework.restdocs.request.RequestDocumentation.pathPara
 
 import com.jjikmuk.sikdorak.user.user.controller.request.UserFollowAndUnfollowRequest;
 import com.jjikmuk.sikdorak.user.user.controller.request.UserModifyRequest;
+import com.jjikmuk.sikdorak.user.user.controller.response.FollowUserProfile;
 import com.jjikmuk.sikdorak.user.user.controller.response.UserDetailProfileResponse;
 import com.jjikmuk.sikdorak.user.user.controller.response.UserReviewResponse;
 import com.jjikmuk.sikdorak.user.user.controller.response.UserSimpleProfileResponse;
@@ -94,16 +95,21 @@ public interface UserSnippet {
         )
     );
 
-    Snippet USER_SEARCH_FOLLOWERS_REQUEST_SNIPPET = pathParameters(
-        parameterWithName("userId").description("팔로워 목록을 조회할 유저 아이디")
+    Snippet USER_SEARCH_FOLLOWERS_FOLLOWINGS_REQUEST_SNIPPET = pathParameters(
+        parameterWithName("userId").description("팔로워/팔로워 목록을 조회할 유저 아이디")
     );
 
-//    Snippet USER_SEARCH_FOLLOWERS_RESPONSE_SNIPPET = createResponseSnippetWithFields(
-//        responseFieldsOfCommon(),
-//
-//        responseFieldsOfListWithConstraintsAndFields(
-//
-//        )
-//    );
+    Snippet USER_SEARCH_FOLLOWERS_FOLLOWINGS_RESPONSE_SNIPPET = createResponseSnippetWithFields(
+        responseFieldsOfCommon(),
+
+        responseFieldsOfListWithConstraintsAndFields(
+            FollowUserProfile.class,
+            fieldWithPath("id").type(JsonFieldType.NUMBER).description("유저 아이디"),
+            fieldWithPath("nickname").type(JsonFieldType.STRING).description("유저 닉네임"),
+            fieldWithPath("profileImage").type(JsonFieldType.STRING).description("유저 프로필 이미지"),
+            fieldWithPath("isViewer").type(JsonFieldType.BOOLEAN).description("자신의 프로필 여부"),
+            fieldWithPath("followStatus").type(JsonFieldType.BOOLEAN).description("유저와의 관계")
+        )
+    );
 
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserDeleteIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserDeleteIntegrationTest.java
@@ -14,7 +14,6 @@ import com.jjikmuk.sikdorak.user.user.exception.NotFoundUserException;
 import com.jjikmuk.sikdorak.user.user.service.UserService;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -59,11 +58,11 @@ class UserDeleteIntegrationTest extends InitIntegrationTest {
 
         userService.deleteUser(loginUser);
 
-        Set<Long> hoiFollowings = userRepository.findFollowings(testData.hoi.getId());
-        Set<Long> rumkaFollowers = userRepository.findFollowers(testData.rumka.getId());
+        List<User> hoiFollowings = userRepository.findFollowingsByUserId(testData.hoi.getId());
+        List<User> rumkaFollowers = userRepository.findFollowersByUserId(testData.rumka.getId());
 
-        assertThat(hoiFollowings).isNotEmpty().doesNotContain(loginUser.getId());
-        assertThat(rumkaFollowers).isNotEmpty().doesNotContain(loginUser.getId());
+        assertThat(hoiFollowings).isNotEmpty().noneMatch(u -> u.getId().equals(testData.forky.getId()));
+        assertThat(rumkaFollowers).isNotEmpty().noneMatch(u -> u.getId().equals(testData.forky.getId()));
     }
 
     @Test

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserFollowUnfollowIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserFollowUnfollowIntegrationTest.java
@@ -7,13 +7,14 @@ import com.jjikmuk.sikdorak.integration.InitIntegrationTest;
 import com.jjikmuk.sikdorak.user.auth.controller.Authority;
 import com.jjikmuk.sikdorak.user.auth.controller.LoginUser;
 import com.jjikmuk.sikdorak.user.user.controller.request.UserFollowAndUnfollowRequest;
+import com.jjikmuk.sikdorak.user.user.domain.User;
 import com.jjikmuk.sikdorak.user.user.domain.UserRepository;
 import com.jjikmuk.sikdorak.user.user.exception.DuplicateFollowingException;
 import com.jjikmuk.sikdorak.user.user.exception.DuplicateSendAcceptUserException;
 import com.jjikmuk.sikdorak.user.user.exception.NotFoundFollowException;
 import com.jjikmuk.sikdorak.user.user.exception.NotFoundUserException;
 import com.jjikmuk.sikdorak.user.user.service.UserService;
-import java.util.Set;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,11 +38,11 @@ class UserFollowUnfollowIntegrationTest extends InitIntegrationTest {
 
         userService.followUser(loginUser, request);
 
-        Set<Long> sendUserFollowings = userRepository.findFollowings(testData.forky.getId());
-        Set<Long> acceptUserFollowers = userRepository.findFollowers(testData.kukim.getId());
+        List<User> sendUserFollowings = userRepository.findFollowingsByUserId(testData.forky.getId());
+        List<User> acceptUserFollowers = userRepository.findFollowersByUserId(testData.kukim.getId());
 
-        assertThat(sendUserFollowings).contains(testData.kukim.getId());
-        assertThat(acceptUserFollowers).contains(testData.forky.getId());
+        assertThat(sendUserFollowings).anyMatch(u -> u.getId().equals(testData.kukim.getId()));
+        assertThat(acceptUserFollowers).anyMatch(u -> u.getId().equals(testData.forky.getId()));
     }
 
     @Test
@@ -90,11 +91,11 @@ class UserFollowUnfollowIntegrationTest extends InitIntegrationTest {
 
         userService.unfollowUser(loginUser, unfollowRequest);
 
-        Set<Long> sendUserFollowings = userRepository.findFollowings(testData.forky.getId());
-        Set<Long> acceptUserFollowers = userRepository.findFollowers(testData.jay.getId());
+        List<User> sendUserFollowings = userRepository.findFollowingsByUserId(testData.forky.getId());
+        List<User> acceptUserFollowers = userRepository.findFollowersByUserId(testData.jay.getId());
 
-        assertThat(sendUserFollowings).doesNotContain(testData.jay.getId());
-        assertThat(acceptUserFollowers).doesNotContain(testData.forky.getId());
+        assertThat(sendUserFollowings).noneMatch(u -> u.getId().equals(testData.jay.getId()));
+        assertThat(acceptUserFollowers).noneMatch( u -> u.getId().equals(testData.forky.getId()));
     }
 
     @Test

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserFollowersSearchByUserIdIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserFollowersSearchByUserIdIntegrationTest.java
@@ -7,7 +7,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.jjikmuk.sikdorak.integration.InitIntegrationTest;
 import com.jjikmuk.sikdorak.user.auth.controller.Authority;
 import com.jjikmuk.sikdorak.user.auth.controller.LoginUser;
-import com.jjikmuk.sikdorak.user.user.controller.response.UserSimpleProfileResponse;
+import com.jjikmuk.sikdorak.user.user.controller.response.FollowUserProfile;
 import com.jjikmuk.sikdorak.user.user.exception.NotFoundUserException;
 import com.jjikmuk.sikdorak.user.user.service.UserService;
 import java.util.List;
@@ -22,23 +22,23 @@ public class UserFollowersSearchByUserIdIntegrationTest extends InitIntegrationT
     private UserService userService;
 
     @Test
-    @DisplayName("회원의 특정 유저에 대한 팔로워 목록 요청이 올바를 경우 팔로워 목록을 반환한다.")
+    @DisplayName("특정 유저에 대한 팔로워 목록 요청이 올바를 경우 팔로워 목록을 반환한다.")
     void search_followers_by_user() {
         LoginUser loginUser = new LoginUser(testData.kukim.getId(), Authority.USER);
 
-        List<UserSimpleProfileResponse> followers = userService.searchFollowersByUserId(testData.rumka.getId(), loginUser);
+        List<FollowUserProfile> followers = userService.searchFollowersByUserId(testData.rumka.getId(), loginUser);
 
         assertThat(followers.size()).isEqualTo(2);
     }
 
     @Test
-    @DisplayName("비회원의 특정 유저에 대한 팔로워 목록 요청이 올바를 경우 팔로워 목록을 반환한다.")
-    void search_followers_by_anonymous_user() {
+    @DisplayName("특정 유저의 팔로워 목록이 존재하지 않을 경우 비어있는 목록을 반환한다.")
+    void search_followers_is_empty() {
         LoginUser loginUser = new LoginUser(Authority.ANONYMOUS);
 
-        List<UserSimpleProfileResponse> followers = userService.searchFollowersByUserId(testData.rumka.getId(), loginUser);
+        List<FollowUserProfile> followers = userService.searchFollowersByUserId(testData.kukim.getId(), loginUser);
 
-        assertThat(followers.size()).isEqualTo(2);
+        assertThat(followers).isEmpty();
     }
 
     @Test

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserFollowersSearchByUserIdIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserFollowersSearchByUserIdIntegrationTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 @DisplayName("유저 팔로워 목록 조회 통합 테스트")
-public class UserFollowersSearchByUserIdIntegrationTest extends InitIntegrationTest {
+class UserFollowersSearchByUserIdIntegrationTest extends InitIntegrationTest {
 
     @Autowired
     private UserService userService;
@@ -28,7 +28,7 @@ public class UserFollowersSearchByUserIdIntegrationTest extends InitIntegrationT
 
         List<FollowUserProfile> followers = userService.searchFollowersByUserId(testData.rumka.getId(), loginUser);
 
-        assertThat(followers.size()).isEqualTo(2);
+        assertThat(followers).hasSize(2);
     }
 
     @Test

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserFollowersSearchByUserIdIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserFollowersSearchByUserIdIntegrationTest.java
@@ -1,0 +1,52 @@
+package com.jjikmuk.sikdorak.integration.user.user;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.jjikmuk.sikdorak.integration.InitIntegrationTest;
+import com.jjikmuk.sikdorak.user.auth.controller.Authority;
+import com.jjikmuk.sikdorak.user.auth.controller.LoginUser;
+import com.jjikmuk.sikdorak.user.user.controller.response.UserSimpleProfileResponse;
+import com.jjikmuk.sikdorak.user.user.exception.NotFoundUserException;
+import com.jjikmuk.sikdorak.user.user.service.UserService;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayName("유저 팔로워 목록 조회 통합 테스트")
+public class UserFollowersSearchByUserIdIntegrationTest extends InitIntegrationTest {
+
+    @Autowired
+    private UserService userService;
+
+    @Test
+    @DisplayName("회원의 특정 유저에 대한 팔로워 목록 요청이 올바를 경우 팔로워 목록을 반환한다.")
+    void search_followers_by_user() {
+        LoginUser loginUser = new LoginUser(testData.kukim.getId(), Authority.USER);
+
+        List<UserSimpleProfileResponse> followers = userService.searchFollowersByUserId(testData.rumka.getId(), loginUser);
+
+        assertThat(followers.size()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("비회원의 특정 유저에 대한 팔로워 목록 요청이 올바를 경우 팔로워 목록을 반환한다.")
+    void search_followers_by_anonymous_user() {
+        LoginUser loginUser = new LoginUser(Authority.ANONYMOUS);
+
+        List<UserSimpleProfileResponse> followers = userService.searchFollowersByUserId(testData.rumka.getId(), loginUser);
+
+        assertThat(followers.size()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 유저에 대한 팔로워 목록 요청일 경우 예외를 반환한다.")
+    void search_not_found_user_followers() {
+        LoginUser loginUser = new LoginUser(Authority.ANONYMOUS);
+
+        assertThatThrownBy(() -> userService.searchFollowersByUserId(98989898L, loginUser))
+            .isInstanceOf(NotFoundUserException.class);
+    }
+}

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserFollowingsSearchByUserIdIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserFollowingsSearchByUserIdIntegrationTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 @DisplayName("유저 팔로잉 목록 조회 통합 테스트")
-public class UserFollowingsSearchByUserIdIntegrationTest extends InitIntegrationTest {
+class UserFollowingsSearchByUserIdIntegrationTest extends InitIntegrationTest {
 
     @Autowired
     private UserService userService;
@@ -28,7 +28,7 @@ public class UserFollowingsSearchByUserIdIntegrationTest extends InitIntegration
 
         List<FollowUserProfile> followings = userService.searchFollowingsByUserId(testData.hoi.getId(), loginUser);
 
-        assertThat(followings.size()).isEqualTo(2);
+        assertThat(followings).hasSize(2);
     }
 
     @Test

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserFollowingsSearchByUserIdIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserFollowingsSearchByUserIdIntegrationTest.java
@@ -1,0 +1,51 @@
+package com.jjikmuk.sikdorak.integration.user.user;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.jjikmuk.sikdorak.integration.InitIntegrationTest;
+import com.jjikmuk.sikdorak.user.auth.controller.Authority;
+import com.jjikmuk.sikdorak.user.auth.controller.LoginUser;
+import com.jjikmuk.sikdorak.user.user.controller.response.FollowUserProfile;
+import com.jjikmuk.sikdorak.user.user.exception.NotFoundUserException;
+import com.jjikmuk.sikdorak.user.user.service.UserService;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayName("유저 팔로잉 목록 조회 통합 테스트")
+public class UserFollowingsSearchByUserIdIntegrationTest extends InitIntegrationTest {
+
+    @Autowired
+    private UserService userService;
+
+    @Test
+    @DisplayName("회원의 특정 유저에 대한 팔로잉 목록 요청이 올바를 경우 팔로잉 목록을 반환한다.")
+    void search_followings_by_user() {
+        LoginUser loginUser = new LoginUser(testData.kukim.getId(), Authority.USER);
+
+        List<FollowUserProfile> followings = userService.searchFollowingsByUserId(testData.hoi.getId(), loginUser);
+
+        assertThat(followings.size()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("특정 유저의 팔로잉 목록이 존재하지 않을 경우 비어있는 목록을 반환한다.")
+    void search_followers_is_empty() {
+        LoginUser loginUser = new LoginUser(Authority.ANONYMOUS);
+
+        List<FollowUserProfile> followings = userService.searchFollowingsByUserId(testData.kukim.getId(), loginUser);
+
+        assertThat(followings).isEmpty();
+    }
+    @Test
+    @DisplayName("존재하지 않는 유저에 대한 팔로잉 목록 요청일 경우 예외를 반환한다.")
+    void search_not_found_user_followings() {
+        LoginUser loginUser = new LoginUser(Authority.ANONYMOUS);
+
+        assertThatThrownBy(() -> userService.searchFollowingsByUserId(98989898L, loginUser))
+            .isInstanceOf(NotFoundUserException.class);
+    }
+}


### PR DESCRIPTION
### ❗️ 이슈 번호

[SDR-202]

<br><br>

### 📝 구현 내용

- 유저의 팔로워/팔로잉 목록 조회 인수테스트, 통합테스트 작성
- 유저의 팔로워/팔로잉 목록 조회 기능 구현

<br><br>

### 🙇🏻‍♂️ 리뷰어에게 부탁합니다!

- 아래 커밋 내역에 현재 pr을 보낸 유저 자신의 프로필 조회 api 브랜치의 커밋이 나오는 이유는 해당 브랜치에서 작성한 클래스가 필요해서 해당 브랜치를 rebase했기 때문입니다! 머지 된 이후 다시 rebase하면 되기 때문에 신경 안쓰셔도 될것 같습니다.
> 리뷰가 어려울 수 있으니 이전pr이 머지된 이후 리뷰해주세요!!

- 레파지토리의 유저 팔로잉/팔로워 목록을 가져오는 메서드에서 `native query`를 수정하여 반환값이 `List<Long>`에서 `List<User>`로 변경되었습니다.



[SDR-202]: https://jjikmuk.atlassian.net/browse/SDR-202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ