### PR TITLE
[SDR-292] BE : 리뷰 추천목록 로직 수정

### DIFF
--- a/be/src/main/java/com/jjikmuk/sikdorak/review/repository/ReviewRepository.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/repository/ReviewRepository.java
@@ -19,21 +19,24 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     Integer countByUserId(Long userId);
 
-    @Query("""
-        select r from Review r
-        where r.reviewVisibility = 'PUBLIC' and r.id <= :targetId
-        order by r.id desc
-        """)
+    @Query(value = """
+        select * from review as r
+        where r.review_visibility = 'PUBLIC' and r.review_id <= :targetId
+        order by (select count(*) from likes as l where l.review_id = r.review_id) desc, r.review_id desc 
+        """,
+        nativeQuery = true)
     List<Review> findPublicRecommendedReviewsInRecentOrder(
         @Param("targetId") long targetId,
         Pageable pageable);
 
     @Query("""
         	select r from Review r
-        	where r.reviewVisibility = 'PROTECTED' or r.reviewVisibility = 'PUBLIC' and r.id <= :targetId
+        	where r.reviewVisibility = 'PROTECTED' or r.reviewVisibility = 'PUBLIC'
+        	and r.id <= :targetId and r.userId <> :authorId
         	order by r.id desc
         """)
     List<Review> findPublicAndProtectedRecommendedReviewsInRecentOrder(
+        @Param("authorId") long authorId,
         @Param("targetId") long targetId,
         Pageable pageable);
 

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/service/ReviewService.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/service/ReviewService.java
@@ -28,14 +28,12 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 
 @Service
 @RequiredArgsConstructor
-@Slf4j
 public class ReviewService {
 
     private static final long FIRST_CURSOR_ID = 0L;

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/service/ReviewService.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/service/ReviewService.java
@@ -28,12 +28,14 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class ReviewService {
 
     private static final long FIRST_CURSOR_ID = 0L;
@@ -233,8 +235,15 @@ public class ReviewService {
             return reviewRepository.findPublicRecommendedReviewsInRecentOrder(pagingInfo.cursor(),
                 pagingInfo.pageable());
         }
+
+        if (!userRepository.existsById(loginUser.getId())) {
+            throw new NotFoundUserException();
+        }
+
         return reviewRepository.findPublicAndProtectedRecommendedReviewsInRecentOrder(
-            pagingInfo.cursor(), pagingInfo.pageable());
+            loginUser.getId(),
+            pagingInfo.cursor(),
+            pagingInfo.pageable());
     }
 
     private Map<Long, Store> getReviewStores(List<Long> storeIds) {

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/review/ReviewsRecommendIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/review/ReviewsRecommendIntegrationTest.java
@@ -24,17 +24,17 @@ class ReviewsRecommendIntegrationTest extends InitIntegrationTest {
     @Test
     @DisplayName("비회원이 리뷰 피드 목록 조회 요청을 할 경우 공개범위가 public 인 리뷰들을 좋아요 순서대로 반환한다.")
     void anonymous_user_get_recommended_reviews() {
-
         long cursorPage = 15;
         int size = 9;
-
         LoginUser loginUser = new LoginUser(Authority.ANONYMOUS);
         CursorPageRequest cursorPageRequest = new CursorPageRequest(0L, cursorPage, size, true);
 
         RecommendedReviewResponse recommendedReviews = reviewService.getRecentRecommendedReviews(
             loginUser, cursorPageRequest);
+        long firstReviewLikeCount = recommendedReviews.reviews().get(0).like().count();
+        long secondReviewLikeCount = recommendedReviews.reviews().get(1).like().count();
 
-        assertThat(recommendedReviews.reviews().get(0).like().count()).isGreaterThan(0L);
+        assertThat(firstReviewLikeCount).isGreaterThan(secondReviewLikeCount);
         assertThat(recommendedReviews.reviews().stream()
             .anyMatch(r -> r.reviewVisibility().equals(ReviewVisibility.PROTECTED.name()))).isFalse();
     }
@@ -42,10 +42,8 @@ class ReviewsRecommendIntegrationTest extends InitIntegrationTest {
     @Test
     @DisplayName("회원이 리뷰 피드 목록 조회 요청을 할 경우 공개범위가 public|protected 인 리뷰들을 반환한다.")
     void user_get_recommended_reviews() {
-
         long cursorPage = 0;
         int size = 5;
-
         LoginUser loginUser = new LoginUser(testData.kukim.getId(), Authority.USER);
         CursorPageRequest cursorPageRequest = new CursorPageRequest(0L, cursorPage, size, true);
 
@@ -59,10 +57,8 @@ class ReviewsRecommendIntegrationTest extends InitIntegrationTest {
     @Test
     @DisplayName("리뷰 피드 목록 조회 요청시 존재하지 않는 페이지를 요청할 경우 빈배열을 반환한다.")
     void get_invalid_page_recommended_reviews() {
-
         long invalidPage = -1L;
         int size = 5;
-
         LoginUser loginUser = new LoginUser(Authority.ANONYMOUS);
         CursorPageRequest cursorPageRequest = new CursorPageRequest(0L, invalidPage, size, true);
 
@@ -75,10 +71,8 @@ class ReviewsRecommendIntegrationTest extends InitIntegrationTest {
     @Test
     @DisplayName("리뷰 피드 목록 조회 시 요청하는 id가 0이면 첫 페이지의 데이터를 반환한다.")
     void get_recommended_reviews_in_first_page() {
-
         long cursorPage = 0;
         int size = 10;
-
         LoginUser loginUser = new LoginUser(Authority.ANONYMOUS);
         CursorPageRequest cursorPageRequest = new CursorPageRequest(0L, cursorPage, size, true);
 
@@ -91,10 +85,8 @@ class ReviewsRecommendIntegrationTest extends InitIntegrationTest {
     @Test
     @DisplayName("리뷰 피드 목록 조회 시 요청한 페이지부터 요청한 사이즈 개수의 데이터를 반환한다.")
     void get_recommended_reviews_with_page_and_size() {
-
         long cursorPage = 20;
         int size = 7;
-
         LoginUser loginUser = new LoginUser(Authority.ANONYMOUS);
         CursorPageRequest cursorPageRequest = new CursorPageRequest(0L, cursorPage, size, true);
 
@@ -110,7 +102,6 @@ class ReviewsRecommendIntegrationTest extends InitIntegrationTest {
     void invalid_page_size() {
         long cursorPage = 11;
         int size = Integer.MAX_VALUE;
-
         LoginUser loginUser = new LoginUser(Authority.ANONYMOUS);
         CursorPageRequest cursorPageRequest = new CursorPageRequest(0L, cursorPage, size, true);
 

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/review/ReviewsRecommendIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/review/ReviewsRecommendIntegrationTest.java
@@ -22,11 +22,11 @@ class ReviewsRecommendIntegrationTest extends InitIntegrationTest {
     private ReviewService reviewService;
 
     @Test
-    @DisplayName("비회원이 리뷰 피드 목록 조회 요청을 할 경우 공개범위가 public 인 리뷰들을 반환한다.")
+    @DisplayName("비회원이 리뷰 피드 목록 조회 요청을 할 경우 공개범위가 public 인 리뷰들을 좋아요 순서대로 반환한다.")
     void anonymous_user_get_recommended_reviews() {
 
-        long cursorPage = 0;
-        int size = 5;
+        long cursorPage = 15;
+        int size = 9;
 
         LoginUser loginUser = new LoginUser(Authority.ANONYMOUS);
         CursorPageRequest cursorPageRequest = new CursorPageRequest(0L, cursorPage, size, true);
@@ -34,7 +34,7 @@ class ReviewsRecommendIntegrationTest extends InitIntegrationTest {
         RecommendedReviewResponse recommendedReviews = reviewService.getRecentRecommendedReviews(
             loginUser, cursorPageRequest);
 
-        assertThat(recommendedReviews.reviews()).hasSize(5);
+        assertThat(recommendedReviews.reviews().get(0).like().count()).isGreaterThan(0L);
         assertThat(recommendedReviews.reviews().stream()
             .anyMatch(r -> r.reviewVisibility().equals(ReviewVisibility.PROTECTED.name()))).isFalse();
     }
@@ -52,7 +52,6 @@ class ReviewsRecommendIntegrationTest extends InitIntegrationTest {
         RecommendedReviewResponse recommendedReviews = reviewService.getRecentRecommendedReviews(
             loginUser, cursorPageRequest);
 
-        assertThat(recommendedReviews.reviews()).hasSize(5);
         assertThat(recommendedReviews.reviews().stream().anyMatch(
             r -> r.reviewVisibility().equals(ReviewVisibility.PROTECTED.name()))).isTrue();
     }

--- a/be/src/test/java/com/jjikmuk/sikdorak/tool/DatabaseConfigurator.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/tool/DatabaseConfigurator.java
@@ -215,7 +215,9 @@ public class DatabaseConfigurator implements InitializingBean {
 	}
 
 	private void likeReview() {
+		followAcceptUserPublicReview.like(kukim);
 		followAcceptUserProtectedReview.like(kukim);
+		reviewRepository.save(followAcceptUserPublicReview);
 		reviewRepository.save(followAcceptUserProtectedReview);
 	}
 }


### PR DESCRIPTION
### ❗️ 이슈 번호

[SDR-292]

<br><br>

### 📝 구현 내용

- 비회원일 경우 좋아요 많은 순서의 데이터를 최신순으로 제공하도록 수정
  - 좋아요 개수를 얻기 위해 subquery를 사용했습니다.
- 회원일 경우 자신의 글은 제외하도록 수정



[SDR-292]: https://jjikmuk.atlassian.net/browse/SDR-292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ