### PR TITLE
[SDR-52] common : 테라폼을 활용한 FE 팀 정적 리소스 배포용도의 CloudFront 

### DIFF
--- a/infra/FE_s3_cloudfront/.terraform.lock.hcl
+++ b/infra/FE_s3_cloudfront/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "4.27.0"
+  hashes = [
+    "h1:JjDRnFkYnMTgW1OJclVkE7ucHPFXwhNzrdexhtj97Lo=",
+    "zh:0f5ade3801fec487641e4f7d81e28075b716c787772f9709cc2378d20f325791",
+    "zh:19ffa83be6b6765a4f821a17b8d260dd0f192a6c40765fa53ac65fd042cb1f65",
+    "zh:3ac89d33ff8ca75bdc42f31c63ce0018ffc66aa69917c18713e824e381950e4e",
+    "zh:81a199724e74992c8a029a968d211cb45277d95a2e88d0f07ec85127b6c6849b",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a2e2c851a37ef97bbccccd2e686b4d016abe207a7f56bff70b10bfdf8ed1cbfd",
+    "zh:baf844def338d77f8a3106b1411a1fe22e93a82e3dc51e5d33b766f741c4a6a3",
+    "zh:bc33137fae808f91da0a9de7031cbea77d0ee4eefb4d2ad6ab7f58cc2111a7ff",
+    "zh:c960ae2b33c8d3327f67a3db5ce1952315146d69dfc3f1b0922242e2b218eec8",
+    "zh:f3ea1a25797c79c035463a1188a6a42e131f391f3cb714975ce49ccd301cda07",
+    "zh:f7e77c871d38236e5fedee0086ff77ff396e88964348c794cf38e578fcc00293",
+    "zh:fb338d5dfafab907b8608bd66cad8ca9ae4679f8c62c2435c2056a38b719baa2",
+  ]
+}

--- a/infra/FE_s3_cloudfront/cloudfront.tf
+++ b/infra/FE_s3_cloudfront/cloudfront.tf
@@ -1,0 +1,52 @@
+# https://github.com/terraform-aws-modules/terraform-aws-cloudfront
+
+module "sikdorak-cdn" {
+  source = "terraform-aws-modules/cloudfront/aws"
+  version = "2.9.3"
+
+# 현재 domain 없음, 추가한다면 레코드 작업 A 수동으로 추가해야함
+#  aliases = ["sikdorak.com"]
+
+  comment             = "식도락 웹 서비스 by React"
+  enabled             = true
+  is_ipv6_enabled     = true
+  price_class         = "PriceClass_All"
+  retain_on_delete    = true
+  wait_for_deployment = true
+  default_root_object = "index.html"
+
+#  restrictions {
+#    geo_restriction {
+#        locations        = ["US", "CA", "GB", "DE"]
+#    }
+#  }
+
+  create_origin_access_identity = true
+  origin_access_identities = {
+    sikdorak-fe = "Access for sikdorak web"
+  }
+
+  origin = {
+    sikdorak-fe = {
+      domain_name = "sikdorak-fe.s3.ap-northeast-2.amazonaws.com"
+      s3_origin_config = {
+        origin_access_identity = "sikdorak-fe" 
+        # cloudfront 오리진 설정 버킷 정책 업데이트 설정으로 수동 추가해야함
+      }
+    }
+  }
+
+  default_cache_behavior = {
+    target_origin_id           = "sikdorak-fe"
+    viewer_protocol_policy     = "redirect-to-https"
+
+    allowed_methods = ["GET", "HEAD", "OPTIONS"]
+    cached_methods  = ["GET", "HEAD"]
+    compress        = true
+    query_string    = true
+  }
+
+  viewer_certificate = {
+    cloudfront_default_certificate = true
+  }
+}

--- a/infra/FE_s3_cloudfront/provider.tf
+++ b/infra/FE_s3_cloudfront/provider.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+    region = "ap-northeast-2" 
+}

--- a/infra/FE_s3_cloudfront/s3.tf
+++ b/infra/FE_s3_cloudfront/s3.tf
@@ -1,0 +1,7 @@
+#resource "aws_s3_bucket" "sikdorak-fe" {
+#    bucket = "sikdorak-fe"
+
+#    tags = {
+#        Name = "sikdorak-web"
+#    }
+#}


### PR DESCRIPTION
### ❗️ 이슈 번호

[SDR-52]

<br><br>

### 📝 구현 내용

- FE 팀 배포를 위한 AWS CDN 사용
- module 활용
- 단, 현재 s3 는 테라폼으로 설정하지 않음 -> 변경 예정

[SDR-52]: https://jjikmuk.atlassian.net/browse/SDR-52?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ