### PR TITLE
[SDR-226] common: 테라폼을 활용한 이미지 스토리지 목적의 s3, 스프링이 사용할 iam 유저 프로비저닝

### DIFF
--- a/infra/s3_images/.terraform.lock.hcl
+++ b/infra/s3_images/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "4.28.0"
+  hashes = [
+    "h1:Z7sun0kcsON43rhvjmlv0nzkL2XMoBUTGLdCIFTmJ4I=",
+    "zh:1d4806e50971d2cd565273cedf3206e38931677a6f546cf2b9fb140b52b80604",
+    "zh:3f076791002b8afa5ba2d2038f1e1db5956022327eb5242152723ed410ae4571",
+    "zh:40e5944a9df0d083dbd316bcc6ac9ceada5c00dab70c21897e62b68c4c936bc9",
+    "zh:68b78d0c1866aa0bcbbadb1cf51349c9af697f8789f5778b7e7e2912a9c4845d",
+    "zh:72d6e66136841c0e5ae264e03555cf59751ddae1b9784eafcb877c624332c70a",
+    "zh:902c8f89dc10d321b87c09270c27a31a42d4e74e4da1608e55b7f241cd010a62",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:bf54c9f55d420b4e1fe68db81a759c40b9f9747159dea3061212a1c9768dcdfd",
+    "zh:bfbe7e745c420a4ebd27ca35dfe5c2acc7cdd05092e1daf60f5ae29a1130d752",
+    "zh:d271a30b16f0861f020e423d120d1458cf1757e740e016ace22084c39dc13550",
+    "zh:f1e4672d1625fd1f1268d4b807cb90e28150d46fb2d0dd0836de65db29c8d5e6",
+    "zh:f5cee910b4db2da3c2a28dae9055cbca4273eb774c362bb7bb5bde04deff4557",
+  ]
+}

--- a/infra/s3_images/iam.tf
+++ b/infra/s3_images/iam.tf
@@ -1,0 +1,31 @@
+resource "aws_iam_user" "s3_images_springboot" {
+
+  name = "BE-springserver"
+
+  tags = {
+
+    Name = "BE-developers"
+
+  }
+}
+
+resource "aws_iam_user_policy" "art_devops_black" {
+  name = "s3_images_access"
+  user = aws_iam_user.s3_images_springboot.name
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:*"
+      ],
+      "Effect": "Allow",
+      "Resource": "${aws_s3_bucket.sikdorak_images.arn}"
+    }
+  ]
+
+}
+EOF
+}

--- a/infra/s3_images/provider.tf
+++ b/infra/s3_images/provider.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = "ap-northeast-2"
+}

--- a/infra/s3_images/s3.tf
+++ b/infra/s3_images/s3.tf
@@ -1,0 +1,19 @@
+resource "aws_s3_bucket" "sikdorak_images" {
+  bucket = var.s3_images_name
+
+  tags = {
+    Name = "sikdorak"
+  }
+}
+
+resource "aws_s3_bucket_acl" "sikdora_images_acl" {
+  bucket = aws_s3_bucket.sikdorak_images.id
+  acl    = "public-read"
+}
+
+resource "aws_s3_bucket_versioning" "sikdorak_images_versioning" {
+  bucket = aws_s3_bucket.sikdorak_images.id
+  versioning_configuration {
+    status = "Disabled"
+  }
+}

--- a/infra/s3_images/variabels.tf
+++ b/infra/s3_images/variabels.tf
@@ -1,0 +1,7 @@
+variable "s3_images_name" {
+  description = "식도락 이미지 서버 버킷 이름"
+
+  type = string
+
+  default = "sikdorak-images"
+}


### PR DESCRIPTION
### ❗️ 이슈 번호

[SDR-226]

<br><br>

### 📝 구현 내용

- 테라폼을 활용한 이미지 스토리지를 위한 s3 생성

![image](https://user-images.githubusercontent.com/57086195/187383863-18c01921-3895-4132-9338-8a0487ad86fd.png)

- 스프링에서 사용할 유저 생성


![image](https://user-images.githubusercontent.com/57086195/187391234-1f0b0437-c4e5-4b5a-a3cf-5d4606323783.png)

![image](https://user-images.githubusercontent.com/57086195/187390661-ec773506-caa3-499d-9f08-37c118b29112.png)

- BE-springboot 유저 토큰은 config에 넣어놓을게요!

![image](https://user-images.githubusercontent.com/57086195/187390821-ff3f7c6e-9562-4872-817f-6c855f70bbed.png)


[SDR-226]: https://jjikmuk.atlassian.net/browse/SDR-226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ