### PR TITLE
[SDR-283] common : 불필요한 sonar-project.properties 제거

### DIFF
--- a/.github/workflows/CI-FE.yml
+++ b/.github/workflows/CI-FE.yml
@@ -55,6 +55,13 @@ jobs:
 
       - name: SonarCloud Scan
         uses: SonarSource/sonarcloud-github-action@master
+        with:
+          args: >
+            -Dsonar.organization=jjik-muk
+            -Dsonar.projectKey=sikdorak-fe
+            -Dsonar.sources=fe
+            -Dsonar.sourceEncoding=UTF-8
+            -Dsonar.verbose=true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_FE }}

--- a/.github/workflows/CI-FE.yml
+++ b/.github/workflows/CI-FE.yml
@@ -61,7 +61,6 @@ jobs:
             -Dsonar.projectKey=sikdorak-fe
             -Dsonar.sources=fe
             -Dsonar.sourceEncoding=UTF-8
-            -Dsonar.verbose=true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_FE }}

--- a/.github/workflows/CI-Infra.yml
+++ b/.github/workflows/CI-Infra.yml
@@ -37,7 +37,6 @@ jobs:
             -Dsonar.organization=jjik-muk
             -Dsonar.projectKey=sikdorak-infra
             -Dsonar.sources=infra
-            -Dsonar.verbose=true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN_INFRA }}

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,6 +1,0 @@
-sonar.projectKey=jjik_muk_sikdorak
-sonar.organization=jjik-muk
-
-sonar.projectName=sikdorak
-
-sonar.sourceEncoding=UTF-8

--- a/infra/sonar-project.properties
+++ b/infra/sonar-project.properties
@@ -1,7 +1,0 @@
-sonar.organization=jjik-muk
-sonar.projectKey=sikdorak-infra
-sonar.projectName=sikdorak-infra
-
-sonar.modules = infra
-
-sonar.sourceEncoding=UTF-8

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,0 @@
-sonar.organization=jjik-muk
-sonar.projectKey=sikdorak-fe
-sonar.projectName=sikdorak-fe
-
-sonar.modules = fe
-
-sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
### ❗️ 이슈 번호

[SDR-283]

<br><br>

### 📝 구현 내용

- 불필요한 sonar cloud properties 제거
- FE sonarcloud properties는 CI-FE.yml 으로 이동
- 제거 이유 :  sonarcloud 모노 모듈 기능을 각각의 프로젝트(fe/infra/be) 에서 작동하기 위해서

[SDR-283]: https://jjikmuk.atlassian.net/browse/SDR-283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ