### PR TITLE
[SDR-265] BE : 유저 상세 조회 시 팔로워 팔로잉 목록을 올바르게 주도록 수정

### DIFF
--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/controller/response/UserDetailProfileResponse.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/controller/response/UserDetailProfileResponse.java
@@ -37,7 +37,7 @@ public record UserDetailProfileResponse(
 
 ) {
 
-    public static UserDetailProfileResponse of(User user, UserProfileRelationStatusResponse userProfileRelationStatusResponse,  int followingCount, int followersCount, int reviewCount) {
+    public static UserDetailProfileResponse of(User user, UserProfileRelationStatusResponse userProfileRelationStatusResponse, int followingCount, int followersCount, int reviewCount) {
         return new UserDetailProfileResponse(
             user.getId(),
             user.getNickname(),

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/service/UserService.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/service/UserService.java
@@ -72,15 +72,15 @@ public class UserService {
             .orElseThrow(NotFoundUserException::new);
         RelationType relationType = searchUser.relationTypeTo(loginUser);
         int reviewCount = reviewRepository.countByUserId(searchUser.getId());
-        int followerCount = userRepository.findFollowingsByUserId(userId).size();
         int followingCount = userRepository.findFollowingsByUserId(userId).size();
+        int followerCount = userRepository.findFollowersByUserId(userId).size();
 
 
         return UserDetailProfileResponse.of(
             searchUser,
             UserProfileRelationStatusResponse.of(relationType),
-            followerCount,
             followingCount,
+            followerCount,
             reviewCount
         );
     }

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserSearchProfileIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserSearchProfileIntegrationTest.java
@@ -37,7 +37,9 @@ class UserSearchProfileIntegrationTest extends InitIntegrationTest {
             () -> assertThat(userDetailProfileResponse.nickname()).isEqualTo(testData.kukim.getNickname()),
             () -> assertThat(userDetailProfileResponse.relationStatus().isViewer()).isTrue(),
             () -> assertThat(userDetailProfileResponse.relationStatus().followStatus()).isFalse(),
-            () -> assertThat(userDetailProfileResponse.reviewCount()).isEqualTo(1)
+            () -> assertThat(userDetailProfileResponse.reviewCount()).isEqualTo(1),
+            () -> assertThat(userDetailProfileResponse.followingCount()).isZero(),
+            () -> assertThat(userDetailProfileResponse.followersCount()).isZero()
         );
     }
 
@@ -54,7 +56,9 @@ class UserSearchProfileIntegrationTest extends InitIntegrationTest {
             () -> assertThat(userDetailProfileResponse.nickname()).isEqualTo(testData.kukim.getNickname()),
             () -> assertThat(userDetailProfileResponse.relationStatus().isViewer()).isFalse(),
             () -> assertThat(userDetailProfileResponse.relationStatus().followStatus()).isFalse(),
-            () -> assertThat(userDetailProfileResponse.reviewCount()).isEqualTo(1)
+            () -> assertThat(userDetailProfileResponse.reviewCount()).isEqualTo(1),
+            () -> assertThat(userDetailProfileResponse.followingCount()).isZero(),
+            () -> assertThat(userDetailProfileResponse.followersCount()).isZero()
         );
     }
 
@@ -71,12 +75,15 @@ class UserSearchProfileIntegrationTest extends InitIntegrationTest {
             () -> assertThat(userDetailProfileResponse.nickname()).isEqualTo(testData.hoi.getNickname()),
             () -> assertThat(userDetailProfileResponse.relationStatus().isViewer()).isFalse(),
             () -> assertThat(userDetailProfileResponse.relationStatus().followStatus()).isTrue(),
-            () -> assertThat(userDetailProfileResponse.reviewCount()).isEqualTo(3)
+            () -> assertThat(userDetailProfileResponse.reviewCount()).isEqualTo(3),
+            () -> assertThat(userDetailProfileResponse.followingCount()).isEqualTo(2),
+            () -> assertThat(userDetailProfileResponse.followersCount()).isEqualTo(1)
+
         );
     }
 
     @Test
-    @DisplayName("팔로우 되어 있는 회원이 유저의 정보를 조회할 경우 유저 정보를 반환한다.")
+    @DisplayName("팔로우 되어있지 않은 회원이 유저의 정보를 조회할 경우 유저 정보를 반환한다.")
     void user_search_unfollowing_user_profile() {
         LoginUser loginUser = new LoginUser(testData.forky.getId(), Authority.USER);
 
@@ -88,7 +95,9 @@ class UserSearchProfileIntegrationTest extends InitIntegrationTest {
             () -> assertThat(userDetailProfileResponse.nickname()).isEqualTo(testData.jay.getNickname()),
             () -> assertThat(userDetailProfileResponse.relationStatus().isViewer()).isFalse(),
             () -> assertThat(userDetailProfileResponse.relationStatus().followStatus()).isFalse(),
-            () -> assertThat(userDetailProfileResponse.reviewCount()).isZero()
+            () -> assertThat(userDetailProfileResponse.reviewCount()).isZero(),
+            () -> assertThat(userDetailProfileResponse.followingCount()).isZero(),
+            () -> assertThat(userDetailProfileResponse.followersCount()).isZero()
         );
     }
 


### PR DESCRIPTION
### ❗️ 이슈 번호

[SDR-265]


### 📝 구현 내용

- 기존에 팔로잉 목록만 주도록 되어 있던 코드를 팔로워 목록까지 주도록 수정




[SDR-265]: https://jjikmuk.atlassian.net/browse/SDR-265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ