### PR TITLE
[SDR-225] BE : PUT S3 presigned URL 생성하는 API (이미지 업로드를 위한 기능)

### DIFF
--- a/be/build.gradle
+++ b/be/build.gradle
@@ -83,6 +83,8 @@ dependencies {
     // WireMock
     testImplementation "org.springframework.cloud:spring-cloud-starter-contract-stub-runner"
 
+    // aws : https://spring.io/blog/2021/03/17/spring-cloud-aws-2-3-is-now-available#why-has-the-package-name-changed
+    implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.2'
 }
 
 test {

--- a/be/build.gradle
+++ b/be/build.gradle
@@ -85,6 +85,7 @@ dependencies {
 
     // aws : https://spring.io/blog/2021/03/17/spring-cloud-aws-2-3-is-now-available#why-has-the-package-name-changed
     implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.2'
+    testImplementation "org.testcontainers:localstack:1.17.3"
 }
 
 test {

--- a/be/src/docs/asciidoc/aws/s3.adoc
+++ b/be/src/docs/asciidoc/aws/s3.adoc
@@ -1,0 +1,16 @@
+=== AWS : 업로드할 수 있는 S3 Presigned URL 생성
+
+API : `PUT /api/images/url`
+
+RequestBody로 이미지 파일 확장자(jpg, jpeg, png) 를 보내야합니다.
+
+=== `201 CREATED`
+
+
+==== `Request`
+
+operation::presigned_url_create_acceptance_test/create_presigned_url_success[snippets='http-request,request-fields']
+
+==== `Response`
+
+operation::presigned_url_create_acceptance_test/create_presigned_url_success[snippets='http-response,response-fields']

--- a/be/src/docs/asciidoc/index.adoc
+++ b/be/src/docs/asciidoc/index.adoc
@@ -19,6 +19,10 @@ API : `GET /api/docs/info`
 
 include::{docdir}/review/review.adoc[]
 
+== 이미지 생성 API
+
+include::{docdir}/aws/s3.adoc[]
+
 == 댓글 API
 
 include::{docdir}/comment/comment.adoc[]
@@ -34,5 +38,4 @@ include::{docdir}/user/user.adoc[]
 == 로그인 API
 
 include::{docdir}/auth/auth.adoc[]
-
 

--- a/be/src/main/java/com/jjikmuk/sikdorak/aws/controller/AwsS3Controller.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/aws/controller/AwsS3Controller.java
@@ -1,0 +1,38 @@
+package com.jjikmuk.sikdorak.aws.controller;
+
+import com.jjikmuk.sikdorak.aws.controller.request.PresignedUrlCreateRequest;
+import com.jjikmuk.sikdorak.aws.controller.response.PresignedUrlCreateResponse;
+import com.jjikmuk.sikdorak.aws.service.GeneratePresignedURLService;
+import com.jjikmuk.sikdorak.common.ResponseCodeAndMessages;
+import com.jjikmuk.sikdorak.common.aop.UserOnly;
+import com.jjikmuk.sikdorak.common.response.CommonResponseEntity;
+import com.jjikmuk.sikdorak.user.auth.controller.LoginUser;
+import com.jjikmuk.sikdorak.user.auth.domain.AuthenticatedUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/images/url")
+public class AwsS3Controller {
+
+	private final GeneratePresignedURLService generatePresignedURLService;
+
+	@UserOnly
+	@PutMapping
+	public CommonResponseEntity<PresignedUrlCreateResponse> createPresignedUrl(
+		@RequestBody PresignedUrlCreateRequest presignedUrlCreateRequest,
+		@AuthenticatedUser LoginUser loginUser) {
+		PresignedUrlCreateResponse presignedUrlCreateResponse = generatePresignedURLService.createPresignedUrl(
+			presignedUrlCreateRequest, loginUser);
+
+		return new CommonResponseEntity<>(
+			ResponseCodeAndMessages.IMAGES_UPLOAD_PRESIGNED_URL_CREATE_SUCCESS,
+			presignedUrlCreateResponse,
+			HttpStatus.OK);
+	}
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/aws/controller/AwsS3Controller.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/aws/controller/AwsS3Controller.java
@@ -33,6 +33,6 @@ public class AwsS3Controller {
 		return new CommonResponseEntity<>(
 			ResponseCodeAndMessages.IMAGES_UPLOAD_PRESIGNED_URL_CREATE_SUCCESS,
 			presignedUrlCreateResponse,
-			HttpStatus.OK);
+			HttpStatus.CREATED);
 	}
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/aws/controller/request/PresignedUrlCreateRequest.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/aws/controller/request/PresignedUrlCreateRequest.java
@@ -1,0 +1,20 @@
+package com.jjikmuk.sikdorak.aws.controller.request;
+
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PresignedUrlCreateRequest {
+
+	@NotEmpty
+	@Pattern(regexp = ".jpg\\|.jpeg\\|.png")
+	private String extension;
+
+	public PresignedUrlCreateRequest(String extension) {
+		this.extension = extension;
+	}
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/aws/controller/request/PresignedUrlCreateRequest.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/aws/controller/request/PresignedUrlCreateRequest.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 public class PresignedUrlCreateRequest {
 
 	@NotEmpty
-	@Pattern(regexp = ".jpg\\|.jpeg\\|.png")
+	@Pattern(regexp = "jpg\\|jpeg\\|png")
 	private String extension;
 
 	public PresignedUrlCreateRequest(String extension) {

--- a/be/src/main/java/com/jjikmuk/sikdorak/aws/controller/response/PresignedUrlCreateResponse.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/aws/controller/response/PresignedUrlCreateResponse.java
@@ -1,6 +1,10 @@
 package com.jjikmuk.sikdorak.aws.controller.response;
 
-public record PresignedUrlCreateResponse(String presignedUrl) {
+import javax.validation.constraints.NotEmpty;
+import org.hibernate.validator.constraints.URL;
+
+public record PresignedUrlCreateResponse(
+	@NotEmpty @URL String presignedUrl) {
 
 }
 

--- a/be/src/main/java/com/jjikmuk/sikdorak/aws/controller/response/PresignedUrlCreateResponse.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/aws/controller/response/PresignedUrlCreateResponse.java
@@ -1,0 +1,6 @@
+package com.jjikmuk.sikdorak.aws.controller.response;
+
+public record PresignedUrlCreateResponse(String presignedUrl) {
+
+}
+

--- a/be/src/main/java/com/jjikmuk/sikdorak/aws/service/GeneratePresignedURLService.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/aws/service/GeneratePresignedURLService.java
@@ -1,0 +1,57 @@
+package com.jjikmuk.sikdorak.aws.service;
+
+import com.amazonaws.HttpMethod;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.GeneratePresignedUrlRequest;
+import com.jjikmuk.sikdorak.aws.controller.request.PresignedUrlCreateRequest;
+import com.jjikmuk.sikdorak.aws.controller.response.PresignedUrlCreateResponse;
+import com.jjikmuk.sikdorak.common.properties.AwsProperties;
+import com.jjikmuk.sikdorak.user.auth.controller.LoginUser;
+import java.net.URL;
+import java.time.Instant;
+import java.util.Date;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class GeneratePresignedURLService {
+
+	public static final int FIVE_MINUTE = 1000 * 60 * 5;
+
+	private final AmazonS3 amazonS3;
+	private final AwsProperties awsProperties;
+
+	/**
+	 * 이미지 파일 확장자에 따른 s3 저장할 수 있는 presignedURL을 리턴합니다.
+	 * 현재는 유저에 따른 이미지 폴더 경로로 저장하지 않습니다.
+	 * @param presignedUrlCreateRequest 이미지 파일 확장자를 담고있는 요청 객체
+	 * @param loginUser (현재 사용하지 않습니다.)
+	 * @return presignedURL를 담고있는 응답 객체
+	 */
+	@Transactional(readOnly = true)
+	public PresignedUrlCreateResponse createPresignedUrl(PresignedUrlCreateRequest presignedUrlCreateRequest, LoginUser loginUser) {
+		ImageExtension imageExtension = ImageExtension.create(
+			presignedUrlCreateRequest.getExtension());
+		String fileName = UUID.randomUUID() + imageExtension.getExtension();
+
+		// Generate the presigned URL.
+		GeneratePresignedUrlRequest generatePresignedUrlRequest =
+			new GeneratePresignedUrlRequest(awsProperties.getBucket(), "origin/" + fileName)
+				.withMethod(HttpMethod.PUT)
+				.withExpiration(getExpiration(FIVE_MINUTE));
+		URL url = amazonS3.generatePresignedUrl(generatePresignedUrlRequest);
+
+		return new PresignedUrlCreateResponse(url.toString());
+	}
+
+	private static Date getExpiration(long expirationAsMilliseconds) {
+		java.util.Date expiration = new java.util.Date();
+		long expTimeMillis = Instant.now().toEpochMilli();
+		expTimeMillis += expirationAsMilliseconds;
+		expiration.setTime(expTimeMillis);
+		return expiration;
+	}
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/aws/service/ImageExtension.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/aws/service/ImageExtension.java
@@ -1,0 +1,25 @@
+package com.jjikmuk.sikdorak.aws.service;
+
+import com.jjikmuk.sikdorak.aws.service.exception.InvalidImagesExtensionException;
+
+public enum ImageExtension {
+	JPG(".jpg"), JPEG(".jpeg"), PNG(".png");
+
+	private final String extension;
+
+	ImageExtension(String extension) {
+		this.extension = extension;
+	}
+
+	public static ImageExtension create(String extension) {
+		try {
+			return valueOf(extension.toUpperCase());
+		} catch (IllegalArgumentException | NullPointerException e) {
+			throw new InvalidImagesExtensionException(e);
+		}
+	}
+
+	public String getExtension() {
+		return extension;
+	}
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/aws/service/exception/InvalidImagesExtensionException.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/aws/service/exception/InvalidImagesExtensionException.java
@@ -1,0 +1,18 @@
+package com.jjikmuk.sikdorak.aws.service.exception;
+
+import com.jjikmuk.sikdorak.common.exception.SikdorakRuntimeException;
+import org.springframework.http.HttpStatus;
+
+public class InvalidImagesExtensionException extends
+	SikdorakRuntimeException {
+
+	public InvalidImagesExtensionException(Throwable cause) {
+		super(cause);
+	}
+
+	@Override
+	public HttpStatus getHttpStatus() {
+		return HttpStatus.BAD_REQUEST;
+	}
+
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/ResponseCodeAndMessages.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/ResponseCodeAndMessages.java
@@ -39,7 +39,8 @@ public enum ResponseCodeAndMessages implements CodeAndMessages {
     COMMENT_SEARCH_SUCCESS("T-C004", "댓글 조회에 성공했습니다."),
 
     // ETC
-    SYSTEMINFO_SEARCH_API_DOCS_INFO("T-S001", "API 문서 코드/메세지 검색 성공했습니다.");
+    SYSTEMINFO_SEARCH_API_DOCS_INFO("T-S001", "API 문서 코드/메세지 검색 성공했습니다."),
+	IMAGES_UPLOAD_PRESIGNED_URL_CREATE_SUCCESS("T-I001", "업로드 용도의 S3 PreSigned URL이 생성에 성공했습니다.");
 
 
     private final String code;

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/exception/ExceptionCodeAndMessages.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/exception/ExceptionCodeAndMessages.java
@@ -1,5 +1,6 @@
 package com.jjikmuk.sikdorak.common.exception;
 
+import com.jjikmuk.sikdorak.aws.service.exception.InvalidImagesExtensionException;
 import com.jjikmuk.sikdorak.comment.exception.InvalidCommentContentException;
 import com.jjikmuk.sikdorak.comment.exception.NotFoundCommentException;
 import com.jjikmuk.sikdorak.common.CodeAndMessages;
@@ -55,6 +56,9 @@ public enum ExceptionCodeAndMessages implements CodeAndMessages {
     INVALID_REVIEW_IMAGE("F-R009", "유효하지 않은 리뷰 이미지 입니다.", InvalidReviewImageException.class),
     DUPLICATE_LIKE_USER("F-R010", "이미 좋아요를 누른 리뷰입니다.", DuplicateLikeUserException.class),
     NOT_FOUND_LIKE_USER("F-R011", "존재하지 않는 좋아요 정보입니다.", NotFoundLikeUserException.class),
+
+    // Images
+    INVALID_IMAGES_EXTENSION("F-I001", "유효하지 않은 이미지 확장자 입니다.", InvalidImagesExtensionException.class),
 
     // Store
     NOT_FOUND_STORE("F-S001", "Store Id를 찾을 수 없습니다.", NotFoundStoreException.class),

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/properties/AwsProperties.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/properties/AwsProperties.java
@@ -1,0 +1,25 @@
+package com.jjikmuk.sikdorak.common.properties;
+
+import javax.validation.constraints.NotEmpty;
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.validation.annotation.Validated;
+
+@Getter
+@Validated
+@ConstructorBinding
+@ConfigurationProperties(prefix = "cloud.aws.s3")
+public class AwsProperties {
+
+	@NotEmpty
+	private final String bucket;
+
+	public AwsProperties(String bucket) {
+		this.bucket = bucket;
+	}
+
+	public String getBucket() {
+		return bucket;
+	}
+}

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/AWSMockConfig.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/AWSMockConfig.java
@@ -1,0 +1,45 @@
+package com.jjikmuk.sikdorak.acceptance;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.containers.localstack.LocalStackContainer.Service;
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * Reference : https://www.testcontainers.org/modules/localstack/
+ */
+@TestConfiguration
+public class AWSMockConfig {
+
+	@Bean(initMethod = "start", destroyMethod = "stop")
+	public LocalStackContainer localStackContainer() {
+		DockerImageName localstackImage = DockerImageName.parse("localstack/localstack:0.11.3");
+
+		return new LocalStackContainer(localstackImage)
+			.withServices(LocalStackContainer.Service.S3);
+	}
+
+	@Bean
+	public AmazonS3 amazonS3(LocalStackContainer localStack) {
+		return AmazonS3ClientBuilder.standard()
+			.withEndpointConfiguration(
+				new AwsClientBuilder.EndpointConfiguration(
+					localStack.getEndpointOverride(Service.S3).toString(),
+					localStack.getRegion()
+				)
+			)
+			.withCredentials(
+				new AWSStaticCredentialsProvider(
+					new BasicAWSCredentials(localStack.getAccessKey(), localStack.getSecretKey())
+				)
+			)
+			.build();
+	}
+
+}

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/InitAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/InitAcceptanceTest.java
@@ -4,8 +4,10 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.mo
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.documentationConfiguration;
 
+import com.amazonaws.services.s3.AmazonS3;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jjikmuk.sikdorak.common.DatabaseConfigurator;
+import com.jjikmuk.sikdorak.common.properties.AwsProperties;
 import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.config.ObjectMapperConfig;
@@ -23,7 +25,7 @@ import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.operation.preprocess.OperationPreprocessor;
 import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, classes = AWSMockConfig.class)
 @ExtendWith(RestDocumentationExtension.class)
 @ActiveProfiles("test")
 public class InitAcceptanceTest {
@@ -42,6 +44,12 @@ public class InitAcceptanceTest {
 
 	@Autowired
 	protected DatabaseConfigurator testData;
+
+	@Autowired
+	AmazonS3 amazonS3;
+
+	@Autowired
+	AwsProperties awsProperties;
 
 	{
 		setUpRestAssured();

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/aws/PresignedURLCreateAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/aws/PresignedURLCreateAcceptanceTest.java
@@ -1,0 +1,41 @@
+package com.jjikmuk.sikdorak.acceptance.aws;
+
+import static com.jjikmuk.sikdorak.acceptance.aws.S3Snippet.PRESIGNED_URL_CREATE_REQUEST_SNIPPET;
+import static com.jjikmuk.sikdorak.acceptance.aws.S3Snippet.PRESIGNED_URL_CREATE_RESPONSE_SNIPPET;
+import static io.restassured.RestAssured.given;
+import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
+
+import com.jjikmuk.sikdorak.acceptance.InitAcceptanceTest;
+import com.jjikmuk.sikdorak.aws.controller.request.PresignedUrlCreateRequest;
+import com.jjikmuk.sikdorak.common.ResponseCodeAndMessages;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+class PresignedURLCreateAcceptanceTest extends InitAcceptanceTest {
+
+	@Test
+	@DisplayName("PUT S3 presigned URL 생성 요청이 정상적인 경우라면 URL 생성 후 정상 상태 코드와 URL을 반환한다")
+	void create_presignedURL_success() {
+		PresignedUrlCreateRequest presignedUrlCreateRequest = new PresignedUrlCreateRequest("jpg");
+
+		given(this.spec)
+			.filter(document(DEFAULT_RESTDOC_PATH,
+				PRESIGNED_URL_CREATE_REQUEST_SNIPPET,
+				PRESIGNED_URL_CREATE_RESPONSE_SNIPPET))
+			.accept(MediaType.APPLICATION_JSON_VALUE)
+			.header("Content-type", "application/json")
+			.header("Authorization", testData.user1ValidAuthorizationHeader)
+			.body(presignedUrlCreateRequest)
+
+		.when()
+			.put("/api/images/url")
+
+		.then()
+			.statusCode(HttpStatus.CREATED.value())
+			.body("code", Matchers.equalTo(ResponseCodeAndMessages.IMAGES_UPLOAD_PRESIGNED_URL_CREATE_SUCCESS.getCode()))
+			.body("message", Matchers.equalTo(ResponseCodeAndMessages.IMAGES_UPLOAD_PRESIGNED_URL_CREATE_SUCCESS.getMessage()));
+	}
+}

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/aws/S3Snippet.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/aws/S3Snippet.java
@@ -1,0 +1,29 @@
+package com.jjikmuk.sikdorak.acceptance.aws;
+
+import static com.jjikmuk.sikdorak.acceptance.DocumentFormatGenerator.createResponseSnippetWithFields;
+import static com.jjikmuk.sikdorak.acceptance.DocumentFormatGenerator.requestSnippetWithConstraintsAndFields;
+import static com.jjikmuk.sikdorak.acceptance.DocumentFormatGenerator.responseFieldsOfCommon;
+import static com.jjikmuk.sikdorak.acceptance.DocumentFormatGenerator.responseFieldsOfObjectWithConstraintsAndFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+
+import com.jjikmuk.sikdorak.aws.controller.request.PresignedUrlCreateRequest;
+import com.jjikmuk.sikdorak.aws.controller.response.PresignedUrlCreateResponse;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.restdocs.snippet.Snippet;
+
+public interface S3Snippet {
+
+	Snippet PRESIGNED_URL_CREATE_REQUEST_SNIPPET = requestSnippetWithConstraintsAndFields(
+		PresignedUrlCreateRequest.class,
+		fieldWithPath("extension").type(JsonFieldType.STRING).description("이미지 파일 확장자")
+	);
+
+	Snippet PRESIGNED_URL_CREATE_RESPONSE_SNIPPET = createResponseSnippetWithFields(
+		responseFieldsOfCommon(),
+
+		responseFieldsOfObjectWithConstraintsAndFields(PresignedUrlCreateResponse.class,
+			fieldWithPath("presignedUrl").type(JsonFieldType.STRING).description("PUT S3 presigned URL"))
+
+	);
+
+}

--- a/be/src/test/java/com/jjikmuk/sikdorak/aws/ImageExtensionTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/aws/ImageExtensionTest.java
@@ -1,0 +1,55 @@
+package com.jjikmuk.sikdorak.aws;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.jjikmuk.sikdorak.aws.service.ImageExtension;
+import com.jjikmuk.sikdorak.aws.service.exception.InvalidImagesExtensionException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@DisplayName("ImageExtensionTest 클래스")
+class ImageExtensionTest {
+
+	@Nested
+	@DisplayName("생성자")
+	class Describe_constructor {
+
+		@Nested
+		@DisplayName("만약 이미지 확장자(jpg, jpeg, png) 문자열이 주어진다면")
+		class Context_with_valid_paramegers {
+
+			@ParameterizedTest
+			@CsvSource(value = {"'jpg', '.jpg'", "'png', '.png'", "'jpeg', '.jpeg'",
+				"'JPG','.jpg'", "'Png', '.png'", "'jpEG', '.jpeg'"})
+
+			@DisplayName("enum을 반환한다")
+			void It_returns_a_enum(String extension, String expected) {
+				ImageExtension imageExtension = ImageExtension.create(extension);
+
+				assertThat(imageExtension.getExtension()).isEqualTo(expected);
+			}
+		}
+
+		@Nested
+		@DisplayName("만약 이미지 확장자가 아닌 문자열이 주어진다면")
+		class Context_with_invalid_paramegers {
+
+			@ParameterizedTest
+			@NullAndEmptySource
+			@ValueSource(strings = {"out", "java", "class", "1234"})
+			@DisplayName("예외를 발생시킨다")
+			void It_throws_error(String extension) {
+				assertThatThrownBy(() ->
+					ImageExtension.create(extension))
+					.isInstanceOf(InvalidImagesExtensionException.class);
+			}
+		}
+
+	}
+}
+


### PR DESCRIPTION
### ❗️ 이슈 번호

[SDR-225]

<br><br>

### 📝 구현 내용

- put presigned url을 생성합니다.
- 파일 이름은 /origin 디렉토리 하위에 유저 구분 없이 UUID.random() 파일로 생성됩니다.
- 이미지 파일은 jpg/jpeg/png만 허용합니다. (2중 체크(스프링 서버에서, s3 업로드 시)
- 테스트, s3 mock은 testcontainers를 사용하여 AWS 자원을 mock 기능을 제공하는 도커 이미지, localstack을 사용합니다.
 
<br><br>

### 🙇🏻‍♂️ 리뷰어에게 부탁합니다!

- 이미지 업로드 크기 제한 문제로 추후에 presigned URL API는 AWS Lambda로 변경될 수 있어요.

<br><br>

### 💡 참고 자료

![image](https://user-images.githubusercontent.com/57086195/188105462-06ea4f5d-36b5-4d7d-b296-06aa3b653c9a.png)

![image](https://user-images.githubusercontent.com/57086195/188105516-b21c7583-953e-4c14-a25f-ad108d3c7464.png)


- [팀 위키](https://www.notion.so/kukim/710909cd78a1464abd80b1068d6d18ed)를 참고해주세요.


[SDR-225]: https://jjikmuk.atlassian.net/browse/SDR-225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ