### PR TITLE
SDR-186 리뷰 댓글 수정 API 구현

### DIFF
--- a/be/src/docs/asciidoc/comment/comment.adoc
+++ b/be/src/docs/asciidoc/comment/comment.adoc
@@ -11,3 +11,18 @@ operation::comment_create_acceptance_test/create_comment_success[snippets='http-
 ==== `Response`
 
 operation::comment_create_acceptance_test/create_comment_success[snippets='http-response,response-fields']
+
+=== 댓글 수정
+
+API : `PUT /api/reviews/{reviewId}/comments{commentId}`
+
+=== `201 CREATED`
+
+==== `Request`
+
+operation::comment_modify_acceptance_test/modify_comment_success[snippets='http-request,request-body,path-parameters']
+
+==== `Response`
+
+operation::comment_modify_acceptance_test/modify_comment_success[snippets='http-response,response-fields']
+

--- a/be/src/main/java/com/jjikmuk/sikdorak/comment/controller/CommentController.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/comment/controller/CommentController.java
@@ -1,6 +1,7 @@
 package com.jjikmuk.sikdorak.comment.controller;
 
 import com.jjikmuk.sikdorak.comment.controller.request.CommentCreateRequest;
+import com.jjikmuk.sikdorak.comment.controller.request.CommentModifyRequest;
 import com.jjikmuk.sikdorak.comment.service.CommentService;
 import com.jjikmuk.sikdorak.common.ResponseCodeAndMessages;
 import com.jjikmuk.sikdorak.common.aop.UserOnly;
@@ -11,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -23,7 +25,7 @@ public class CommentController {
 	private final CommentService commentService;
 
 	@UserOnly
-	@PostMapping()
+	@PostMapping
 	public CommonResponseEntity<Void> createComment(
 		@PathVariable long reviewId,
 		@AuthenticatedUser LoginUser loginUser,
@@ -33,5 +35,19 @@ public class CommentController {
 
 		return new CommonResponseEntity<>(ResponseCodeAndMessages.COMMENT_CREATE_SUCCESS,
 			HttpStatus.CREATED);
+	}
+
+	@UserOnly
+	@PutMapping("/{commentId}")
+	public CommonResponseEntity<Void> modifyComment(
+		@PathVariable long reviewId,
+		@PathVariable long commentId,
+		@AuthenticatedUser LoginUser loginUser,
+		@RequestBody CommentModifyRequest commentModifyRequest
+	) {
+		commentService.modifyComment(reviewId, commentId, loginUser, commentModifyRequest);
+
+		return new CommonResponseEntity<>(ResponseCodeAndMessages.COMMENT_MODIFY_SUCCESS,
+			HttpStatus.OK);
 	}
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/comment/controller/request/CommentModifyRequest.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/comment/controller/request/CommentModifyRequest.java
@@ -1,0 +1,19 @@
+package com.jjikmuk.sikdorak.comment.controller.request;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CommentModifyRequest {
+
+	@NotBlank
+	@Size(min = 1, max = 500)
+	private String content;
+
+	public CommentModifyRequest(String content) {
+		this.content = content;
+	}
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/comment/domain/Comment.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/comment/domain/Comment.java
@@ -11,7 +11,6 @@ import javax.persistence.Id;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
-import org.springframework.context.annotation.EnableMBeanExport;
 
 
 @Entity

--- a/be/src/main/java/com/jjikmuk/sikdorak/comment/domain/Comment.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/comment/domain/Comment.java
@@ -49,4 +49,12 @@ public class Comment extends BaseTimeEntity {
 	public String getCommentContent() {
 		return commentContent.getReviewContent();
 	}
+
+	public boolean isAuthor(long userId) {
+		return this.userId == userId;
+	}
+
+	public void updateComment(String content) {
+		this.commentContent = new CommentContent(content);
+	}
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/comment/domain/Comment.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/comment/domain/Comment.java
@@ -1,6 +1,7 @@
 package com.jjikmuk.sikdorak.comment.domain;
 
 import com.jjikmuk.sikdorak.common.domain.BaseTimeEntity;
+import com.jjikmuk.sikdorak.common.domain.Deleted;
 import javax.persistence.Column;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
@@ -8,10 +9,15 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+import org.springframework.context.annotation.EnableMBeanExport;
 
 
 @Entity
 @NoArgsConstructor
+@SQLDelete(sql = "update comment set deleted = true where comment_id = ?")
+@Where(clause = "deleted = false")
 public class Comment extends BaseTimeEntity {
 
 	@Id
@@ -27,6 +33,9 @@ public class Comment extends BaseTimeEntity {
 
 	@Embedded
 	private CommentContent commentContent;
+
+	@Embedded
+	private Deleted deleted = Deleted.FALSE;
 
 	public Comment(long reviewId, long userId, String commentContent) {
 		this.reviewId = reviewId;
@@ -56,5 +65,9 @@ public class Comment extends BaseTimeEntity {
 
 	public void updateComment(String content) {
 		this.commentContent = new CommentContent(content);
+	}
+
+	public void delete() {
+		this.deleted.delete();
 	}
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/comment/exception/NotFoundCommentException.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/comment/exception/NotFoundCommentException.java
@@ -1,0 +1,12 @@
+package com.jjikmuk.sikdorak.comment.exception;
+
+import com.jjikmuk.sikdorak.common.exception.SikdorakRuntimeException;
+import org.springframework.http.HttpStatus;
+
+public class NotFoundCommentException extends SikdorakRuntimeException {
+
+	@Override
+	public HttpStatus getHttpStatus() {
+		return HttpStatus.BAD_REQUEST;
+	}
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/comment/service/CommentService.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/comment/service/CommentService.java
@@ -49,12 +49,10 @@ public class CommentService {
 
 		loginUser.ifAnonymousThrowException();
 
-		reviewRepository.findById(reviewId)
-			.orElseThrow(NotFoundReviewException::new);
+		validateReviewExists(reviewId);
 
 		User currentUser = userRepository.findById(loginUser.getId())
 			.orElseThrow(NotFoundUserException::new);
-
 
 		Comment comment = commentRepository.findById(commentId)
 			.orElseThrow(NotFoundCommentException::new);
@@ -62,6 +60,12 @@ public class CommentService {
 		validateModifiableUserOrThrow(comment, currentUser);
 
 		comment.updateComment(modifyRequest.getContent());
+	}
+
+	private void validateReviewExists(long reviewId) {
+		if (!reviewRepository.existsById(reviewId)) {
+			throw new NotFoundReviewException();
+		}
 	}
 
 	private void validateModifiableUserOrThrow(Comment comment, User currentUser) {

--- a/be/src/main/java/com/jjikmuk/sikdorak/comment/service/CommentService.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/comment/service/CommentService.java
@@ -1,7 +1,9 @@
 package com.jjikmuk.sikdorak.comment.service;
 
 import com.jjikmuk.sikdorak.comment.controller.request.CommentCreateRequest;
+import com.jjikmuk.sikdorak.comment.controller.request.CommentModifyRequest;
 import com.jjikmuk.sikdorak.comment.domain.Comment;
+import com.jjikmuk.sikdorak.comment.exception.NotFoundCommentException;
 import com.jjikmuk.sikdorak.comment.repository.CommentRepository;
 import com.jjikmuk.sikdorak.review.domain.Review;
 import com.jjikmuk.sikdorak.review.exception.NotFoundReviewException;
@@ -10,20 +12,21 @@ import com.jjikmuk.sikdorak.user.auth.controller.LoginUser;
 import com.jjikmuk.sikdorak.user.user.domain.User;
 import com.jjikmuk.sikdorak.user.user.domain.UserRepository;
 import com.jjikmuk.sikdorak.user.user.exception.NotFoundUserException;
+import com.jjikmuk.sikdorak.user.user.exception.UnauthorizedUserException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class CommentService {
+
 	private final CommentRepository commentRepository;
 	private final UserRepository userRepository;
 	private final ReviewRepository reviewRepository;
 
-	public Comment createComment(
-		long reviewId,
-		LoginUser loginUser,
+	public Comment createComment(long reviewId, LoginUser loginUser,
 		CommentCreateRequest commentCreateRequest) {
+
 		User user = userRepository.findById(loginUser.getId())
 			.orElseThrow(NotFoundUserException::new);
 
@@ -36,5 +39,29 @@ public class CommentService {
 			commentCreateRequest.getContent());
 
 		return commentRepository.save(comment);
+	}
+
+	public void modifyComment(long reviewId, long commentId, LoginUser loginUser,
+		CommentModifyRequest modifyRequest) {
+
+		User currentUser = userRespository.findById(loginUser.getId())
+			.orElseThrow(NotFoundUserException::new);
+
+		Review review = reviewRepository.findById(reviewId)
+			.orElseThrow(NotFoundReviewException::new);
+
+		Comment savedComment = commentRepository.findById(commentId)
+			.orElseThrow(NotFoundCommentException::new);
+
+		validateCommentModifiableOrThrow(savedComment, currentUser);
+
+		savedComment.updateComment(modifyRequest.getContent());
+
+	}
+
+	private void validateCommentModifiableOrThrow(Comment comment, User currentUser) {
+		if (!comment.isAuthor(currentUser.getId())) {
+			throw new UnauthorizedUserException();
+		}
 	}
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/comment/service/CommentService.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/comment/service/CommentService.java
@@ -52,7 +52,7 @@ public class CommentService {
 		reviewRepository.findById(reviewId)
 			.orElseThrow(NotFoundReviewException::new);
 
-		User currentUser = userRespository.findById(loginUser.getId())
+		User currentUser = userRepository.findById(loginUser.getId())
 			.orElseThrow(NotFoundUserException::new);
 
 

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/ResponseCodeAndMessages.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/ResponseCodeAndMessages.java
@@ -30,6 +30,7 @@ public enum ResponseCodeAndMessages implements CodeAndMessages {
 
     // Comment
     COMMENT_CREATE_SUCCESS("T-C001", "댓글 작성에 성공했습니다."),
+    COMMENT_MODIFY_SUCCESS("T-C002", "댓글 수정에 성공했습니다."),
 
     // ETC
     SYSTEMINFO_SEARCH_API_DOCS_INFO("T-S001", "API 문서 코드/메세지 검색 성공했습니다.");

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/exception/ExceptionCodeAndMessages.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/exception/ExceptionCodeAndMessages.java
@@ -1,6 +1,7 @@
 package com.jjikmuk.sikdorak.common.exception;
 
 import com.jjikmuk.sikdorak.comment.exception.InvalidCommentContentException;
+import com.jjikmuk.sikdorak.comment.exception.NotFoundCommentException;
 import com.jjikmuk.sikdorak.common.CodeAndMessages;
 import com.jjikmuk.sikdorak.review.exception.InvalidReviewContentException;
 import com.jjikmuk.sikdorak.review.exception.InvalidReviewImageException;
@@ -76,7 +77,8 @@ public enum ExceptionCodeAndMessages implements CodeAndMessages {
     NEED_LOGIN("F-O004", "로그인이 필요한 서비스입니다.", NeedLoginException.class),
 
     // Comment
-    INVALID_COMMENT_CONTENT_EXCEPTION("F-C001", "유효하지 않은 댓글 내용입니다.", InvalidCommentContentException.class);
+    INVALID_COMMENT_CONTENT_EXCEPTION("F-C001", "유효하지 않은 댓글 내용입니다.", InvalidCommentContentException.class),
+    NOT_FOUND_COMMENT_EXCEPTION("F-C002", "댓글을 찾을 수 없습니다.", NotFoundCommentException.class);
 
     private final String code;
 

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/comment/CommentCreateAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/comment/CommentCreateAcceptanceTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
+@DisplayName("CommentCreate 인수테스트")
 class CommentCreateAcceptanceTest extends InitAcceptanceTest {
 
 

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/comment/CommentModifyAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/comment/CommentModifyAcceptanceTest.java
@@ -23,7 +23,7 @@ class CommentModifyAcceptanceTest extends InitAcceptanceTest {
 
 
 	@Test
-	@DisplayName("댓글 수정 요청이 정상적인 경우라면 댓글 생성 후 정상 상태 코드를 반환한다")
+	@DisplayName("댓글 수정 요청이 정상적인 경우라면 댓글 수정 후 정상 상태 코드를 반환한다")
 	void modify_comment_success() {
 		Review review = testData.user1PublicReview;
 		User kukim = testData.kukim;

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/comment/CommentModifyAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/comment/CommentModifyAcceptanceTest.java
@@ -24,7 +24,7 @@ class CommentModifyAcceptanceTest extends InitAcceptanceTest {
 
 	@Test
 	@DisplayName("댓글 수정 요청이 정상적인 경우라면 댓글 생성 후 정상 상태 코드를 반환한다")
-	void create_comment_success() {
+	void modify_comment_success() {
 		Review review = testData.user1PublicReview;
 		User user1 = testData.user1;
 		Comment savedComment = testData.saveAndGetComment(review, user1, "안녕하세요");

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/comment/CommentModifyAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/comment/CommentModifyAcceptanceTest.java
@@ -1,0 +1,56 @@
+package com.jjikmuk.sikdorak.acceptance.comment;
+
+import static com.jjikmuk.sikdorak.acceptance.comment.CommentSnippet.COMMENT_MODIFY_PATH_VARIABLE_SNIPPET;
+import static com.jjikmuk.sikdorak.acceptance.comment.CommentSnippet.COMMENT_MODIFY_REQUEST_SNIPPET;
+import static com.jjikmuk.sikdorak.acceptance.comment.CommentSnippet.COMMENT_MODIFY_RESPONSE_SNIPPET;
+import static io.restassured.RestAssured.given;
+import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
+
+import com.jjikmuk.sikdorak.acceptance.InitAcceptanceTest;
+import com.jjikmuk.sikdorak.comment.controller.request.CommentModifyRequest;
+import com.jjikmuk.sikdorak.comment.domain.Comment;
+import com.jjikmuk.sikdorak.common.ResponseCodeAndMessages;
+import com.jjikmuk.sikdorak.review.domain.Review;
+import com.jjikmuk.sikdorak.user.user.domain.User;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+@DisplayName("CommentModify 인수테스트")
+class CommentModifyAcceptanceTest extends InitAcceptanceTest {
+
+
+	@Test
+	@DisplayName("댓글 수정 요청이 정상적인 경우라면 댓글 생성 후 정상 상태 코드를 반환한다")
+	void create_comment_success() {
+		Review review = testData.user1PublicReview;
+		User user1 = testData.user1;
+		Comment savedComment = testData.saveAndGetComment(review, user1, "안녕하세요");
+
+		CommentModifyRequest commentModifyRequest = new CommentModifyRequest(
+			"좋은 리뷰 감사합니다"
+		);
+
+		ResponseCodeAndMessages expectedCodeAndMessage = ResponseCodeAndMessages.COMMENT_MODIFY_SUCCESS;
+
+		given(this.spec)
+			.filter(document(DEFAULT_RESTDOC_PATH,
+				COMMENT_MODIFY_PATH_VARIABLE_SNIPPET,
+				COMMENT_MODIFY_REQUEST_SNIPPET,
+				COMMENT_MODIFY_RESPONSE_SNIPPET))
+			.accept(MediaType.APPLICATION_JSON_VALUE)
+			.header("Content-type", "application/json")
+			.header("Authorization", testData.user1ValidAuthorizationHeader)
+			.body(commentModifyRequest)
+
+		.when()
+			.put("/api/reviews/{reviewId}/comments/{commentId}", review.getId(), savedComment.getReviewId())
+
+		.then().log().all()
+			.statusCode(HttpStatus.OK.value())
+			.body("code", Matchers.equalTo(expectedCodeAndMessage.getCode()))
+			.body("message", Matchers.equalTo(expectedCodeAndMessage.getMessage()));
+	}
+}

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/comment/CommentModifyAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/comment/CommentModifyAcceptanceTest.java
@@ -26,8 +26,8 @@ class CommentModifyAcceptanceTest extends InitAcceptanceTest {
 	@DisplayName("댓글 수정 요청이 정상적인 경우라면 댓글 생성 후 정상 상태 코드를 반환한다")
 	void modify_comment_success() {
 		Review review = testData.user1PublicReview;
-		User user1 = testData.user1;
-		Comment savedComment = testData.saveAndGetComment(review, user1, "안녕하세요");
+		User kukim = testData.kukim;
+		Comment savedComment = testData.generator.comment(review, kukim, "안녕하세요");
 
 		CommentModifyRequest commentModifyRequest = new CommentModifyRequest(
 			"좋은 리뷰 감사합니다"
@@ -42,7 +42,7 @@ class CommentModifyAcceptanceTest extends InitAcceptanceTest {
 				COMMENT_MODIFY_RESPONSE_SNIPPET))
 			.accept(MediaType.APPLICATION_JSON_VALUE)
 			.header("Content-type", "application/json")
-			.header("Authorization", testData.user1ValidAuthorizationHeader)
+			.header("Authorization", testData.generator.validAuthorizationHeader(kukim))
 			.body(commentModifyRequest)
 
 		.when()

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/comment/CommentSnippet.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/comment/CommentSnippet.java
@@ -23,4 +23,16 @@ interface CommentSnippet {
 	);
 
 	Snippet COMMENT_CREATE_RESPONSE_SNIPPET = createResponseSnippetWithFields(responseFieldsOfCommonNonData());
+
+	Snippet COMMENT_MODIFY_PATH_VARIABLE_SNIPPET = pathParameters(
+		parameterWithName("reviewId").description("리뷰 아이디"),
+		parameterWithName("commentId").description("댓글 아이디")
+	);
+
+	Snippet COMMENT_MODIFY_REQUEST_SNIPPET = requestSnippetWithConstraintsAndFields(
+		CommentCreateRequest.class,
+		fieldWithPath("content").type(JsonFieldType.STRING).description("댓글 내용")
+	);
+
+	Snippet COMMENT_MODIFY_RESPONSE_SNIPPET = createResponseSnippetWithFields(responseFieldsOfCommonNonData());
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/common/DataGenerator.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/common/DataGenerator.java
@@ -1,0 +1,45 @@
+package com.jjikmuk.sikdorak.common;
+
+import com.jjikmuk.sikdorak.comment.domain.Comment;
+import com.jjikmuk.sikdorak.comment.repository.CommentRepository;
+import com.jjikmuk.sikdorak.review.domain.Review;
+import com.jjikmuk.sikdorak.user.auth.domain.JwtProvider;
+import com.jjikmuk.sikdorak.user.user.domain.User;
+import java.util.Date;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DataGenerator {
+
+	@Autowired
+	private JwtProvider jwtProvider;
+
+	@Autowired
+	private CommentRepository commentRepository;
+
+	public String validAuthorizationHeader(User user) {
+		String userPayload = String.valueOf(user.getId());
+
+		Date now = new Date();
+		Date expiredTime = new Date(now.getTime() + 1800000);
+
+		return "Bearer " + jwtProvider.createAccessToken(userPayload, expiredTime);
+	}
+
+	public String validAuthorizationHeader(User user, Date expiredTime) {
+		String userPayload = String.valueOf(user.getId());
+
+		return "Bearer " + jwtProvider.createAccessToken(userPayload, expiredTime);
+	}
+
+	public String refreshToken(User user, Date expiredTime) {
+		String userPayload = String.valueOf(user.getId());
+
+		return jwtProvider.createRefreshToken(userPayload, expiredTime);
+	}
+
+	public Comment comment(Review review, User user, String content) {
+		return commentRepository.save(new Comment(review.getId(), user.getId(), content));
+	}
+}

--- a/be/src/test/java/com/jjikmuk/sikdorak/common/DatabaseConfigurator.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/common/DatabaseConfigurator.java
@@ -1,5 +1,7 @@
 package com.jjikmuk.sikdorak.common;
 
+import com.jjikmuk.sikdorak.comment.domain.Comment;
+import com.jjikmuk.sikdorak.comment.repository.CommentRepository;
 import com.jjikmuk.sikdorak.review.domain.Review;
 import com.jjikmuk.sikdorak.review.repository.ReviewRepository;
 import com.jjikmuk.sikdorak.store.domain.Store;
@@ -37,6 +39,9 @@ public class DatabaseConfigurator implements InitializingBean {
 
     @Autowired
     private ReviewRepository reviewRepository;
+
+    @Autowired
+    private CommentRepository commentRepository;
 
     @Autowired
     private JwtProvider jwtProvider;
@@ -82,6 +87,10 @@ public class DatabaseConfigurator implements InitializingBean {
     @Override
     public void afterPropertiesSet() {
         entityManager.unwrap(Session.class).doWork(this::extractTableNames);
+    }
+
+    public Comment saveAndGetComment(Review review, User user, String content) {
+        return commentRepository.save(new Comment(review.getId(), user.getId(), content));
     }
 
 

--- a/be/src/test/java/com/jjikmuk/sikdorak/common/DatabaseConfigurator.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/common/DatabaseConfigurator.java
@@ -1,12 +1,9 @@
 package com.jjikmuk.sikdorak.common;
 
-import com.jjikmuk.sikdorak.comment.domain.Comment;
-import com.jjikmuk.sikdorak.comment.repository.CommentRepository;
 import com.jjikmuk.sikdorak.review.domain.Review;
 import com.jjikmuk.sikdorak.review.repository.ReviewRepository;
 import com.jjikmuk.sikdorak.store.domain.Store;
 import com.jjikmuk.sikdorak.store.repository.StoreRepository;
-import com.jjikmuk.sikdorak.user.auth.domain.JwtProvider;
 import com.jjikmuk.sikdorak.user.user.domain.User;
 import com.jjikmuk.sikdorak.user.user.domain.UserRepository;
 import java.sql.Connection;
@@ -40,14 +37,11 @@ public class DatabaseConfigurator implements InitializingBean {
     @Autowired
     private ReviewRepository reviewRepository;
 
-    @Autowired
-    private CommentRepository commentRepository;
-
-    @Autowired
-    private JwtProvider jwtProvider;
-
 //    @Autowired
 //    private UserDataConfigurator userDataConfigurator;
+
+    @Autowired
+    public DataGenerator generator;
 
     public Store store;
 //    public TUser kukim;
@@ -88,11 +82,6 @@ public class DatabaseConfigurator implements InitializingBean {
     public void afterPropertiesSet() {
         entityManager.unwrap(Session.class).doWork(this::extractTableNames);
     }
-
-    public Comment saveAndGetComment(Review review, User user, String content) {
-        return commentRepository.save(new Comment(review.getId(), user.getId(), content));
-    }
-
 
     // reference : https://www.baeldung.com/jdbc-database-metadata
     private void extractTableNames(Connection connection) throws SQLException {
@@ -177,24 +166,15 @@ public class DatabaseConfigurator implements InitializingBean {
     }
 
     private void initUserAuthorizationData() {
-        String user1Payload = String.valueOf(this.kukim.getId());
-        String user2Payload = String.valueOf(this.jay.getId());
-        String followSendUserPayload = String.valueOf(this.forky.getId());
-        String followAcceptUserPayload = String.valueOf(this.hoi.getId());
-
         Date now = new Date();
         Date accessTokenExpiredTime = new Date(now.getTime() + 1800000);
 
-        this.user1ValidAuthorizationHeader =
-            "Bearer " + jwtProvider.createAccessToken(user1Payload, accessTokenExpiredTime);
-        this.user2ValidAuthorizationHeader =
-            "Bearer " + jwtProvider.createAccessToken(user2Payload,accessTokenExpiredTime);
-        this.followSendUserValidAuthorizationHeader =
-            "Bearer " + jwtProvider.createAccessToken(followSendUserPayload, accessTokenExpiredTime);
-        this.followAcceptUserValidAuthorizationHeader =
-            "Bearer " + jwtProvider.createAccessToken(followAcceptUserPayload, accessTokenExpiredTime);
-        this.user1RefreshToken = jwtProvider.createRefreshToken(user1Payload, new Date(now.getTime()+8000000));
-        this.user1ExpiredRefreshToken = jwtProvider.createRefreshToken(user1Payload, new Date(now.getTime() - 1000));
+        this.user1ValidAuthorizationHeader = generator.validAuthorizationHeader(kukim, accessTokenExpiredTime);
+        this.user2ValidAuthorizationHeader = generator.validAuthorizationHeader(jay, accessTokenExpiredTime);
+        this.followSendUserValidAuthorizationHeader = generator.validAuthorizationHeader(forky, accessTokenExpiredTime);
+        this.followAcceptUserValidAuthorizationHeader = generator.validAuthorizationHeader(hoi, accessTokenExpiredTime);
+        this.user1RefreshToken = generator.refreshToken(kukim, new Date(now.getTime()+8000000));
+        this.user1ExpiredRefreshToken = generator.refreshToken(kukim, new Date(now.getTime() - 1000));
         this.user1InvalidRefreshToken = user1RefreshToken + "invalid";
     }
 

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/comment/CommentCreateIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/comment/CommentCreateIntegrationTest.java
@@ -24,11 +24,11 @@ class CommentCreateIntegrationTest extends InitIntegrationTest {
 
 	@Nested
 	@DisplayName("댓글을 작성할 때")
-	class CreateStoreTest {
+	class CreateCommentTest {
 
 		@Test
 		@DisplayName("정상적인 댓글 작성 요청이 주어진다면, 댓글이 생성된다.")
-		void create_store_success() {
+		void create_comment_success() {
 			// given
 			long reviewId = testData.user1PublicReview.getId();
 			LoginUser loginUser = new LoginUser(testData.kukim.getId(), Authority.USER);

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/comment/CommentCreateIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/comment/CommentCreateIntegrationTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+@DisplayName("CommentCreate 통합테스트")
 class CommentCreateIntegrationTest extends InitIntegrationTest {
 
 	@Autowired

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/comment/CommentModifyIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/comment/CommentModifyIntegrationTest.java
@@ -43,8 +43,8 @@ class CommentModifyIntegrationTest extends InitIntegrationTest {
 		void create_comment_success() {
 			// given
 			Review review = testData.user1PublicReview;
-			User user1 = testData.user1;
-			Comment comment = testData.saveAndGetComment(review, user1, "잘보고가요");
+			User user1 = testData.forky;
+			Comment comment = testData.generator.comment(review, user1, "잘보고가요");
 			String updatedContent = "정말 맛있겠네요";
 
 			// when
@@ -67,8 +67,8 @@ class CommentModifyIntegrationTest extends InitIntegrationTest {
 		void modify_comment_with_deleted_review_will_failed() {
 			// given
 			Review review = testData.user1PublicReview;
-			User user1 = testData.user1;
-			Comment comment = testData.saveAndGetComment(review, user1, "잘보고가요");
+			User user1 = testData.forky;
+			Comment comment = testData.generator.comment(review, user1, "잘보고가요");
 
 			reviewRepository.delete(review);
 
@@ -87,7 +87,7 @@ class CommentModifyIntegrationTest extends InitIntegrationTest {
 		void modify_comment_with_not_existing_comment_will_failed() {
 			// given
 			Review review = testData.user1PublicReview;
-			User user1 = testData.user1;
+			User user1 = testData.forky;
 			long notExistingCommentId = Long.MIN_VALUE;
 
 			// then
@@ -105,8 +105,8 @@ class CommentModifyIntegrationTest extends InitIntegrationTest {
 		void modify_comment_with_deleted_comment_will_failed() {
 			// given
 			Review review = testData.user1PublicReview;
-			User user1 = testData.user1;
-			Comment comment = testData.saveAndGetComment(review, user1, "잘보고가요");
+			User user1 = testData.forky;
+			Comment comment = testData.generator.comment(review, user1, "잘보고가요");
 			commentRepository.delete(comment);
 
 			// then
@@ -124,8 +124,8 @@ class CommentModifyIntegrationTest extends InitIntegrationTest {
 		void modify_comment_with_not_existing_user_will_failed() {
 			// given
 			Review review = testData.user1PublicReview;
-			User user1 = testData.user1;
-			Comment comment = testData.saveAndGetComment(review, user1, "잘보고가요");
+			User user1 = testData.forky;
+			Comment comment = testData.generator.comment(review, user1, "잘보고가요");
 
 			// then
 			assertThatThrownBy(
@@ -142,14 +142,14 @@ class CommentModifyIntegrationTest extends InitIntegrationTest {
 		void modify_comment_with_not_autor_will_failed() {
 			// given
 			Review review = testData.user1PublicReview;
-			User user1 = testData.user1;
-			Comment comment = testData.saveAndGetComment(review, user1, "잘보고가요");
+			User user1 = testData.forky;
+			Comment comment = testData.generator.comment(review, user1, "잘보고가요");
 
 			// then
 			assertThatThrownBy(
 				() -> commentService.modifyComment(review.getId(),
 					comment.getId(),
-					createLoginUserWithUserId(testData.user2.getId()),
+					createLoginUserWithUserId(testData.kukim.getId()),
 					new CommentModifyRequest("맛집이네요!")
 				))
 				.isInstanceOf(UnauthorizedUserException.class);

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/comment/CommentModifyIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/comment/CommentModifyIntegrationTest.java
@@ -1,0 +1,162 @@
+package com.jjikmuk.sikdorak.integration.comment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.jjikmuk.sikdorak.comment.controller.request.CommentModifyRequest;
+import com.jjikmuk.sikdorak.comment.domain.Comment;
+import com.jjikmuk.sikdorak.comment.exception.NotFoundCommentException;
+import com.jjikmuk.sikdorak.comment.repository.CommentRepository;
+import com.jjikmuk.sikdorak.comment.service.CommentService;
+import com.jjikmuk.sikdorak.integration.InitIntegrationTest;
+import com.jjikmuk.sikdorak.review.domain.Review;
+import com.jjikmuk.sikdorak.review.exception.NotFoundReviewException;
+import com.jjikmuk.sikdorak.review.repository.ReviewRepository;
+import com.jjikmuk.sikdorak.user.auth.controller.Authority;
+import com.jjikmuk.sikdorak.user.auth.controller.LoginUser;
+import com.jjikmuk.sikdorak.user.auth.exception.NeedLoginException;
+import com.jjikmuk.sikdorak.user.user.domain.User;
+import com.jjikmuk.sikdorak.user.user.exception.UnauthorizedUserException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayName("CommentModify 통합테스트")
+class CommentModifyIntegrationTest extends InitIntegrationTest {
+
+	@Autowired
+	private CommentService commentService;
+
+	@Autowired
+	private CommentRepository commentRepository;
+
+	@Autowired
+	private ReviewRepository reviewRepository;
+
+	@Nested
+	@DisplayName("댓글을 수정할 때")
+	class ModifyCommentTest {
+
+		@Test
+		@DisplayName("정상적인 댓글 수정 요청이 주어진다면, 댓글이 수정된다.")
+		void create_comment_success() {
+			// given
+			Review review = testData.user1PublicReview;
+			User user1 = testData.user1;
+			Comment comment = testData.saveAndGetComment(review, user1, "잘보고가요");
+			String updatedContent = "정말 맛있겠네요";
+
+			// when
+			commentService.modifyComment(review.getId(),
+				comment.getId(),
+				createLoginUserWithUserId(user1.getId()),
+				new CommentModifyRequest(updatedContent)
+			);
+
+			// then
+			Comment updatedComment = commentRepository.findById(comment.getId()).orElseThrow();
+			assertThat(updatedComment.getId()).isEqualTo(comment.getId());
+			assertThat(updatedComment.getUserId()).isEqualTo(comment.getUserId());
+			assertThat(updatedComment.getReviewId()).isEqualTo(comment.getReviewId());
+			assertThat(updatedComment.getCommentContent()).isEqualTo(updatedContent);
+		}
+
+		@Test
+		@DisplayName("삭제 처리된 리뷰에 대해 댓글 수정 요청이 주어진다면 예외를 발생시킨다")
+		void modify_comment_with_deleted_review_will_failed() {
+			// given
+			Review review = testData.user1PublicReview;
+			User user1 = testData.user1;
+			Comment comment = testData.saveAndGetComment(review, user1, "잘보고가요");
+
+			reviewRepository.delete(review);
+
+			// then
+			assertThatThrownBy(
+				() -> commentService.modifyComment(review.getId(),
+					comment.getId(),
+					createLoginUserWithUserId(user1.getId()),
+					new CommentModifyRequest("맛집이네요!")
+				))
+				.isInstanceOf(NotFoundReviewException.class);
+		}
+
+		@Test
+		@DisplayName("존재하지 않는 댓글에 대해 수정 요청이 주어진다면 예외를 발생시킨다")
+		void modify_comment_with_not_existing_comment_will_failed() {
+			// given
+			Review review = testData.user1PublicReview;
+			User user1 = testData.user1;
+			long notExistingCommentId = Long.MIN_VALUE;
+
+			// then
+			assertThatThrownBy(
+				() -> commentService.modifyComment(review.getId(),
+					notExistingCommentId,
+					createLoginUserWithUserId(user1.getId()),
+					new CommentModifyRequest("맛집이네요!")
+				))
+				.isInstanceOf(NotFoundCommentException.class);
+		}
+
+		@Test
+		@DisplayName("삭제 처리된 댓글에 대해 수정 요청이 주어진다면 예외를 발생시킨다")
+		void modify_comment_with_deleted_comment_will_failed() {
+			// given
+			Review review = testData.user1PublicReview;
+			User user1 = testData.user1;
+			Comment comment = testData.saveAndGetComment(review, user1, "잘보고가요");
+			commentRepository.delete(comment);
+
+			// then
+			assertThatThrownBy(
+				() -> commentService.modifyComment(review.getId(),
+					comment.getId(),
+					createLoginUserWithUserId(user1.getId()),
+					new CommentModifyRequest("맛집이네요!")
+				))
+				.isInstanceOf(NotFoundCommentException.class);
+		}
+
+		@Test
+		@DisplayName("로그인 하지 않은 유저가 댓글 수정 요청을 한다면 예외를 발생시킨다")
+		void modify_comment_with_not_existing_user_will_failed() {
+			// given
+			Review review = testData.user1PublicReview;
+			User user1 = testData.user1;
+			Comment comment = testData.saveAndGetComment(review, user1, "잘보고가요");
+
+			// then
+			assertThatThrownBy(
+				() -> commentService.modifyComment(review.getId(),
+					comment.getId(),
+					new LoginUser(Authority.ANONYMOUS),
+					new CommentModifyRequest("맛집이네요!")
+				))
+				.isInstanceOf(NeedLoginException.class);
+		}
+
+		@Test
+		@DisplayName("유저가 본인이 작성한 댓글이 아닌데 수정 요청을 한다면 예외를 발생시킨다")
+		void modify_comment_with_not_autor_will_failed() {
+			// given
+			Review review = testData.user1PublicReview;
+			User user1 = testData.user1;
+			Comment comment = testData.saveAndGetComment(review, user1, "잘보고가요");
+
+			// then
+			assertThatThrownBy(
+				() -> commentService.modifyComment(review.getId(),
+					comment.getId(),
+					createLoginUserWithUserId(testData.user2.getId()),
+					new CommentModifyRequest("맛집이네요!")
+				))
+				.isInstanceOf(UnauthorizedUserException.class);
+		}
+	}
+
+	private static LoginUser createLoginUserWithUserId(long userId) {
+		return new LoginUser(userId, Authority.USER);
+	}
+}


### PR DESCRIPTION
### ❗️ 이슈 번호

[SDR-186]

<br><br>

### 📝 구현 내용

- 댓글 수정 API 구현
- DataGenerator 추가

<br><br>

### 🙇🏻‍♂️ 리뷰어에게 부탁합니다!

- DataGenerator 를 추가하였는데, 이에 대한 리뷰 부탁드려요!
  - 추가 배경 : comment 를 미리 생성 해놓으려면, `Review` `User` 가 필요
    - 미리 생성된 Comment 를 사용하면 어떤 `Review` 에 대해 어떤 `User` 가 작성한 Comment 인지 확인하기 어려움
      - `testData.commentByJayOnReview1` 이렇게 하려다가, 이게 맞나 싶었어요
    - 그래서 Review, User 를 받아 Comment 를 생성하는 로직이 필요했음..! (외부에서 쉽게 인지하기 위해)
    - AccessToken 도 같은 맥락에서 Generator 에 생성하는 로직을 추가함!(어떤 User 의 AccessToken 인지 명확하게 알 수 있도록 하기 위함)

=> "의존성이 없는 객체는 `DatabaseConfigurator` 에서 사전에 생성해서 제공하고, 여러 의존성이 필요한 경우 Generator 에서 조합해주는 메소드를 제공하는건 어떨까" 하는게 제 생각입니닷

<br><br>

[SDR-186]: https://jjikmuk.atlassian.net/browse/SDR-186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ