### PR TITLE
[SDR-259] BE : 리뷰 작성 시 선택한 가게의 상세 주소를 카카오 로컬 API 에서조회하여 저장하도록 변경

### DIFF
--- a/be/src/docs/asciidoc/store/store.adoc
+++ b/be/src/docs/asciidoc/store/store.adoc
@@ -66,6 +66,8 @@ operation::store_remove_acceptance_test/remove_store_failed[snippets='http-reque
 
 operation::store_remove_acceptance_test/remove_store_failed[snippets='http-response,response-fields']
 
+=== 가게 목록 위치 기반 조회
+
 API : `GET /api/stores?type=maps&x=127.123&y=36.123&radius=100`
 
 === `200 SUCCESS`
@@ -77,3 +79,17 @@ operation::store_search_by_radius_acceptance_test/stores_radius_success[snippets
 ==== `Response`
 
 operation::store_search_by_radius_acceptance_test/stores_radius_success[snippets='http-response,response-fields']
+
+=== 가게 등록 검증
+
+API : `PUT /api/stores`
+
+=== `200 SUCCESS`
+
+==== `Request`
+
+operation::store_verify_or_save_acceptance_test/search_store_by_name_containing_success[snippets='http-request,request-body']
+
+==== `Response`
+
+operation::store_verify_or_save_acceptance_test/search_store_by_name_containing_success[snippets='http-response,response-fields']

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/exception/ExceptionCodeAndMessages.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/exception/ExceptionCodeAndMessages.java
@@ -20,6 +20,7 @@ import com.jjikmuk.sikdorak.store.exception.InvalidContactNumberException;
 import com.jjikmuk.sikdorak.store.exception.InvalidStoreLocationException;
 import com.jjikmuk.sikdorak.store.exception.InvalidStoreNameException;
 import com.jjikmuk.sikdorak.store.exception.InvalidXYException;
+import com.jjikmuk.sikdorak.store.exception.NotFoundApiAddressException;
 import com.jjikmuk.sikdorak.store.exception.NotFoundStoreException;
 import com.jjikmuk.sikdorak.user.auth.exception.ExpiredTokenException;
 import com.jjikmuk.sikdorak.user.auth.exception.InvalidTokenException;
@@ -65,8 +66,9 @@ public enum ExceptionCodeAndMessages implements CodeAndMessages {
     NOT_FOUND_STORE("F-S001", "Store Id를 찾을 수 없습니다.", NotFoundStoreException.class),
     INVALID_STORE_NAME("F-S002", "유효하지 않은 가게이름 입니다.",InvalidStoreNameException.class),
     INVALID_CONTACT_NUMER("F-S003", "유효하지 않은 연락처 입니다.", InvalidContactNumberException.class),
-    INVALID_ADDRESS("F-S004", "유효하지 않은 연락처 입니다.", InvalidAddressException.class),
+    INVALID_ADDRESS("F-S004", "유효하지 않은 주소 입니다.", InvalidAddressException.class),
     INVALID_STORE_LOCATION("F-S005", "유효하지 않은 좌표 입니다.",InvalidStoreLocationException .class),
+    NOT_FOUND_API_ADDRESS("F-S006", "API 에서 주소를 불러올 수 없습니다.", NotFoundApiAddressException.class),
 
     // Place API
     INVALID_XY_EXCEPTION("F-P001", "x, y 좌표가 유효하지 않습니다.", InvalidXYException.class),

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/domain/Address.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/domain/Address.java
@@ -1,16 +1,16 @@
 package com.jjikmuk.sikdorak.store.domain;
 
+import com.jjikmuk.sikdorak.store.exception.InvalidAddressException;
+import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @Embeddable
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 public class Address {
@@ -59,10 +59,32 @@ public class Address {
     @Column(length = 5) // 도로명주소.건물부번
     private String subBuildingNo;
 
-    public static Address of(String addressName, String roadAddressName) {
-        return new Address(
-            addressName, roadAddressName,
-            null, null, null, null, null, null, null, null, null
-        );
+    public Address(String addressName, String roadAddressName, String region1DepthName,
+        String region2DepthName, String region3DepthName, String region3DepthHName,
+        String mainAddressNo, String subAddressNo, String roadName, String mainBuildingNo,
+        String subBuildingNo) {
+
+        if (Objects.isNull(addressName) ||
+            Objects.isNull(roadAddressName)) {
+            throw new InvalidAddressException();
+        }
+
+        this.addressName = addressName;
+        this.roadAddressName = roadAddressName;
+        this.region1DepthName = region1DepthName;
+        this.region2DepthName = region2DepthName;
+        this.region3DepthName = region3DepthName;
+        this.region3DepthHName = region3DepthHName;
+        this.mainAddressNo = mainAddressNo;
+        this.subAddressNo = subAddressNo;
+        this.roadName = roadName;
+        this.mainBuildingNo = mainBuildingNo;
+        this.subBuildingNo = subBuildingNo;
+    }
+
+    public static AddressBuilder requiredFieldBuilder(String addressName, String roadAddressName) {
+        return builder()
+            .addressName(addressName)
+            .roadAddressName(roadAddressName);
     }
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/domain/Address.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/domain/Address.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Builder
+@Builder(builderMethodName = "hiddenBuilder")
 public class Address {
 
     /**
@@ -83,7 +83,7 @@ public class Address {
     }
 
     public static AddressBuilder requiredFieldBuilder(String addressName, String roadAddressName) {
-        return builder()
+        return hiddenBuilder()
             .addressName(addressName)
             .roadAddressName(roadAddressName);
     }

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/domain/Address.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/domain/Address.java
@@ -3,12 +3,16 @@ package com.jjikmuk.sikdorak.store.domain;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @Embeddable
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
 public class Address {
 
     /**
@@ -22,11 +26,11 @@ public class Address {
      * https://www.juso.go.kr/addrlink/attrbDBDwld/attrbDBDwldList.do?cPath=99MD&menu=주소DB
      */
 
-    @Column(length = 255, nullable = false)
-    private String addressName; // 지번 주소
+    @Column(length = 255, nullable = false) // 지번 주소
+    private String addressName;
 
-    @Column(length = 255, nullable = false)
-    private String roadAddressName; // 도로명 주소
+    @Column(length = 255, nullable = false) // 도로명 주소
+    private String roadAddressName;
 
     @Column(length = 20) // 지번.시도명
     private String region1DepthName;
@@ -40,29 +44,25 @@ public class Address {
     @Column(length = 20) // 부가정보.행정동명
     private String region3DepthHName;
 
-    @Column(length = 40) // 지번.지번본번(번지)
+    @Column(length = 4) // 지번.지번본번(번지)
     private String mainAddressNo;
 
-    @Column(length = 40) // 지번.지번부번(호)
+    @Column(length = 4) // 지번.지번부번(호)
     private String subAddressNo;
 
-    public Address(String addressName, String roadAddressName, String region1DepthName,
-        String region2DepthName, String region3DepthName, String region3DepthHName,
-        String mainAddressNo, String subAddressNo) {
-        this.addressName = addressName;
-        this.roadAddressName = roadAddressName;
-        this.region1DepthName = region1DepthName;
-        this.region2DepthName = region2DepthName;
-        this.region3DepthName = region3DepthName;
-        this.region3DepthHName = region3DepthHName;
-        this.mainAddressNo = mainAddressNo;
-        this.subAddressNo = subAddressNo;
-    }
+    @Column(length = 80) // 도로명코드.도로명
+    private String roadName;
+
+    @Column(length = 5) // 도로명주소.건물본번
+    private String mainBuildingNo;
+
+    @Column(length = 5) // 도로명주소.건물부번
+    private String subBuildingNo;
 
     public static Address of(String addressName, String roadAddressName) {
         return new Address(
             addressName, roadAddressName,
-            null, null, null, null, null, null
+            null, null, null, null, null, null, null, null, null
         );
     }
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/domain/Store.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/domain/Store.java
@@ -80,6 +80,10 @@ public class Store extends BaseTimeEntity {
         return this.address.getRoadAddressName();
     }
 
+    public Address getAddress() {
+        return this.address;
+    }
+
     public double getY() {
         return location.getY();
     }

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/exception/NotFoundApiAddressException.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/exception/NotFoundApiAddressException.java
@@ -1,0 +1,12 @@
+package com.jjikmuk.sikdorak.store.exception;
+
+import com.jjikmuk.sikdorak.common.exception.SikdorakRuntimeException;
+import org.springframework.http.HttpStatus;
+
+public class NotFoundApiAddressException extends SikdorakRuntimeException {
+
+	@Override
+	public HttpStatus getHttpStatus() {
+		return HttpStatus.NOT_FOUND;
+	}
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/service/PlaceApiService.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/service/PlaceApiService.java
@@ -1,9 +1,13 @@
 package com.jjikmuk.sikdorak.store.service;
 
+import com.jjikmuk.sikdorak.store.service.dto.AddressSearchRequest;
+import com.jjikmuk.sikdorak.store.service.dto.AddressSearchResponse;
 import com.jjikmuk.sikdorak.store.service.dto.PlaceSearchRequest;
 import com.jjikmuk.sikdorak.store.service.dto.PlaceSearchResponse;
 
 public interface PlaceApiService {
 
 	PlaceSearchResponse searchPlaces(PlaceSearchRequest searchRequest);
+
+	AddressSearchResponse searchAddress(AddressSearchRequest searchRequest);
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/service/StoreService.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/service/StoreService.java
@@ -9,8 +9,12 @@ import com.jjikmuk.sikdorak.store.controller.response.StoreSearchResponse;
 import com.jjikmuk.sikdorak.store.controller.response.StoreVerifyOrSaveResponse;
 import com.jjikmuk.sikdorak.store.domain.Address;
 import com.jjikmuk.sikdorak.store.domain.Store;
+import com.jjikmuk.sikdorak.store.exception.NotFoundApiAddressException;
 import com.jjikmuk.sikdorak.store.exception.NotFoundStoreException;
 import com.jjikmuk.sikdorak.store.repository.StoreRepository;
+import com.jjikmuk.sikdorak.store.service.dto.AddressResponse;
+import com.jjikmuk.sikdorak.store.service.dto.AddressSearchRequest;
+import com.jjikmuk.sikdorak.store.service.dto.AddressSearchResponse;
 import com.jjikmuk.sikdorak.store.service.dto.PlaceResponse;
 import com.jjikmuk.sikdorak.store.service.dto.PlaceSearchRequest;
 import com.jjikmuk.sikdorak.store.service.dto.PlaceSearchResponse;
@@ -20,11 +24,13 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class StoreService {
 
 	private final StoreRepository storeRepository;
@@ -111,12 +117,25 @@ public class StoreService {
 	@Transactional
 	public StoreVerifyOrSaveResponse verifyOrSave(StoreVerifyOrSaveRequest request) {
 		Store store = storeRepository.findStoreByPlaceId(request.getPlaceId())
-			.orElseGet(() -> searchApiPlaceAndSave(request));
+			.orElseGet(() -> searchApiAndSave(request));
 
 		return StoreVerifyOrSaveResponse.from(store);
 	}
 
-	private Store searchApiPlaceAndSave(StoreVerifyOrSaveRequest request) {
+	private Store searchApiAndSave(StoreVerifyOrSaveRequest request) {
+		PlaceResponse placeResponse = searchPlaceApi(request);
+		AddressResponse addressResponse = searchAddressApi(placeResponse);
+
+		return storeRepository.save(new Store(
+			placeResponse.id(),
+			placeResponse.placeName(),
+			placeResponse.contactNumber(),
+			getAddress(addressResponse),
+			placeResponse.x(),
+			placeResponse.y()));
+	}
+
+	private PlaceResponse searchPlaceApi(StoreVerifyOrSaveRequest request) {
 		PlaceSearchResponse placeSearchResponse = kakaoPlaceApiService.searchPlaces(
 			new PlaceSearchRequest(
 				request.getStoreName(),
@@ -124,15 +143,7 @@ public class StoreService {
 				request.getY()
 			));
 
-		PlaceResponse place = findFirstPlace(request.getPlaceId(), placeSearchResponse);
-
-		return storeRepository.save(new Store(
-			place.id(),
-			place.placeName(),
-			place.contactNumber(),
-			Address.of(place.addressName(), place.roadAddressName()),
-			place.x(),
-			place.y()));
+		return findFirstPlace(request.getPlaceId(), placeSearchResponse);
 	}
 
 	private PlaceResponse findFirstPlace(Long placeId, PlaceSearchResponse placeSearchResponse) {
@@ -141,5 +152,37 @@ public class StoreService {
 			.filter(place -> place.id().equals(placeId))
 			.findFirst()
 			.orElseThrow(NotFoundStoreException::new);
+	}
+
+	private AddressResponse searchAddressApi(PlaceResponse place) {
+		AddressSearchResponse addresses = kakaoPlaceApiService.searchAddress(
+			new AddressSearchRequest(place.addressName()));
+
+		try {
+			return addresses.getAddressResponses()
+				.stream()
+				.findFirst()
+				.orElseThrow(NotFoundApiAddressException::new);
+		} catch (Exception e) {
+			// 예측하지 못한 예외도 해당 로직을 타게 하기 Exception 으로 선언
+			log.error(e.getMessage(), e);
+			return new AddressResponse(place.addressName(), place.roadAddressName());
+		}
+	}
+
+	private Address getAddress(AddressResponse addressResponse) {
+		return Address.builder()
+			.addressName(addressResponse.addressName())
+			.roadAddressName(addressResponse.roadAddressName())
+			.region1DepthName(addressResponse.region1DepthName())
+			.region2DepthName(addressResponse.region2DepthName())
+			.region3DepthName(addressResponse.region3DepthName())
+			.region3DepthHName(addressResponse.region3DepthHName())
+			.mainAddressNo(addressResponse.mainAddressNo())
+			.subAddressNo(addressResponse.subAddressNo())
+			.roadName(addressResponse.roadName())
+			.mainBuildingNo(addressResponse.mainBuildingNo())
+			.subBuildingNo(addressResponse.subBuildingNo())
+			.build();
 	}
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/service/StoreService.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/service/StoreService.java
@@ -78,10 +78,14 @@ public class StoreService {
 
 	@Transactional
 	public Long createStore(StoreCreateRequest createRequest) {
+		Address address = Address.requiredFieldBuilder(
+				createRequest.getAddressName(), createRequest.getRoadAddressName())
+			.build();
+
 		Store store = new Store(
 			createRequest.getStoreName(),
 			createRequest.getContactNumber(),
-			Address.of(createRequest.getAddressName(), createRequest.getRoadAddressName()),
+			address,
 			createRequest.getY(),
 			createRequest.getX()
 		);
@@ -95,10 +99,14 @@ public class StoreService {
 		Store store = storeRepository.findById(storeId)
 			.orElseThrow(NotFoundStoreException::new);
 
+		Address address = Address.requiredFieldBuilder(
+				modifyRequest.getAddressName(), modifyRequest.getRoadAddressName())
+			.build();
+
 		store.editAll(
 			modifyRequest.getStoreName(),
 			modifyRequest.getContactNumber(),
-			Address.of(modifyRequest.getAddressName(), modifyRequest.getRoadAddressName()),
+			address,
 			modifyRequest.getY(),
 			modifyRequest.getX()
 		);
@@ -171,9 +179,9 @@ public class StoreService {
 	}
 
 	private Address getAddress(AddressResponse addressResponse) {
-		return Address.builder()
-			.addressName(addressResponse.addressName())
-			.roadAddressName(addressResponse.roadAddressName())
+		return Address.requiredFieldBuilder(
+				addressResponse.addressName(),
+				addressResponse.roadAddressName())
 			.region1DepthName(addressResponse.region1DepthName())
 			.region2DepthName(addressResponse.region2DepthName())
 			.region3DepthName(addressResponse.region3DepthName())

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/service/client/KakaoAddressDocumentResponse.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/service/client/KakaoAddressDocumentResponse.java
@@ -1,0 +1,15 @@
+package com.jjikmuk.sikdorak.store.service.client;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class KakaoAddressDocumentResponse {
+
+	private KakaoAddressResponse address;
+	private KakaoRoadAddressResponse roadAddress;
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/service/client/KakaoAddressResponse.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/service/client/KakaoAddressResponse.java
@@ -1,0 +1,20 @@
+package com.jjikmuk.sikdorak.store.service.client;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class KakaoAddressResponse {
+
+	private String addressName;
+	private String region1DepthName;
+	private String region2DepthName;
+	private String region3DepthName;
+	private String region3DepthHName;
+	private String mainAddressNo;
+	private String subAddressNo;
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/service/client/KakaoAddressSearchResponse.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/service/client/KakaoAddressSearchResponse.java
@@ -1,0 +1,13 @@
+package com.jjikmuk.sikdorak.store.service.client;
+
+import java.util.Collections;
+import java.util.List;
+
+public class KakaoAddressSearchResponse {
+
+	List<KakaoAddressDocumentResponse> documents;
+
+	public List<KakaoAddressDocumentResponse> getDocuments() {
+		return Collections.unmodifiableList(documents);
+	}
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/service/client/KakaoLocalAddressSearchClient.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/service/client/KakaoLocalAddressSearchClient.java
@@ -1,0 +1,16 @@
+package com.jjikmuk.sikdorak.store.service.client;
+
+import com.jjikmuk.sikdorak.common.config.feignclient.FeignClientKakaoAuthHeaderConfiguration;
+import com.jjikmuk.sikdorak.common.config.feignclient.FeignClientOAuthErrorConfiguration;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name = "local-address-client", url="${api.kakao.api_url}", configuration = {
+	FeignClientKakaoAuthHeaderConfiguration.class,
+	FeignClientOAuthErrorConfiguration.class})
+public interface KakaoLocalAddressSearchClient {
+
+	@GetMapping("/v2/local/search/address.json")
+	KakaoAddressSearchResponse searchAddress(@RequestParam("query") String query);
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/service/client/KakaoPlaceSearchResponse.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/service/client/KakaoPlaceSearchResponse.java
@@ -1,14 +1,13 @@
 package com.jjikmuk.sikdorak.store.service.client;
 
+import java.util.Collections;
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
 public class KakaoPlaceSearchResponse {
 
 	List<KakaoPlaceResponse> documents;
+
+	public List<KakaoPlaceResponse> getDocuments() {
+		return Collections.unmodifiableList(documents);
+	}
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/service/client/KakaoRoadAddressResponse.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/service/client/KakaoRoadAddressResponse.java
@@ -3,10 +3,8 @@ package com.jjikmuk.sikdorak.store.service.client;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class KakaoRoadAddressResponse {
 

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/service/client/KakaoRoadAddressResponse.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/service/client/KakaoRoadAddressResponse.java
@@ -1,0 +1,21 @@
+package com.jjikmuk.sikdorak.store.service.client;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class KakaoRoadAddressResponse {
+
+	private String addressName;
+	private String region1DepthName;
+	private String region2DepthName;
+	private String region3DepthName;
+	private String region3DepthHName;
+	private String roadName;
+	private String mainBuildingNo;
+	private String subBuildingNo;
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/service/dto/AddressResponse.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/service/dto/AddressResponse.java
@@ -1,0 +1,23 @@
+package com.jjikmuk.sikdorak.store.service.dto;
+
+import lombok.Builder;
+
+@Builder
+public record AddressResponse(
+	String addressName,         // 지번 주소
+	String roadAddressName,     // 도로명 주소
+	String region1DepthName,    // 지번.시도명
+	String region2DepthName,    // 지번.시군구명
+	String region3DepthName,    // 지번.법정읍면동명
+	String region3DepthHName,   // 부가정보.행정동명
+	String mainAddressNo,       // 지번.지번본번(번지)
+	String subAddressNo,        // 지번.지번부번(호)
+	String roadName,            // 지번.지번부번(호)
+	String mainBuildingNo,      // 지번.지번부번(호)
+	String subBuildingNo        // 지번.지번부번(호)
+) {
+
+	public AddressResponse(String addressName, String roadAddressName) {
+		this(addressName, roadAddressName, null, null, null, null, null, null, null, null, null);
+	}
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/service/dto/AddressSearchRequest.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/service/dto/AddressSearchRequest.java
@@ -1,0 +1,15 @@
+package com.jjikmuk.sikdorak.store.service.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AddressSearchRequest {
+
+	private String query;
+
+	public AddressSearchRequest(String query) {
+		this.query = query;
+	}
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/service/dto/AddressSearchResponse.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/service/dto/AddressSearchResponse.java
@@ -2,14 +2,14 @@ package com.jjikmuk.sikdorak.store.service.dto;
 
 import java.util.Collections;
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.NoArgsConstructor;
 
-@NoArgsConstructor
-@AllArgsConstructor
 public class AddressSearchResponse {
 
-	private List<AddressResponse> addressResponses;
+	private final List<AddressResponse> addressResponses;
+
+	public AddressSearchResponse(List<AddressResponse> addressResponses) {
+		this.addressResponses = addressResponses;
+	}
 
 	public List<AddressResponse> getAddressResponses() {
 		return Collections.unmodifiableList(addressResponses);

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/service/dto/AddressSearchResponse.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/service/dto/AddressSearchResponse.java
@@ -1,0 +1,17 @@
+package com.jjikmuk.sikdorak.store.service.dto;
+
+import java.util.Collections;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+public class AddressSearchResponse {
+
+	private List<AddressResponse> addressResponses;
+
+	public List<AddressResponse> getAddressResponses() {
+		return Collections.unmodifiableList(addressResponses);
+	}
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/service/dto/PlaceSearchRequest.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/service/dto/PlaceSearchRequest.java
@@ -1,13 +1,17 @@
 package com.jjikmuk.sikdorak.store.service.dto;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
-@AllArgsConstructor
 public class PlaceSearchRequest {
 
-	private String storeName;
-	private Double x;
-	private Double y;
+	private final String storeName;
+	private final Double x;
+	private final Double y;
+
+	public PlaceSearchRequest(String storeName, Double x, Double y) {
+		this.storeName = storeName;
+		this.x = x;
+		this.y = y;
+	}
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/service/dto/PlaceSearchResponse.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/service/dto/PlaceSearchResponse.java
@@ -2,14 +2,14 @@ package com.jjikmuk.sikdorak.store.service.dto;
 
 import java.util.Collections;
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.NoArgsConstructor;
 
-@NoArgsConstructor
-@AllArgsConstructor
 public class PlaceSearchResponse {
 
 	List<PlaceResponse> places;
+
+	public PlaceSearchResponse(List<PlaceResponse> places) {
+		this.places = places;
+	}
 
 	public List<PlaceResponse> getPlaces() {
 		return Collections.unmodifiableList(places);

--- a/be/src/test/java/com/jjikmuk/sikdorak/acceptance/store/StoreVerifyOrSaveAcceptanceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/acceptance/store/StoreVerifyOrSaveAcceptanceTest.java
@@ -24,7 +24,7 @@ class StoreVerifyOrSaveAcceptanceTest extends InitAcceptanceTest {
 	void search_store_by_name_containing_success() {
 		ResponseCodeAndMessages expectedCodeAndMessage = ResponseCodeAndMessages.STORE_VERIFY_OR_SAVE_RESPONSE;
 		StoreVerifyOrSaveRequest verifyOrSaveRequest = new StoreVerifyOrSaveRequest(1455921244L,
-			"한국계", 127.111, 37.111);
+			"한국계", 127.079996336912,  37.5107289013413);
 
 		given(this.spec)
 			.filter(

--- a/be/src/test/java/com/jjikmuk/sikdorak/common/DatabaseConfigurator.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/common/DatabaseConfigurator.java
@@ -25,195 +25,197 @@ import org.springframework.stereotype.Component;
 @Component
 public class DatabaseConfigurator implements InitializingBean {
 
-    @PersistenceContext
-    private EntityManager entityManager;
-    private List<String> tableNames;
+	@Autowired
+	public DataGenerator generator;
+	public Store store;
+	public User kukim;
+	public User jay;
+	public User forky;
+	public User hoi;
+	public User rumka;
+	public String user1ValidAuthorizationHeader;
+	public String user2ValidAuthorizationHeader;
+	public String followSendUserValidAuthorizationHeader;
+	public String followAcceptUserValidAuthorizationHeader;
+	public String user1RefreshToken;
+	public String user1ExpiredRefreshToken;
+	public String user1InvalidRefreshToken;
+	public Review user1PublicReview;
+	public Review followAcceptUserPublicReview;
+	public Review followAcceptUserProtectedReview;
+	public Review followAcceptUserPrivateReview;
+	@PersistenceContext
+	private EntityManager entityManager;
+	private List<String> tableNames;
+	@Autowired
+	private StoreRepository storeRepository;
+	@Autowired
+	private UserRepository userRepository;
+	@Autowired
+	private ReviewRepository reviewRepository;
 
-    @Autowired
-    private StoreRepository storeRepository;
+	public void initDataSource() {
+		initStoreData();
+		initBasicUserData();
+		initFollowingUserData();
+		initUserAuthorizationData();
+		initReviewData();
+		postReviews();
+		likeReview();
+	}
 
-    @Autowired
-    private UserRepository userRepository;
+	public void clear() {
+		entityManager.unwrap(Session.class).doWork(this::cleanUpDatabase);
+	}
 
-    @Autowired
-    private ReviewRepository reviewRepository;
+	@Override
+	public void afterPropertiesSet() {
+		entityManager.unwrap(Session.class).doWork(this::extractTableNames);
+	}
 
-    @Autowired
-    public DataGenerator generator;
+	// reference : https://www.baeldung.com/jdbc-database-metadata
+	private void extractTableNames(Connection connection) throws SQLException {
+		List<String> tableNames = new ArrayList<>();
 
-    public Store store;
-    public User kukim;
-    public User jay;
-    public User forky;
-    public User hoi;
-    public User rumka;
-    public String user1ValidAuthorizationHeader;
-    public String user2ValidAuthorizationHeader;
-    public String followSendUserValidAuthorizationHeader;
-    public String followAcceptUserValidAuthorizationHeader;
-    public String user1RefreshToken;
-    public String user1ExpiredRefreshToken;
-    public String user1InvalidRefreshToken;
-    public Review user1PublicReview;
-    public Review followAcceptUserPublicReview;
-    public Review followAcceptUserProtectedReview;
-    public Review followAcceptUserPrivateReview;
+		ResultSet tables = connection
+			.getMetaData()
+			.getTables(connection.getCatalog(), null, "%", new String[]{"TABLE"});
 
-    public void initDataSource() {
-        initStoreData();
-        initBasicUserData();
-        initFollowingUserData();
-        initUserAuthorizationData();
-        initReviewData();
-        postReviews();
-        likeReview();
-    }
+		try (tables) {
+			while (tables.next()) {
+				tableNames.add(tables.getString("table_name"));
+			}
 
-    public void clear() {
-        entityManager.unwrap(Session.class).doWork(this::cleanUpDatabase);
-    }
+			this.tableNames = tableNames;
+		}
+	}
 
-    @Override
-    public void afterPropertiesSet() {
-        entityManager.unwrap(Session.class).doWork(this::extractTableNames);
-    }
+	private void cleanUpDatabase(Connection connection) throws SQLException {
+		try (Statement statement = connection.createStatement()) {
+			statement.executeUpdate("SET FOREIGN_KEY_CHECKS = 0");
 
-    // reference : https://www.baeldung.com/jdbc-database-metadata
-    private void extractTableNames(Connection connection) throws SQLException {
-        List<String> tableNames = new ArrayList<>();
+			for (String tableName : tableNames) {
+				statement.executeUpdate("TRUNCATE TABLE " + tableName);
+			}
 
-        ResultSet tables = connection
-            .getMetaData()
-            .getTables(connection.getCatalog(), null, "%", new String[]{"TABLE"});
+			statement.executeUpdate("SET FOREIGN_KEY_CHECKS = 1");
+		}
+	}
 
-        try (tables) {
-            while (tables.next()) {
-                tableNames.add(tables.getString("table_name"));
-            }
+	private void initStoreData() {
+		Address address = Address.requiredFieldBuilder("서울시 송파구 11-22", "서울시 송파구 좋은길1")
+			.build();
 
-            this.tableNames = tableNames;
-        }
-    }
+		this.store = storeRepository.save(new Store(
+			123123L,
+			"맛있는가게",
+			"02-0000-0000",
+			address,
+			127.105143,
+			37.5093890));
+	}
 
-    private void cleanUpDatabase(Connection connection) throws SQLException {
-        try (Statement statement = connection.createStatement()) {
-            statement.executeUpdate("SET FOREIGN_KEY_CHECKS = 0");
+	private void initBasicUserData() {
+		this.kukim = userRepository.save(
+			new User(1000000L, "쿠킴", "https://s3.ap-northeast-2.amazonaws.com/user/kukim.jpg",
+				"kukim@gmail.com"));
+		this.jay = userRepository.save(
+			new User(2000000L, "제이", "https://s3.ap-northeast-2.amazonaws.com/user/jay.jpg",
+				"jay@gmail.com"));
+		this.forky = userRepository.save(
+			new User(3000000L, "포키", "https://s3.ap-northeast-2.amazonaws.com/user/forky.jpg",
+				"forky@gmail.com"));
+		this.hoi = userRepository.save(
+			new User(4000000L, "호이", "https://s3.ap-northeast-2.amazonaws.com/user/hoi.jpg",
+				"hoi@gmail.com"));
+		this.rumka = userRepository.save(
+			new User(5000000L, "럼카", "https://s3.ap-northeast-2.amazonaws.com/user/rumka.jpg",
+				"rumka@gmail.com"));
+	}
 
-            for (String tableName : tableNames) {
-                statement.executeUpdate("TRUNCATE TABLE " + tableName);
-            }
+	private void initFollowingUserData() {
+		this.forky.follow(this.hoi);
+		this.forky.follow(this.rumka);
+		this.hoi.follow(this.forky);
+		this.hoi.follow(this.rumka);
+		this.forky = userRepository.save(this.forky);
+		this.hoi = userRepository.save(this.hoi);
+		this.rumka = userRepository.save(this.rumka);
+	}
 
-            statement.executeUpdate("SET FOREIGN_KEY_CHECKS = 1");
-        }
-    }
+	private void initUserAuthorizationData() {
+		Date now = new Date();
+		Date accessTokenExpiredTime = new Date(now.getTime() + 1800000);
 
-    private void initStoreData() {
-        this.store = storeRepository.save(new Store(
-            123123L,
-            "맛있는가게",
-            "02-0000-0000",
-            Address.of("서울시 송파구 11-22", "서울시 송파구 좋은길1"),
-            127.105143,
-            37.5093890));
-    }
+		this.user1ValidAuthorizationHeader = generator.validAuthorizationHeader(kukim,
+			accessTokenExpiredTime);
+		this.user2ValidAuthorizationHeader = generator.validAuthorizationHeader(jay,
+			accessTokenExpiredTime);
+		this.followSendUserValidAuthorizationHeader = generator.validAuthorizationHeader(forky,
+			accessTokenExpiredTime);
+		this.followAcceptUserValidAuthorizationHeader = generator.validAuthorizationHeader(hoi,
+			accessTokenExpiredTime);
+		this.user1RefreshToken = generator.refreshToken(kukim, new Date(now.getTime() + 8000000));
+		this.user1ExpiredRefreshToken = generator.refreshToken(kukim,
+			new Date(now.getTime() - 1000));
+		this.user1InvalidRefreshToken = user1RefreshToken + "invalid";
+	}
 
-    private void initBasicUserData() {
-        this.kukim = userRepository.save(
-            new User(1000000L, "쿠킴", "https://s3.ap-northeast-2.amazonaws.com/user/kukim.jpg",
-                "kukim@gmail.com"));
-        this.jay = userRepository.save(
-            new User(2000000L, "제이", "https://s3.ap-northeast-2.amazonaws.com/user/jay.jpg",
-                "jay@gmail.com"));
-        this.forky = userRepository.save(
-            new User(3000000L, "포키", "https://s3.ap-northeast-2.amazonaws.com/user/forky.jpg",
-                "forky@gmail.com"));
-        this.hoi = userRepository.save(
-            new User(4000000L, "호이", "https://s3.ap-northeast-2.amazonaws.com/user/hoi.jpg",
-                "hoi@gmail.com"));
-        this.rumka = userRepository.save(
-            new User(5000000L, "럼카", "https://s3.ap-northeast-2.amazonaws.com/user/rumka.jpg",
-                "rumka@gmail.com"));
-    }
+	private void initReviewData() {
+		this.user1PublicReview = reviewRepository.save(new Review(this.kukim.getId(),
+			this.store.getId(),
+			"Test review contents",
+			3.f,
+			"public",
+			LocalDate.of(2022, 1, 1),
+			List.of("tag1", "tag2"),
+			List.of("https://s3.ap-northeast-2.amazonaws.com/sikdorak/test.jpg")));
 
-    private void initFollowingUserData() {
-        this.forky.follow(this.hoi);
-        this.forky.follow(this.rumka);
-        this.hoi.follow(this.forky);
-        this.hoi.follow(this.rumka);
-        this.forky = userRepository.save(this.forky);
-        this.hoi = userRepository.save(this.hoi);
-        this.rumka = userRepository.save(this.rumka);
-    }
+		this.followAcceptUserPublicReview = reviewRepository.save(new Review(this.hoi.getId(),
+			this.store.getId(),
+			"전체 공개된 리뷰 게시물",
+			3.f,
+			"public",
+			LocalDate.of(2022, 1, 1),
+			List.of("tag1", "tag2"),
+			List.of("https://s3.ap-northeast-2.amazonaws.com/sikdorak/test.jpg")));
 
-    private void initUserAuthorizationData() {
-        Date now = new Date();
-        Date accessTokenExpiredTime = new Date(now.getTime() + 1800000);
+		this.followAcceptUserProtectedReview = reviewRepository.save(new Review(this.hoi.getId(),
+			this.store.getId(),
+			"친구 공개된 리뷰 게시물",
+			3.f,
+			"protected",
+			LocalDate.of(2022, 1, 1),
+			List.of("tag1", "tag2"),
+			List.of("https://s3.ap-northeast-2.amazonaws.com/sikdorak/test.jpg")));
 
-        this.user1ValidAuthorizationHeader = generator.validAuthorizationHeader(kukim, accessTokenExpiredTime);
-        this.user2ValidAuthorizationHeader = generator.validAuthorizationHeader(jay, accessTokenExpiredTime);
-        this.followSendUserValidAuthorizationHeader = generator.validAuthorizationHeader(forky, accessTokenExpiredTime);
-        this.followAcceptUserValidAuthorizationHeader = generator.validAuthorizationHeader(hoi, accessTokenExpiredTime);
-        this.user1RefreshToken = generator.refreshToken(kukim, new Date(now.getTime()+8000000));
-        this.user1ExpiredRefreshToken = generator.refreshToken(kukim, new Date(now.getTime() - 1000));
-        this.user1InvalidRefreshToken = user1RefreshToken + "invalid";
-    }
+		this.followAcceptUserPrivateReview = reviewRepository.save(new Review(this.hoi.getId(),
+			this.store.getId(),
+			"비공개된 리뷰 게시물",
+			3.f,
+			"private",
+			LocalDate.of(2022, 1, 1),
+			List.of("tag1", "tag2"),
+			List.of("https://s3.ap-northeast-2.amazonaws.com/sikdorak/test.jpg")));
+	}
 
-    private void initReviewData() {
-        this.user1PublicReview = reviewRepository.save(new Review(this.kukim.getId(),
-            this.store.getId(),
-            "Test review contents",
-            3.f,
-            "public",
-            LocalDate.of(2022, 1, 1),
-            List.of("tag1", "tag2"),
-            List.of("https://s3.ap-northeast-2.amazonaws.com/sikdorak/test.jpg")));
+	private void postReviews() {
+		for (int i = 0; i < 30; i++) {
+			String visibility = i % 2 == 0 ? "public" : "protected";
 
-        this.followAcceptUserPublicReview = reviewRepository.save(new Review(this.hoi.getId(),
-            this.store.getId(),
-            "전체 공개된 리뷰 게시물",
-            3.f,
-            "public",
-            LocalDate.of(2022, 1, 1),
-            List.of("tag1", "tag2"),
-            List.of("https://s3.ap-northeast-2.amazonaws.com/sikdorak/test.jpg")));
+			reviewRepository.save(new Review(this.forky.getId(),
+				this.store.getId(),
+				"전체 공개된 리뷰 게시물 " + i,
+				3.f,
+				visibility,
+				LocalDate.of(2022, 1, 1),
+				List.of("tag1", "tag2"),
+				List.of("https://s3.ap-northeast-2.amazonaws.com/sikdorak/test.jpg")));
+		}
+	}
 
-
-        this.followAcceptUserProtectedReview = reviewRepository.save(new Review(this.hoi.getId(),
-            this.store.getId(),
-            "친구 공개된 리뷰 게시물",
-            3.f,
-            "protected",
-            LocalDate.of(2022, 1, 1),
-            List.of("tag1", "tag2"),
-            List.of("https://s3.ap-northeast-2.amazonaws.com/sikdorak/test.jpg")));
-
-        this.followAcceptUserPrivateReview = reviewRepository.save(new Review(this.hoi.getId(),
-            this.store.getId(),
-            "비공개된 리뷰 게시물",
-            3.f,
-            "private",
-            LocalDate.of(2022, 1, 1),
-            List.of("tag1", "tag2"),
-            List.of("https://s3.ap-northeast-2.amazonaws.com/sikdorak/test.jpg")));
-    }
-
-    private void postReviews() {
-        for (int i = 0; i < 30; i++) {
-            String visibility = i%2 == 0 ? "public" : "protected";
-
-            reviewRepository.save(new Review(this.forky.getId(),
-                this.store.getId(),
-                "전체 공개된 리뷰 게시물 " + i,
-                3.f,
-                visibility,
-                LocalDate.of(2022, 1, 1),
-                List.of("tag1", "tag2"),
-                List.of("https://s3.ap-northeast-2.amazonaws.com/sikdorak/test.jpg")));
-        }
-    }
-
-    private void likeReview() {
-        followAcceptUserProtectedReview.like(kukim);
-        reviewRepository.save(followAcceptUserProtectedReview);
-    }
+	private void likeReview() {
+		followAcceptUserProtectedReview.like(kukim);
+		reviewRepository.save(followAcceptUserProtectedReview);
+	}
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/common/TestResourceUtils.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/common/TestResourceUtils.java
@@ -1,0 +1,22 @@
+package com.jjikmuk.sikdorak.common;
+
+import static java.nio.charset.Charset.defaultCharset;
+import static org.springframework.util.StreamUtils.copyToString;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public abstract class TestResourceUtils {
+
+	public static String getTestResourceWithPath(String path) {
+		try {
+			return copyToString(getResourceStreamWithPath(path), defaultCharset());
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	private static InputStream getResourceStreamWithPath(String path) {
+		return TestResourceUtils.class.getClassLoader().getResourceAsStream(path);
+	}
+}

--- a/be/src/test/java/com/jjikmuk/sikdorak/common/extension/PlaceMocksExtention.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/common/extension/PlaceMocksExtention.java
@@ -9,11 +9,11 @@ public class PlaceMocksExtention implements BeforeAllCallback, AfterAllCallback 
 
 	@Override
 	public void beforeAll(ExtensionContext context) {
-		KakaoPlaceMocks.startSearchPlacesMockScenario();
+		KakaoPlaceMocks.startAllMocks();
 	}
 
 	@Override
 	public void afterAll(ExtensionContext context) {
-		KakaoPlaceMocks.resetSearchPlacesMockScenario();
+		KakaoPlaceMocks.resetAllMocks();
 	}
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/common/mock/KakaoPlaceMocks.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/common/mock/KakaoPlaceMocks.java
@@ -31,8 +31,8 @@ public abstract class KakaoPlaceMocks {
 	}
 
 	public static void resetAllMocks() {
-		resetSearchPlacesMockScenario();
-		resetSearchAddressMockScenario();
+		WireMock.getAllScenarios()
+			.forEach(scenario -> WireMock.resetScenario(scenario.getId()));
 	}
 
 	public static void startSearchPlacesMockScenario() {

--- a/be/src/test/java/com/jjikmuk/sikdorak/common/mock/KakaoPlaceMocks.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/common/mock/KakaoPlaceMocks.java
@@ -6,7 +6,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
-import com.github.tomakehurst.wiremock.stubbing.Scenario;
+import com.github.tomakehurst.wiremock.stubbing.StubMapping;
 import com.jjikmuk.sikdorak.common.TestResourceUtils;
 import org.apache.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -15,59 +15,43 @@ public abstract class KakaoPlaceMocks {
 
 	private final static String PLACE_KEYWORD_SEARCH_URL = "/v2/local/search/keyword.json";
 
-	private static final String SCENARIO_KEYWORD_SEARCH = "place_keyword_search_url";
-
-	private final static String PLACE_RESPONSE_BODY = TestResourceUtils.getTestResourceWithPath("payload/get-kakao-search-place-response.json");
+	private final static String PLACE_KEYWORD_SEARCH_RESPONSE_BODY = TestResourceUtils.getTestResourceWithPath("payload/get-kakao-search-place-response.json");
 
 	private final static String ADDRESS_SEARCH_URL = "/v2/local/search/address.json";
 
-	private static final String SCENARIO_ADDRESS_SEARCH = "address_search_url";
+	private final static String ADDRESS_SEARCH_RESPONSE_BODY = TestResourceUtils.getTestResourceWithPath("payload/get-kakao-search-address-response.json");
 
-	private final static String ADDRESS_RESPONSE_BODY = TestResourceUtils.getTestResourceWithPath("payload/get-kakao-search-address-response.json");
+	private static StubMapping placeKeywordSearchStub;
+
+	private static StubMapping addressSearchStub;
 
 	public static void startAllMocks() {
-		startSearchPlacesMockScenario();
-		startSearchAddressMockScenario();
+		setupSearchPlacesStub();
+		setupSearchAddressStub();
 	}
 
 	public static void resetAllMocks() {
-		WireMock.getAllScenarios()
-			.forEach(scenario -> WireMock.resetScenario(scenario.getId()));
+		WireMock.removeStub(placeKeywordSearchStub);
+		WireMock.removeStub(addressSearchStub);
 	}
 
-	public static void startSearchPlacesMockScenario() {
-		stubFor(get(urlPathEqualTo(PLACE_KEYWORD_SEARCH_URL))
-			.inScenario(SCENARIO_KEYWORD_SEARCH)
-			.whenScenarioStateIs(Scenario.STARTED)
+	public static void setupSearchPlacesStub() {
+		placeKeywordSearchStub = stubFor(get(urlPathEqualTo(PLACE_KEYWORD_SEARCH_URL))
 			.willReturn(aResponse()
 				.withStatus(HttpStatus.OK.value())
 				.withHeader(HttpHeaders.CONTENT_TYPE, "application/json; charset=utf-8")
-				.withBody(PLACE_RESPONSE_BODY)
+				.withBody(PLACE_KEYWORD_SEARCH_RESPONSE_BODY)
 			)
 		);
-
-		WireMock.setScenarioState(SCENARIO_KEYWORD_SEARCH, Scenario.STARTED);
 	}
 
-	public static void resetSearchPlacesMockScenario() {
-		WireMock.resetScenario(SCENARIO_KEYWORD_SEARCH);
-	}
-
-	public static void startSearchAddressMockScenario() {
-		stubFor(get(urlPathEqualTo(ADDRESS_SEARCH_URL))
-			.inScenario(SCENARIO_ADDRESS_SEARCH)
-			.whenScenarioStateIs(Scenario.STARTED)
+	public static void setupSearchAddressStub() {
+		addressSearchStub = stubFor(get(urlPathEqualTo(ADDRESS_SEARCH_URL))
 			.willReturn(aResponse()
 				.withStatus(HttpStatus.OK.value())
 				.withHeader(HttpHeaders.CONTENT_TYPE, "application/json; charset=utf-8")
-				.withBody(ADDRESS_RESPONSE_BODY)
+				.withBody(ADDRESS_SEARCH_RESPONSE_BODY)
 			)
 		);
-
-		WireMock.setScenarioState(SCENARIO_ADDRESS_SEARCH, Scenario.STARTED);
-	}
-
-	public static void resetSearchAddressMockScenario() {
-		WireMock.resetScenario(SCENARIO_ADDRESS_SEARCH);
 	}
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/common/mock/KakaoPlaceMocks.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/common/mock/KakaoPlaceMocks.java
@@ -7,6 +7,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.stubbing.Scenario;
+import com.jjikmuk.sikdorak.common.TestResourceUtils;
 import org.apache.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 
@@ -16,6 +17,23 @@ public abstract class KakaoPlaceMocks {
 
 	private static final String SCENARIO_KEYWORD_SEARCH = "place_keyword_search_url";
 
+	private final static String PLACE_RESPONSE_BODY = TestResourceUtils.getTestResourceWithPath("payload/get-kakao-search-place-response.json");
+
+	private final static String ADDRESS_SEARCH_URL = "/v2/local/search/address.json";
+
+	private static final String SCENARIO_ADDRESS_SEARCH = "address_search_url";
+
+	private final static String ADDRESS_RESPONSE_BODY = TestResourceUtils.getTestResourceWithPath("payload/get-kakao-search-address-response.json");
+
+	public static void startAllMocks() {
+		startSearchPlacesMockScenario();
+		startSearchAddressMockScenario();
+	}
+
+	public static void resetAllMocks() {
+		resetSearchPlacesMockScenario();
+		resetSearchAddressMockScenario();
+	}
 
 	public static void startSearchPlacesMockScenario() {
 		stubFor(get(urlPathEqualTo(PLACE_KEYWORD_SEARCH_URL))
@@ -24,7 +42,7 @@ public abstract class KakaoPlaceMocks {
 			.willReturn(aResponse()
 				.withStatus(HttpStatus.OK.value())
 				.withHeader(HttpHeaders.CONTENT_TYPE, "application/json; charset=utf-8")
-				.withBody(Payload.PLACE_RESPONSE_BODY)
+				.withBody(PLACE_RESPONSE_BODY)
 			)
 		);
 
@@ -32,62 +50,24 @@ public abstract class KakaoPlaceMocks {
 	}
 
 	public static void resetSearchPlacesMockScenario() {
-		stubFor(get(urlPathEqualTo(PLACE_KEYWORD_SEARCH_URL))
-			.inScenario(SCENARIO_KEYWORD_SEARCH)
+		WireMock.resetScenario(SCENARIO_KEYWORD_SEARCH);
+	}
+
+	public static void startSearchAddressMockScenario() {
+		stubFor(get(urlPathEqualTo(ADDRESS_SEARCH_URL))
+			.inScenario(SCENARIO_ADDRESS_SEARCH)
 			.whenScenarioStateIs(Scenario.STARTED)
 			.willReturn(aResponse()
 				.withStatus(HttpStatus.OK.value())
 				.withHeader(HttpHeaders.CONTENT_TYPE, "application/json; charset=utf-8")
-				.withBody(Payload.PLACE_RESPONSE_BODY)
+				.withBody(ADDRESS_RESPONSE_BODY)
 			)
 		);
 
-		WireMock.resetScenario(SCENARIO_KEYWORD_SEARCH);
+		WireMock.setScenarioState(SCENARIO_ADDRESS_SEARCH, Scenario.STARTED);
 	}
 
-	private static class Payload {
-		private final static String PLACE_RESPONSE_BODY = """
-{
-    "documents": [
-        {
-            "address_name": "서울 송파구 잠실동 177-5",
-            "category_group_code": "FD6",
-            "category_group_name": "음식점",
-            "category_name": "음식점 > 한식 > 육류,고기 > 닭요리",
-            "distance": "",
-            "id": "1455921244",
-            "phone": "02-424-7077",
-            "place_name": "한국계",
-            "place_url": "http://place.map.kakao.com/1455921244",
-            "road_address_name": "서울 송파구 올림픽로8길 10",
-            "x": "127.079996336912",
-            "y": "37.5107289013413"
-        },
-        {
-            "address_name": "서울 송파구 방이동 24-4",
-            "category_group_code": "FD6",
-            "category_group_name": "음식점",
-            "category_name": "음식점 > 한식 > 육류,고기",
-            "distance": "",
-            "id": "415215581",
-            "phone": "02-420-7077",
-            "place_name": "한국계 방이직영점",
-            "place_url": "http://place.map.kakao.com/415215581",
-            "road_address_name": "서울 송파구 오금로11길 7",
-            "x": "127.10796497353",
-            "y": "37.5145458257413"
-        }
-    ],
-    "meta": {
-        "is_end": true,
-        "pageable_count": 2,
-        "same_name": {
-            "keyword": "한국계",
-            "region": [],
-            "selected_region": ""
-        },
-        "total_count": 2
-    }
-}""";
+	public static void resetSearchAddressMockScenario() {
+		WireMock.resetScenario(SCENARIO_ADDRESS_SEARCH);
 	}
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/store/PlaceApiIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/store/PlaceApiIntegrationTest.java
@@ -7,6 +7,8 @@ import com.jjikmuk.sikdorak.common.mock.WireMockPlaceApiTest;
 import com.jjikmuk.sikdorak.integration.InitIntegrationTest;
 import com.jjikmuk.sikdorak.store.exception.InvalidXYException;
 import com.jjikmuk.sikdorak.store.service.PlaceApiService;
+import com.jjikmuk.sikdorak.store.service.dto.AddressSearchRequest;
+import com.jjikmuk.sikdorak.store.service.dto.AddressSearchResponse;
 import com.jjikmuk.sikdorak.store.service.dto.PlaceSearchRequest;
 import com.jjikmuk.sikdorak.store.service.dto.PlaceSearchResponse;
 import java.util.stream.Stream;
@@ -84,6 +86,30 @@ public class PlaceApiIntegrationTest extends InitIntegrationTest {
 				Arguments.of(127.10796497353, null),
 				Arguments.of(null, 37.5145458257413)
 			);
+		}
+	}
+
+	@Nested
+	@DisplayName("주소를 검색할 때")
+	class SearchAddressTest {
+
+		@Test
+		@DisplayName("입력값이 정상이면 장소 목록이 조회된다")
+		void search_place_success() {
+		    // given
+			String query = "서울 송파구 잠실동 177-5";
+			AddressSearchRequest request = new AddressSearchRequest(query);
+
+			// when
+			AddressSearchResponse responses = kakaoPlaceApiService.searchAddress(request);
+
+			// then
+			assertThat(responses.getAddressResponses()).isNotEmpty()
+				.satisfies(addressList -> {
+					addressList.forEach(address -> {
+						assertThat(address.addressName()).isEqualTo(query);
+					});
+				});
 		}
 	}
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/store/PlaceApiIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/store/PlaceApiIntegrationTest.java
@@ -95,7 +95,7 @@ public class PlaceApiIntegrationTest extends InitIntegrationTest {
 
 		@Test
 		@DisplayName("입력값이 정상이면 장소 목록이 조회된다")
-		void search_place_success() {
+		void search_address_success() {
 		    // given
 			String query = "서울 송파구 잠실동 177-5";
 			AddressSearchRequest request = new AddressSearchRequest(query);

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/store/PlaceApiIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/store/PlaceApiIntegrationTest.java
@@ -46,9 +46,7 @@ public class PlaceApiIntegrationTest extends InitIntegrationTest {
 
 		    // then
 			assertThat(searchResponse.getPlaces()).isNotEmpty()
-				.satisfies(places ->
-					places.forEach(place ->
-						assertThat(place.placeName()).contains(storeName)));
+				.allSatisfy(place -> assertThat(place.placeName()).contains(storeName));
 		}
 
 		@Test
@@ -63,9 +61,7 @@ public class PlaceApiIntegrationTest extends InitIntegrationTest {
 
 			// then
 			assertThat(searchResponse.getPlaces()).isNotEmpty()
-				.satisfies(places ->
-					places.forEach(place ->
-						assertThat(place.placeName()).contains(storeName)));
+				.allSatisfy(place -> assertThat(place.placeName()).contains(storeName));
 		}
 
 		@ParameterizedTest
@@ -105,11 +101,12 @@ public class PlaceApiIntegrationTest extends InitIntegrationTest {
 
 			// then
 			assertThat(responses.getAddressResponses()).isNotEmpty()
-				.satisfies(addressList -> {
-					addressList.forEach(address -> {
-						assertThat(address.addressName()).isEqualTo(query);
-					});
-				});
+				.allSatisfy(address ->
+					assertThat(address).isNotNull().satisfiesAnyOf(
+						addr -> assertThat(addr.addressName()).contains(query),
+						addr -> assertThat(addr.roadAddressName()).contains(query)
+					)
+				);
 		}
 	}
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/store/StoreVerifyOrSaveIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/store/StoreVerifyOrSaveIntegrationTest.java
@@ -2,6 +2,7 @@ package com.jjikmuk.sikdorak.integration.store;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -45,6 +46,23 @@ class StoreVerifyOrSaveIntegrationTest extends InitIntegrationTest {
 			.thenReturn(getPlaceSearchResponse());
 		when(placeApiService.searchAddress(any()))
 			.thenReturn(getAddressSearchResponse());
+	}
+
+	private PlaceSearchResponse getPlaceSearchResponse() {
+
+		return new PlaceSearchResponse(
+			List.of(
+				new PlaceResponse(
+					1455921244L,
+					"한국계",
+					"서울 송파구 잠실동 177-5",
+					"서울 송파구 올림픽로8길 10",
+					"02-424-7077",
+					127.079996336912,
+					37.5107289013413
+				)
+			)
+		);
 	}
 
 	@Nested
@@ -155,13 +173,20 @@ class StoreVerifyOrSaveIntegrationTest extends InitIntegrationTest {
 				assertThat(savedStore.getStoreName()).contains(request.getStoreName());
 
 				Address address = savedStore.getAddress();
-				assertThat(address).isNotNull();
-				assertThat(address.getAddressName()).isEqualTo(expectedAddressName);
-				assertThat(address.getRoadAddressName()).isEqualTo(expectedRoadAddressName);
-				assertThat(address.getRegion1DepthName()).isEqualTo(expectedRegion1DepthName);
-				assertThat(address.getRegion2DepthName()).isEqualTo(expectedRegion2DepthName);
-				assertThat(address.getRegion3DepthName()).isEqualTo(expectedRegion3DepthName);
-				assertThat(address.getRegion3DepthHName()).isEqualTo(expectedRegion3DepthHName);
+				assertAll(
+					() -> assertThat(address).isNotNull(),
+					() -> assertThat(address.getAddressName()).isEqualTo(expectedAddressName),
+					() -> assertThat(address.getRoadAddressName()).isEqualTo(
+						expectedRoadAddressName),
+					() -> assertThat(address.getRegion1DepthName()).isEqualTo(
+						expectedRegion1DepthName),
+					() -> assertThat(address.getRegion2DepthName()).isEqualTo(
+						expectedRegion2DepthName),
+					() -> assertThat(address.getRegion3DepthName()).isEqualTo(
+						expectedRegion3DepthName),
+					() -> assertThat(address.getRegion3DepthHName()).isEqualTo(
+						expectedRegion3DepthHName)
+				);
 			}
 		}
 
@@ -186,9 +211,11 @@ class StoreVerifyOrSaveIntegrationTest extends InitIntegrationTest {
 					request);
 
 				// then
-				assertThat(response).isNotNull();
-				assertThat(response.placeId()).isEqualTo(request.getPlaceId());
-				assertThat(response.storeName()).isEqualTo(request.getStoreName());
+				assertThat(response).isNotNull()
+					.satisfies(res -> {
+						assertThat(res.placeId()).isEqualTo(request.getPlaceId());
+						assertThat(res.storeName()).isEqualTo(request.getStoreName());
+					});
 
 				Store savedStore = storeRepository.findById(response.storeId())
 					.orElseThrow();
@@ -198,31 +225,18 @@ class StoreVerifyOrSaveIntegrationTest extends InitIntegrationTest {
 				assertThat(savedStore.getStoreName()).contains(request.getStoreName());
 
 				Address address = savedStore.getAddress();
-				assertThat(address).isNotNull();
-				assertThat(address.getAddressName()).isEqualTo(expectedAddressName);
-				assertThat(address.getRoadAddressName()).isEqualTo(expectedRoadAddressName);
-				assertThat(address.getRegion1DepthName()).isNull();
-				assertThat(address.getRegion2DepthName()).isNull();
-				assertThat(address.getRegion3DepthName()).isNull();
-				assertThat(address.getRegion3DepthHName()).isNull();
+				assertAll(
+					() -> assertThat(address).isNotNull(),
+					() -> assertThat(address.getAddressName()).isEqualTo(expectedAddressName),
+					() -> assertThat(address.getRoadAddressName()).isEqualTo(
+						expectedRoadAddressName),
+					() -> assertThat(address.getRegion1DepthName()).isNull(),
+					() -> assertThat(address.getRegion2DepthName()).isNull(),
+					() -> assertThat(address.getRegion3DepthName()).isNull(),
+					() -> assertThat(address.getRegion3DepthHName()).isNull()
+				);
 			}
 		}
-	}
-
-	private PlaceSearchResponse getPlaceSearchResponse() {
-		return new PlaceSearchResponse(
-			List.of(
-				new PlaceResponse(
-					1455921244L,
-					"한국계",
-					"서울 송파구 잠실동 177-5",
-					"서울 송파구 올림픽로8길 10",
-					"02-424-7077",
-					127.079996336912,
-					37.5107289013413
-				)
-			)
-		);
 	}
 
 	private AddressSearchResponse getAddressSearchResponse() {

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/store/StoreVerifyOrSaveIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/store/StoreVerifyOrSaveIntegrationTest.java
@@ -2,76 +2,246 @@ package com.jjikmuk.sikdorak.integration.store;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
-import com.jjikmuk.sikdorak.common.mock.WireMockPlaceApiTest;
 import com.jjikmuk.sikdorak.integration.InitIntegrationTest;
 import com.jjikmuk.sikdorak.store.controller.request.StoreVerifyOrSaveRequest;
 import com.jjikmuk.sikdorak.store.controller.response.StoreVerifyOrSaveResponse;
+import com.jjikmuk.sikdorak.store.domain.Address;
 import com.jjikmuk.sikdorak.store.domain.Store;
 import com.jjikmuk.sikdorak.store.exception.NotFoundStoreException;
+import com.jjikmuk.sikdorak.store.repository.StoreRepository;
+import com.jjikmuk.sikdorak.store.service.PlaceApiService;
 import com.jjikmuk.sikdorak.store.service.StoreService;
+import com.jjikmuk.sikdorak.store.service.dto.AddressResponse;
+import com.jjikmuk.sikdorak.store.service.dto.AddressSearchResponse;
+import com.jjikmuk.sikdorak.store.service.dto.PlaceResponse;
+import com.jjikmuk.sikdorak.store.service.dto.PlaceSearchResponse;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
-@WireMockPlaceApiTest
 @DisplayName("StoreVerifyOrSave 통합테스트")
 class StoreVerifyOrSaveIntegrationTest extends InitIntegrationTest {
 
 	@Autowired
-	StoreService storeService;
+	private StoreService storeService;
+
+	@MockBean
+	private PlaceApiService placeApiService;
+
+	@Autowired
+	private StoreRepository storeRepository;
+
+	@BeforeEach
+	void setUp() {
+		when(placeApiService.searchPlaces(any()))
+			.thenReturn(getPlaceSearchResponse());
+		when(placeApiService.searchAddress(any()))
+			.thenReturn(getAddressSearchResponse());
+	}
 
 	@Nested
 	@DisplayName("가게 등록을 검증할 때")
 	class VerifyOrSaveStoreTest {
 
-		@Test
-		@DisplayName("저장되 있는 가게면 가게 정보를 반환한다.")
-		void exactly_same_store_name_returns_store_list() {
-			// given
-			Store savedStore = testData.store;
-			Long placeId = savedStore.getPlaceId();
-			String storeName = savedStore.getStoreName();
+		@Nested
+		@DisplayName("저장되어있는 가게라면")
+		class SavedStore {
 
-			// when
-			StoreVerifyOrSaveResponse response = storeService.verifyOrSave(
-				new StoreVerifyOrSaveRequest(placeId, storeName, null, null));
+			@Test
+			@DisplayName("조회된 가게 정보를 반환한다.")
+			void exactly_same_store_name_returns_store_list() {
+				// given
+				Store savedStore = testData.store;
+				Long placeId = savedStore.getPlaceId();
+				String storeName = savedStore.getStoreName();
 
-			// then
-			assertThat(response).isNotNull();
-			assertThat(response.storeId()).isEqualTo(savedStore.getId());
-			assertThat(response.storeName()).isEqualTo(savedStore.getStoreName());
+				// when
+				StoreVerifyOrSaveResponse response = storeService.verifyOrSave(
+					new StoreVerifyOrSaveRequest(placeId, storeName, null, null));
+
+				// then
+				assertThat(response).isNotNull();
+				assertThat(response.storeId()).isEqualTo(savedStore.getId());
+				assertThat(response.storeName()).isEqualTo(savedStore.getStoreName());
+			}
 		}
 
-		@Test
-		@DisplayName("저장되 있지 않지만 장소 API 에서 조회되는 가게면 가게 정보를 반환한다.")
-		void partially_same_store_name_returns_store_list() {
-			// given
-			StoreVerifyOrSaveRequest request = new StoreVerifyOrSaveRequest(
-				1455921244L, "한국계", 127.111, 37.111);
+		@Nested
+		@DisplayName("저장되어 있지 않고 장소 API 조회가 성공한다면")
+		class SearchPlaceSuccess {
 
-			// when
-			StoreVerifyOrSaveResponse response = storeService.verifyOrSave(
-				request);
+			@Test
+			@DisplayName("조회된 가게 정보를 저장하고 반환한다.")
+			void search_store_from_api_and_returns_store_list() {
+				// given
+				StoreVerifyOrSaveRequest request = new StoreVerifyOrSaveRequest(1455921244L, "한국계",
+					127.111, 37.111);
 
-			// then
-			assertThat(response).isNotNull();
-			assertThat(response.placeId()).isEqualTo(request.getPlaceId());
-			assertThat(response.storeName()).isEqualTo(request.getStoreName());
+				// when
+				StoreVerifyOrSaveResponse response = storeService.verifyOrSave(
+					request);
+
+				// then
+				assertThat(response).isNotNull();
+				assertThat(response.placeId()).isEqualTo(request.getPlaceId());
+				assertThat(response.storeName()).isEqualTo(request.getStoreName());
+
+				Store savedStore = storeRepository.findById(response.storeId())
+					.orElseThrow();
+
+				assertThat(savedStore).isNotNull();
+				assertThat(savedStore.getPlaceId()).isEqualTo(request.getPlaceId());
+				assertThat(savedStore.getStoreName()).contains(request.getStoreName());
+			}
 		}
 
-		@Test
-		@DisplayName("저장되 있지 않고 장소 API 에서 조회되지 않으면 예외를 발생시킨다.")
-		void null_store_name_returns_empty_list() {
-			// given
-			long notExistingPlaceId = Long.MIN_VALUE;
-			StoreVerifyOrSaveRequest request = new StoreVerifyOrSaveRequest(
-				notExistingPlaceId, "없는가게이름입니다", 127.111, 37.111);
+		@Nested
+		@DisplayName("저장되어 있지 않고 장소 API 조회가 실패한다면")
+		class SearchPlaceFailed {
 
-			// then
-			assertThatThrownBy(() -> storeService.verifyOrSave(request))
-				.isInstanceOf(NotFoundStoreException.class);
+			@Test
+			@DisplayName("장소 API 에서 조회되지 않으면 예외를 발생시킨다.")
+			void null_store_name_returns_empty_list() {
+				// given
+				long notExistingPlaceId = Long.MIN_VALUE;
+				StoreVerifyOrSaveRequest request = new StoreVerifyOrSaveRequest(
+					notExistingPlaceId, "없는가게이름입니다", 127.111, 37.111);
+
+				// then
+				assertThatThrownBy(() -> storeService.verifyOrSave(request))
+					.isInstanceOf(NotFoundStoreException.class);
+			}
 		}
+
+		@Nested
+		@DisplayName("저장되어 있지 않고 장소 API 와 주소 API 조회가 성공한다면")
+		class SearchPlaceAndAddressSuccess {
+
+			@Test
+			@DisplayName("조회된 가게 정보와 상세 주소를 저장하고 반환한다.")
+			void search_store_from_api_and_returns_store_list() {
+				// given
+				String expectedAddressName = "서울 송파구 잠실동 177-5";
+				String expectedRoadAddressName = "서울 송파구 올림픽로8길 10";
+				String expectedRegion1DepthName = "서울";
+				String expectedRegion2DepthName = "송파구";
+				String expectedRegion3DepthName = "잠실본동";
+				String expectedRegion3DepthHName = "잠실동";
+				StoreVerifyOrSaveRequest request = new StoreVerifyOrSaveRequest(1455921244L, "한국계",
+					127.111, 37.111);
+
+				// when
+				StoreVerifyOrSaveResponse response = storeService.verifyOrSave(
+					request);
+
+				// then
+				assertThat(response).isNotNull();
+				assertThat(response.placeId()).isEqualTo(request.getPlaceId());
+				assertThat(response.storeName()).isEqualTo(request.getStoreName());
+
+				Store savedStore = storeRepository.findById(response.storeId())
+					.orElseThrow();
+
+				assertThat(savedStore).isNotNull();
+				assertThat(savedStore.getPlaceId()).isEqualTo(request.getPlaceId());
+				assertThat(savedStore.getStoreName()).contains(request.getStoreName());
+
+				Address address = savedStore.getAddress();
+				assertThat(address).isNotNull();
+				assertThat(address.getAddressName()).isEqualTo(expectedAddressName);
+				assertThat(address.getRoadAddressName()).isEqualTo(expectedRoadAddressName);
+				assertThat(address.getRegion1DepthName()).isEqualTo(expectedRegion1DepthName);
+				assertThat(address.getRegion2DepthName()).isEqualTo(expectedRegion2DepthName);
+				assertThat(address.getRegion3DepthName()).isEqualTo(expectedRegion3DepthName);
+				assertThat(address.getRegion3DepthHName()).isEqualTo(expectedRegion3DepthHName);
+			}
+		}
+
+		@Nested
+		@DisplayName("저장되어 있지 않고 장소 API 는 성공하고 주소 API 는 실패한다면")
+		class SearchPlaceSuccessAndAddressFailed {
+
+			@Test
+			@DisplayName("상세 주소 없이 조회된 가게 정보만 저장하고 반환한다.")
+			void search_store_from_api_and_returns_store_list() {
+				// given
+				when(placeApiService.searchAddress(any()))
+					.thenReturn(new AddressSearchResponse(Collections.emptyList()));
+
+				String expectedAddressName = "서울 송파구 잠실동 177-5";
+				String expectedRoadAddressName = "서울 송파구 올림픽로8길 10";
+				StoreVerifyOrSaveRequest request = new StoreVerifyOrSaveRequest(1455921244L, "한국계",
+					127.111, 37.111);
+
+				// when
+				StoreVerifyOrSaveResponse response = storeService.verifyOrSave(
+					request);
+
+				// then
+				assertThat(response).isNotNull();
+				assertThat(response.placeId()).isEqualTo(request.getPlaceId());
+				assertThat(response.storeName()).isEqualTo(request.getStoreName());
+
+				Store savedStore = storeRepository.findById(response.storeId())
+					.orElseThrow();
+
+				assertThat(savedStore).isNotNull();
+				assertThat(savedStore.getPlaceId()).isEqualTo(request.getPlaceId());
+				assertThat(savedStore.getStoreName()).contains(request.getStoreName());
+
+				Address address = savedStore.getAddress();
+				assertThat(address).isNotNull();
+				assertThat(address.getAddressName()).isEqualTo(expectedAddressName);
+				assertThat(address.getRoadAddressName()).isEqualTo(expectedRoadAddressName);
+				assertThat(address.getRegion1DepthName()).isNull();
+				assertThat(address.getRegion2DepthName()).isNull();
+				assertThat(address.getRegion3DepthName()).isNull();
+				assertThat(address.getRegion3DepthHName()).isNull();
+			}
+		}
+	}
+
+	private PlaceSearchResponse getPlaceSearchResponse() {
+		return new PlaceSearchResponse(
+			List.of(
+				new PlaceResponse(
+					1455921244L,
+					"한국계",
+					"서울 송파구 잠실동 177-5",
+					"서울 송파구 올림픽로8길 10",
+					"02-424-7077",
+					127.079996336912,
+					37.5107289013413
+				)
+			)
+		);
+	}
+
+	private AddressSearchResponse getAddressSearchResponse() {
+		return new AddressSearchResponse(
+			List.of(
+				AddressResponse.builder()
+					.addressName("서울 송파구 잠실동 177-5")
+					.roadAddressName("서울 송파구 올림픽로8길 10")
+					.region1DepthName("서울")
+					.region2DepthName("송파구")
+					.region3DepthName("잠실본동")
+					.region3DepthHName("잠실동")
+					.mainAddressNo("177")
+					.subAddressNo("5")
+					.roadName("올림픽대로8길")
+					.mainBuildingNo("10")
+					.subBuildingNo("")
+					.build()
+			)
+		);
 	}
 }

--- a/be/src/test/resources/payload/get-kakao-search-address-response.json
+++ b/be/src/test/resources/payload/get-kakao-search-address-response.json
@@ -1,0 +1,43 @@
+{
+  "documents": [
+    {
+      "address": {
+        "address_name": "서울 송파구 잠실동 177-5",
+        "b_code": "1171010100",
+        "h_code": "1171065000",
+        "main_address_no": "177",
+        "mountain_yn": "N",
+        "region_1depth_name": "서울",
+        "region_2depth_name": "송파구",
+        "region_3depth_h_name": "잠실본동",
+        "region_3depth_name": "잠실동",
+        "sub_address_no": "5",
+        "x": "127.079973849354",
+        "y": "37.5107481079524"
+      },
+      "address_name": "서울 송파구 올림픽로8길 10",
+      "address_type": "ROAD_ADDR",
+      "road_address": {
+        "address_name": "서울 송파구 올림픽로8길 10",
+        "building_name": "",
+        "main_building_no": "10",
+        "region_1depth_name": "서울",
+        "region_2depth_name": "송파구",
+        "region_3depth_name": "잠실동",
+        "road_name": "올림픽로8길",
+        "sub_building_no": "",
+        "underground_yn": "N",
+        "x": "127.079973849354",
+        "y": "37.5107481079524",
+        "zone_no": "05556"
+      },
+      "x": "127.079973849354",
+      "y": "37.5107481079524"
+    }
+  ],
+  "meta": {
+    "is_end": true,
+    "pageable_count": 1,
+    "total_count": 1
+  }
+}

--- a/be/src/test/resources/payload/get-kakao-search-place-response.json
+++ b/be/src/test/resources/payload/get-kakao-search-place-response.json
@@ -1,0 +1,42 @@
+{
+  "documents": [
+    {
+      "address_name": "서울 송파구 잠실동 177-5",
+      "category_group_code": "FD6",
+      "category_group_name": "음식점",
+      "category_name": "음식점 > 한식 > 육류,고기 > 닭요리",
+      "distance": "",
+      "id": "1455921244",
+      "phone": "02-424-7077",
+      "place_name": "한국계",
+      "place_url": "http://place.map.kakao.com/1455921244",
+      "road_address_name": "서울 송파구 올림픽로8길 10",
+      "x": "127.079996336912",
+      "y": "37.5107289013413"
+    },
+    {
+      "address_name": "서울 송파구 방이동 24-4",
+      "category_group_code": "FD6",
+      "category_group_name": "음식점",
+      "category_name": "음식점 > 한식 > 육류,고기",
+      "distance": "",
+      "id": "415215581",
+      "phone": "02-420-7077",
+      "place_name": "한국계 방이직영점",
+      "place_url": "http://place.map.kakao.com/415215581",
+      "road_address_name": "서울 송파구 오금로11길 7",
+      "x": "127.10796497353",
+      "y": "37.5145458257413"
+    }
+  ],
+  "meta": {
+    "is_end": true,
+    "pageable_count": 2,
+    "same_name": {
+      "keyword": "한국계",
+      "region": [],
+      "selected_region": ""
+    },
+    "total_count": 2
+  }
+}


### PR DESCRIPTION
### ❗️ 이슈 번호

[SDR-259]

<br><br>

### 📝 구현 내용

- 가게 등록 검증 시, 카카오 API 를 통해 조회한 가게의 상세 주소를 조회하는 로직 추가
  - StoreService 에서 상세 주소 조회 실패 시, `Address` 의 필수값만 저장하도록 함(addressName, roadAddressName)
    카카오 API 가게 정보 조회에서 addressName, roadAddressName 두 정보가 있어서 저장 가능
<img width="595" alt="image" src="https://user-images.githubusercontent.com/45728407/188815679-8f832510-799e-4f88-a02d-e241ac51617b.png">
<img width="431" alt="image" src="https://user-images.githubusercontent.com/45728407/188815820-6f85e09b-8c47-400c-b883-dfbe56304691.png">

<br><br>

### 🙇🏻‍♂️ 리뷰어에게 부탁합니다!

- (리뷰어에게 부탁하는 말을 작성해주세요. 없다면 지워도 됩니다!)

<br><br>

### 💡 참고 자료

- (없다면 지워도 됩니다!)


[SDR-259]: https://jjikmuk.atlassian.net/browse/SDR-259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ