### PR TITLE
[SDR-297] BE : 특정유저의 리뷰목록 조회 API 개선

### DIFF
--- a/be/src/docs/asciidoc/auth/auth.adoc
+++ b/be/src/docs/asciidoc/auth/auth.adoc
@@ -46,16 +46,6 @@ operation::o_auth_update_token_documentation_test/update_access_token_success[sn
 operation::o_auth_update_token_documentation_test/update_access_token_success[snippets='http-response,response-fields']
 
 
-=== `400 BAD_REQUEST`
-
-==== `Request`
-
-operation::o_auth_update_token_documentation_test/update_access_token_fail_expired_token[snippets='http-request,request-headers']
-
-==== `Response`
-
-operation::o_auth_update_token_documentation_test/update_access_token_fail_expired_token[snippets='http-response,response-fields']
-
 === `404 NOT_FOUND`
 
 ==== `Request`

--- a/be/src/docs/asciidoc/user/user.adoc
+++ b/be/src/docs/asciidoc/user/user.adoc
@@ -61,7 +61,7 @@ API : `GET /api/users/{userId}/reviews`
 
 ==== `Request`
 
-operation::user_reviews_search_by_user_id_documentation_test/guest_search_user_reviews_success[snippets='http-request']
+operation::user_reviews_search_by_user_id_documentation_test/guest_search_user_reviews_success[snippets='http-request,path-parameters,request-parameters']
 
 ==== `Response`
 

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/controller/ReviewController.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/controller/ReviewController.java
@@ -7,7 +7,7 @@ import com.jjikmuk.sikdorak.common.controller.request.CursorPageRequest;
 import com.jjikmuk.sikdorak.common.response.CommonResponseEntity;
 import com.jjikmuk.sikdorak.review.controller.request.ReviewCreateRequest;
 import com.jjikmuk.sikdorak.review.controller.request.ReviewModifyRequest;
-import com.jjikmuk.sikdorak.review.controller.response.RecommendedReviewResponse;
+import com.jjikmuk.sikdorak.review.controller.response.ReviewListResponse;
 import com.jjikmuk.sikdorak.review.controller.response.reviewdetail.ReviewDetailResponse;
 import com.jjikmuk.sikdorak.review.service.ReviewService;
 import com.jjikmuk.sikdorak.user.auth.controller.LoginUser;
@@ -44,12 +44,12 @@ public class ReviewController {
 	}
 
 	@GetMapping
-	public CommonResponseEntity<RecommendedReviewResponse> getRecommendedReviews(
+	public CommonResponseEntity<ReviewListResponse> getRecommendedReviews(
 		@AuthenticatedUser LoginUser loginUser,
 //		@RequestParam RecommendationType recommendationType, -> 아키텍처 변경되면 사용하지 않을것으로 판단되어 주석처리
 		@CursorPageable CursorPageRequest cursorPageRequest) {
 
-		RecommendedReviewResponse recommendedReviews = reviewService.getRecentRecommendedReviews(
+		ReviewListResponse recommendedReviews = reviewService.getRecentRecommendedReviews(
 			loginUser, cursorPageRequest);
 
 		return new CommonResponseEntity<>(

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/controller/response/ReviewListResponse.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/controller/response/ReviewListResponse.java
@@ -4,13 +4,13 @@ import com.jjikmuk.sikdorak.common.controller.response.CursorPageResponse;
 import com.jjikmuk.sikdorak.review.controller.response.reviewdetail.ReviewDetailResponse;
 import java.util.List;
 
-public record RecommendedReviewResponse(
+public record ReviewListResponse(
     List<ReviewDetailResponse> reviews,
     CursorPageResponse page
 ) {
 
-    public static RecommendedReviewResponse of(List<ReviewDetailResponse> reviewDetailResponse,
+    public static ReviewListResponse of(List<ReviewDetailResponse> reviewDetailResponse,
         CursorPageResponse page) {
-        return new RecommendedReviewResponse(reviewDetailResponse, page);
+        return new ReviewListResponse(reviewDetailResponse, page);
     }
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/controller/response/reviewdetail/ReviewDetailStoreResponse.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/controller/response/reviewdetail/ReviewDetailStoreResponse.java
@@ -16,9 +16,8 @@ public record ReviewDetailStoreResponse(
 	@Size(min = 1, max = 500)
 	String storeName,
 
-	@NotNull
-	@Size(min = 1, max = 255)
-	String storeAddress
+	String addressName,
+	String roadAddressName
 
 	// String storeImage
 ) {
@@ -26,7 +25,9 @@ public record ReviewDetailStoreResponse(
 	public ReviewDetailStoreResponse(Store store) {
 		this(store.getId(),
 			store.getStoreName(),
-			store.getAddressName());
+			store.getAddressName(),
+			store.getRoadAddressName()
+		);
 	}
 }
 

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/repository/ReviewRepository.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/repository/ReviewRepository.java
@@ -11,11 +11,32 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     List<Review> findByUserId(Long userId);
 
-    @Query("select r from Review as r where r.userId = :userId and not r.reviewVisibility = 'PRIVATE'")
-    List<Review> findByUserIdAndConnection(@Param("userId") Long userId);
+    @Query("""
+        select r from Review as r
+        where r.userId = :userId and r.id <= :targetId
+        order by r.id desc
+        """)
+    List<Review> findByUserIdWithPageable(@Param("userId") long userId,
+        @Param("targetId") long targetId,
+        Pageable pageable);
 
-    @Query("select r from Review as r where r.userId = :userId and r.reviewVisibility = 'PUBLIC'")
-    List<Review> findByUserIdAndDisconnection(@Param("userId") Long userId);
+    @Query("""
+        select r from Review as r
+        where r.userId = :userId and not r.reviewVisibility = 'PRIVATE' and r.id <= :targetId
+        order by r.id desc
+        """)
+    List<Review> findByUserIdAndConnection(@Param("userId") long userId,
+        @Param("targetId") long targetId,
+        Pageable pageable);
+
+    @Query("""
+        select r from Review as r
+        where r.userId = :userId and r.reviewVisibility = 'PUBLIC' and r.id <= :targetId
+        order by r.id desc
+        """)
+    List<Review> findByUserIdAndDisconnection(@Param("userId") Long userId,
+        @Param("targetId") long targetId,
+        Pageable pageable);
 
     Integer countByUserId(Long userId);
 
@@ -31,7 +52,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     @Query("""
         	select r from Review r
-        	where r.reviewVisibility = 'PROTECTED' or r.reviewVisibility = 'PUBLIC'
+        	where not r.reviewVisibility = 'PRIVATE'
         	and r.id <= :targetId and r.userId <> :authorId
         	order by r.id desc
         """)

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/service/ReviewService.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/service/ReviewService.java
@@ -90,8 +90,13 @@ public class ReviewService {
     }
 
     @Transactional(readOnly = true)
-    public ReviewListResponse searchUserReviewsByUserIdAndRelationType(Long searchUserId, LoginUser loginUser, CursorPageRequest cursorPageRequest) {
-        log.debug("searchByUserReviews: searchUserId={}, loginUser.id={}, loginUser.authority={}", searchUserId, loginUser.getId(), loginUser.getAuthority());
+    public ReviewListResponse searchUserReviewsByUserIdAndRelationType(Long searchUserId, LoginUser loginUser,
+        CursorPageRequest cursorPageRequest) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("searchByUserReviews: searchUserId={}, loginUser.id={}, loginUser.authority={}",
+                searchUserId, loginUser.getId(), loginUser.getAuthority());
+        }
 
         validateCursorPageSize(cursorPageRequest);
         PagingInfo pagingInfo = convertToPagingInfo(cursorPageRequest);

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/controller/UserController.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/controller/UserController.java
@@ -54,7 +54,8 @@ public class UserController {
         @AuthenticatedUser LoginUser loginUser,
         @CursorPageable CursorPageRequest cursorPageRequest) {
 
-        ReviewListResponse userReviewResponses = reviewService.searchUserReviewsByUserIdAndRelationType(userId, loginUser, cursorPageRequest);
+        ReviewListResponse userReviewResponses =
+            reviewService.searchUserReviewsByUserIdAndRelationType(userId, loginUser, cursorPageRequest);
 
         return new CommonResponseEntity<>(
             ResponseCodeAndMessages.USER_SEARCH_REVIEWS_SUCCESS,

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/controller/UserController.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/controller/UserController.java
@@ -4,6 +4,7 @@ import com.jjikmuk.sikdorak.common.ResponseCodeAndMessages;
 import com.jjikmuk.sikdorak.common.aop.UserOnly;
 import com.jjikmuk.sikdorak.common.response.CommonResponseEntity;
 import com.jjikmuk.sikdorak.review.controller.response.reviewdetail.ReviewDetailResponse;
+import com.jjikmuk.sikdorak.review.service.ReviewService;
 import com.jjikmuk.sikdorak.user.auth.controller.LoginUser;
 import com.jjikmuk.sikdorak.user.auth.domain.AuthenticatedUser;
 import com.jjikmuk.sikdorak.user.user.controller.request.UserFollowAndUnfollowRequest;
@@ -30,6 +31,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
 
     private final UserService userService;
+    private final ReviewService reviewService;
 
     @GetMapping
     public CommonResponseEntity<List<UserSimpleProfileResponse>> searchUsers(
@@ -49,7 +51,7 @@ public class UserController {
         @PathVariable Long userId,
         @AuthenticatedUser LoginUser loginUser) {
 
-        List<ReviewDetailResponse> userReviewResponses = userService.searchUserReviewsByUserIdAndRelationType(userId, loginUser);
+        List<ReviewDetailResponse> userReviewResponses = reviewService.searchUserReviewsByUserIdAndRelationType(userId, loginUser);
 
         return new CommonResponseEntity<>(
             ResponseCodeAndMessages.USER_SEARCH_REVIEWS_SUCCESS,

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/controller/UserController.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/controller/UserController.java
@@ -3,13 +3,13 @@ package com.jjikmuk.sikdorak.user.user.controller;
 import com.jjikmuk.sikdorak.common.ResponseCodeAndMessages;
 import com.jjikmuk.sikdorak.common.aop.UserOnly;
 import com.jjikmuk.sikdorak.common.response.CommonResponseEntity;
+import com.jjikmuk.sikdorak.review.controller.response.reviewdetail.ReviewDetailResponse;
 import com.jjikmuk.sikdorak.user.auth.controller.LoginUser;
 import com.jjikmuk.sikdorak.user.auth.domain.AuthenticatedUser;
 import com.jjikmuk.sikdorak.user.user.controller.request.UserFollowAndUnfollowRequest;
 import com.jjikmuk.sikdorak.user.user.controller.request.UserModifyRequest;
 import com.jjikmuk.sikdorak.user.user.controller.response.FollowUserProfile;
 import com.jjikmuk.sikdorak.user.user.controller.response.UserDetailProfileResponse;
-import com.jjikmuk.sikdorak.user.user.controller.response.UserReviewResponse;
 import com.jjikmuk.sikdorak.user.user.controller.response.UserSimpleProfileResponse;
 import com.jjikmuk.sikdorak.user.user.service.UserService;
 import java.util.List;
@@ -45,11 +45,11 @@ public class UserController {
     }
 
     @GetMapping("/{userId}/reviews")
-    public CommonResponseEntity<List<UserReviewResponse>> searchReviewsByUserId(
+    public CommonResponseEntity<List<ReviewDetailResponse>> searchReviewsByUserId(
         @PathVariable Long userId,
         @AuthenticatedUser LoginUser loginUser) {
 
-        List<UserReviewResponse> userReviewResponses = userService.searchUserReviewsByUserIdAndRelationType(userId, loginUser);
+        List<ReviewDetailResponse> userReviewResponses = userService.searchUserReviewsByUserIdAndRelationType(userId, loginUser);
 
         return new CommonResponseEntity<>(
             ResponseCodeAndMessages.USER_SEARCH_REVIEWS_SUCCESS,

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/controller/UserController.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/controller/UserController.java
@@ -2,8 +2,10 @@ package com.jjikmuk.sikdorak.user.user.controller;
 
 import com.jjikmuk.sikdorak.common.ResponseCodeAndMessages;
 import com.jjikmuk.sikdorak.common.aop.UserOnly;
+import com.jjikmuk.sikdorak.common.controller.CursorPageable;
+import com.jjikmuk.sikdorak.common.controller.request.CursorPageRequest;
 import com.jjikmuk.sikdorak.common.response.CommonResponseEntity;
-import com.jjikmuk.sikdorak.review.controller.response.reviewdetail.ReviewDetailResponse;
+import com.jjikmuk.sikdorak.review.controller.response.ReviewListResponse;
 import com.jjikmuk.sikdorak.review.service.ReviewService;
 import com.jjikmuk.sikdorak.user.auth.controller.LoginUser;
 import com.jjikmuk.sikdorak.user.auth.domain.AuthenticatedUser;
@@ -47,11 +49,12 @@ public class UserController {
     }
 
     @GetMapping("/{userId}/reviews")
-    public CommonResponseEntity<List<ReviewDetailResponse>> searchReviewsByUserId(
+    public CommonResponseEntity<ReviewListResponse> searchReviewsByUserId(
         @PathVariable Long userId,
-        @AuthenticatedUser LoginUser loginUser) {
+        @AuthenticatedUser LoginUser loginUser,
+        @CursorPageable CursorPageRequest cursorPageRequest) {
 
-        List<ReviewDetailResponse> userReviewResponses = reviewService.searchUserReviewsByUserIdAndRelationType(userId, loginUser);
+        ReviewListResponse userReviewResponses = reviewService.searchUserReviewsByUserIdAndRelationType(userId, loginUser, cursorPageRequest);
 
         return new CommonResponseEntity<>(
             ResponseCodeAndMessages.USER_SEARCH_REVIEWS_SUCCESS,

--- a/be/src/test/java/com/jjikmuk/sikdorak/documentationtest/review/ReviewSnippet.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/documentationtest/review/ReviewSnippet.java
@@ -117,8 +117,8 @@ interface ReviewSnippet {
 			fieldWithPath("reviews[].store").type(JsonFieldType.OBJECT).description("가게 정보"),
 			fieldWithPath("reviews[].store.storeId").type(JsonFieldType.NUMBER).description("가게 아이디"),
 			fieldWithPath("reviews[].store.storeName").type(JsonFieldType.STRING).description("가게 이름"),
-			fieldWithPath("reviews[].store.addressName").type(JsonFieldType.STRING).description("가게 주소"),
-			fieldWithPath("reviews[].store.roadAddressName").type(JsonFieldType.STRING).description("가게 주소")),
+			fieldWithPath("reviews[].store.addressName").type(JsonFieldType.STRING).description("지번 주소"),
+			fieldWithPath("reviews[].store.roadAddressName").type(JsonFieldType.STRING).description("도로명 주소")),
 
 		responseFieldsOfObjectWithConstraintsAndFields(ReviewDetailLikeResponse.class,
 			fieldWithPath("reviews[].like.count").type(JsonFieldType.NUMBER).description("좋아요 개수"),

--- a/be/src/test/java/com/jjikmuk/sikdorak/documentationtest/review/ReviewSnippet.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/documentationtest/review/ReviewSnippet.java
@@ -80,7 +80,8 @@ interface ReviewSnippet {
 			fieldWithPath("store").type(JsonFieldType.OBJECT).description("가게 정보"),
 			fieldWithPath("store.storeId").type(JsonFieldType.NUMBER).description("가게 아이디"),
 			fieldWithPath("store.storeName").type(JsonFieldType.STRING).description("가게 이름"),
-			fieldWithPath("store.storeAddress").type(JsonFieldType.STRING).description("가게 주소")),
+			fieldWithPath("store.addressName").type(JsonFieldType.STRING).description("가게 주소"),
+			fieldWithPath("store.roadAddressName").type(JsonFieldType.STRING).description("가게 주소")),
 
 		responseFieldsOfObjectWithConstraintsAndFields(ReviewDetailLikeResponse.class,
 			fieldWithPath("like.count").type(JsonFieldType.NUMBER).description("좋아요 개수"),
@@ -116,7 +117,8 @@ interface ReviewSnippet {
 			fieldWithPath("reviews[].store").type(JsonFieldType.OBJECT).description("가게 정보"),
 			fieldWithPath("reviews[].store.storeId").type(JsonFieldType.NUMBER).description("가게 아이디"),
 			fieldWithPath("reviews[].store.storeName").type(JsonFieldType.STRING).description("가게 이름"),
-			fieldWithPath("reviews[].store.storeAddress").type(JsonFieldType.STRING).description("가게 주소")),
+			fieldWithPath("reviews[].store.addressName").type(JsonFieldType.STRING).description("가게 주소"),
+			fieldWithPath("reviews[].store.roadAddressName").type(JsonFieldType.STRING).description("가게 주소")),
 
 		responseFieldsOfObjectWithConstraintsAndFields(ReviewDetailLikeResponse.class,
 			fieldWithPath("reviews[].like.count").type(JsonFieldType.NUMBER).description("좋아요 개수"),

--- a/be/src/test/java/com/jjikmuk/sikdorak/documentationtest/user/user/UserReviewsSearchByUserIdDocumentationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/documentationtest/user/user/UserReviewsSearchByUserIdDocumentationTest.java
@@ -1,7 +1,8 @@
 package com.jjikmuk.sikdorak.documentationtest.user.user;
 
 
-import static com.jjikmuk.sikdorak.documentationtest.user.user.UserSnippet.USER_SEARCH_REVIEWS_REQUEST_PARAM_SNIPPET;
+import static com.jjikmuk.sikdorak.documentationtest.user.user.UserSnippet.USER_SEARCH_REVIEWS_REQUEST_PATH_PARAM_SNIPPET;
+import static com.jjikmuk.sikdorak.documentationtest.user.user.UserSnippet.USER_SEARCH_REVIEWS_REQUEST_QUERY_PARAM_SNIPPET;
 import static com.jjikmuk.sikdorak.documentationtest.user.user.UserSnippet.USER_SEARCH_REVIEWS_RESPONSE_SNIPPET;
 import static io.restassured.RestAssured.given;
 import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
@@ -29,7 +30,8 @@ class UserReviewsSearchByUserIdDocumentationTest extends InitDocumentationTest {
 		given(this.spec)
 			.filter(
 				document(DEFAULT_RESTDOC_PATH,
-					USER_SEARCH_REVIEWS_REQUEST_PARAM_SNIPPET,
+					USER_SEARCH_REVIEWS_REQUEST_PATH_PARAM_SNIPPET,
+					USER_SEARCH_REVIEWS_REQUEST_QUERY_PARAM_SNIPPET,
 					USER_SEARCH_REVIEWS_RESPONSE_SNIPPET))
 			.accept(MediaType.APPLICATION_JSON_VALUE)
 			.header("Content-type", "application/json")
@@ -74,7 +76,8 @@ class UserReviewsSearchByUserIdDocumentationTest extends InitDocumentationTest {
 		given(this.spec)
 			.filter(
 				document(DEFAULT_RESTDOC_PATH,
-					USER_SEARCH_REVIEWS_REQUEST_PARAM_SNIPPET,
+					USER_SEARCH_REVIEWS_REQUEST_PATH_PARAM_SNIPPET,
+					USER_SEARCH_REVIEWS_REQUEST_QUERY_PARAM_SNIPPET,
 					USER_SEARCH_REVIEWS_RESPONSE_SNIPPET))
 			.accept(MediaType.APPLICATION_JSON_VALUE)
 			.header("Content-type", "application/json")

--- a/be/src/test/java/com/jjikmuk/sikdorak/documentationtest/user/user/UserReviewsSearchByUserIdDocumentationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/documentationtest/user/user/UserReviewsSearchByUserIdDocumentationTest.java
@@ -33,15 +33,18 @@ class UserReviewsSearchByUserIdDocumentationTest extends InitDocumentationTest {
 					USER_SEARCH_REVIEWS_RESPONSE_SNIPPET))
 			.accept(MediaType.APPLICATION_JSON_VALUE)
 			.header("Content-type", "application/json")
+			.queryParam("after", 0)
+			.queryParam("size", 1)
 
 		.when()
 			.get("/api/users/{userId}/reviews", testData.hoi.getId())
 
 		.then()
 			.statusCode(HttpStatus.OK.value())
+			.log().all()
 			.body("code", Matchers.equalTo(ResponseCodeAndMessages.USER_SEARCH_REVIEWS_SUCCESS.getCode()))
 			.body("message", Matchers.equalTo(ResponseCodeAndMessages.USER_SEARCH_REVIEWS_SUCCESS.getMessage()))
-			.body("data.size()", Matchers.equalTo(1));
+			.body("data.reviews.size()", Matchers.equalTo(1));
 	}
 
 	@Test
@@ -51,16 +54,18 @@ class UserReviewsSearchByUserIdDocumentationTest extends InitDocumentationTest {
 			.accept(MediaType.APPLICATION_JSON_VALUE)
 			.header("Content-type", "application/json")
 			.header("Authorization", testData.followSendUserValidAuthorizationHeader)
+			.queryParam("after", 0)
+			.queryParam("size", 2)
 
 		.when()
 			.get("/api/users/{userId}/reviews", testData.hoi.getId())
 
 		.then()
 			.statusCode(HttpStatus.OK.value())
+			.log().all()
 			.body("code", Matchers.equalTo(ResponseCodeAndMessages.USER_SEARCH_REVIEWS_SUCCESS.getCode()))
 			.body("message", Matchers.equalTo(ResponseCodeAndMessages.USER_SEARCH_REVIEWS_SUCCESS.getMessage()))
-			.body("data.size()", Matchers.equalTo(2));
-
+			.body("data.reviews.size()", Matchers.equalTo(2));
 	}
 
 	@Test
@@ -74,15 +79,18 @@ class UserReviewsSearchByUserIdDocumentationTest extends InitDocumentationTest {
 			.accept(MediaType.APPLICATION_JSON_VALUE)
 			.header("Content-type", "application/json")
 			.header("Authorization", testData.followAcceptUserValidAuthorizationHeader)
+			.queryParam("after", 0)
+			.queryParam("size", 3)
 
 		.when()
 			.get("/api/users/{userId}/reviews", testData.hoi.getId())
 
 		.then()
+			.log().all()
 			.statusCode(HttpStatus.OK.value())
 			.body("code", Matchers.equalTo(ResponseCodeAndMessages.USER_SEARCH_REVIEWS_SUCCESS.getCode()))
 			.body("message", Matchers.equalTo(ResponseCodeAndMessages.USER_SEARCH_REVIEWS_SUCCESS.getMessage()))
-			.body("data.size()", Matchers.equalTo(3));
+			.body("data.reviews.size()", Matchers.equalTo(3));
 	}
 
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/documentationtest/user/user/UserSnippet.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/documentationtest/user/user/UserSnippet.java
@@ -1,6 +1,7 @@
 package com.jjikmuk.sikdorak.documentationtest.user.user;
 
 import static com.jjikmuk.sikdorak.documentationtest.DocumentFormatGenerator.createResponseSnippetWithFields;
+import static com.jjikmuk.sikdorak.documentationtest.DocumentFormatGenerator.requestPagingFieldsOfCommon;
 import static com.jjikmuk.sikdorak.documentationtest.DocumentFormatGenerator.requestSnippetWithConstraintsAndFields;
 import static com.jjikmuk.sikdorak.documentationtest.DocumentFormatGenerator.responseFieldsOfCommon;
 import static com.jjikmuk.sikdorak.documentationtest.DocumentFormatGenerator.responseFieldsOfCommonNonData;
@@ -42,9 +43,11 @@ public interface UserSnippet {
 
     Snippet USER_FOLLOW_RESPONSE_SNIPPET = createResponseSnippetWithFields(responseFieldsOfCommonNonData());
 
-    Snippet USER_SEARCH_REVIEWS_REQUEST_PARAM_SNIPPET = pathParameters(
+    Snippet USER_SEARCH_REVIEWS_REQUEST_PATH_PARAM_SNIPPET = pathParameters(
         parameterWithName("userId").description("리뷰를 조회할 유저 아이디")
     );
+
+    Snippet USER_SEARCH_REVIEWS_REQUEST_QUERY_PARAM_SNIPPET = requestPagingFieldsOfCommon();
 
     Snippet USER_SEARCH_REVIEWS_RESPONSE_SNIPPET = createResponseSnippetWithFields(
         responseFieldsOfCommon(),

--- a/be/src/test/java/com/jjikmuk/sikdorak/documentationtest/user/user/UserSnippet.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/documentationtest/user/user/UserSnippet.java
@@ -60,8 +60,8 @@ public interface UserSnippet {
             fieldWithPath("reviews[].store").type(JsonFieldType.OBJECT).description("가게 정보"),
             fieldWithPath("reviews[].store.storeId").type(JsonFieldType.NUMBER).description("가게 아이디"),
             fieldWithPath("reviews[].store.storeName").type(JsonFieldType.STRING).description("가게 이름"),
-            fieldWithPath("reviews[].store.addressName").type(JsonFieldType.STRING).description("가게 주소"),
-            fieldWithPath("reviews[].store.roadAddressName").type(JsonFieldType.STRING).description("가게 주소")),
+            fieldWithPath("reviews[].store.addressName").type(JsonFieldType.STRING).description("지번 주소"),
+            fieldWithPath("reviews[].store.roadAddressName").type(JsonFieldType.STRING).description("도로명 주소")),
 
         responseFieldsOfObjectWithConstraintsAndFields(ReviewDetailLikeResponse.class,
             fieldWithPath("reviews[].like.count").type(JsonFieldType.NUMBER).description("좋아요 개수"),

--- a/be/src/test/java/com/jjikmuk/sikdorak/documentationtest/user/user/UserSnippet.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/documentationtest/user/user/UserSnippet.java
@@ -6,6 +6,7 @@ import static com.jjikmuk.sikdorak.documentationtest.DocumentFormatGenerator.res
 import static com.jjikmuk.sikdorak.documentationtest.DocumentFormatGenerator.responseFieldsOfCommonNonData;
 import static com.jjikmuk.sikdorak.documentationtest.DocumentFormatGenerator.responseFieldsOfListWithConstraintsAndFields;
 import static com.jjikmuk.sikdorak.documentationtest.DocumentFormatGenerator.responseFieldsOfObjectWithConstraintsAndFields;
+import static com.jjikmuk.sikdorak.documentationtest.DocumentFormatGenerator.responsePagingFieldsOfCommon;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
@@ -49,33 +50,35 @@ public interface UserSnippet {
         responseFieldsOfCommon(),
 
         responseFieldsOfObjectWithConstraintsAndFields(ReviewDetailUserResponse.class,
-            fieldWithPath("[].user").type(JsonFieldType.OBJECT).description("유저 정보"),
-            fieldWithPath("[].user.userId").type(JsonFieldType.NUMBER).description("유저 아이디"),
-            fieldWithPath("[].user.userNickname").type(JsonFieldType.STRING).description("유저 이름"),
-            fieldWithPath("[].user.userProfileImage").type(JsonFieldType.STRING)
+            fieldWithPath("reviews[].user").type(JsonFieldType.OBJECT).description("유저 정보"),
+            fieldWithPath("reviews[].user.userId").type(JsonFieldType.NUMBER).description("유저 아이디"),
+            fieldWithPath("reviews[].user.userNickname").type(JsonFieldType.STRING).description("유저 이름"),
+            fieldWithPath("reviews[].user.userProfileImage").type(JsonFieldType.STRING)
                 .description("유저 프로필 이미지")),
 
         responseFieldsOfObjectWithConstraintsAndFields(ReviewDetailStoreResponse.class,
-            fieldWithPath("[].store").type(JsonFieldType.OBJECT).description("가게 정보"),
-            fieldWithPath("[].store.storeId").type(JsonFieldType.NUMBER).description("가게 아이디"),
-            fieldWithPath("[].store.storeName").type(JsonFieldType.STRING).description("가게 이름"),
-            fieldWithPath("[].store.addressName").type(JsonFieldType.STRING).description("가게 주소"),
-            fieldWithPath("[].store.roadAddressName").type(JsonFieldType.STRING).description("가게 주소")),
+            fieldWithPath("reviews[].store").type(JsonFieldType.OBJECT).description("가게 정보"),
+            fieldWithPath("reviews[].store.storeId").type(JsonFieldType.NUMBER).description("가게 아이디"),
+            fieldWithPath("reviews[].store.storeName").type(JsonFieldType.STRING).description("가게 이름"),
+            fieldWithPath("reviews[].store.addressName").type(JsonFieldType.STRING).description("가게 주소"),
+            fieldWithPath("reviews[].store.roadAddressName").type(JsonFieldType.STRING).description("가게 주소")),
 
         responseFieldsOfObjectWithConstraintsAndFields(ReviewDetailLikeResponse.class,
-            fieldWithPath("[].like.count").type(JsonFieldType.NUMBER).description("좋아요 개수"),
-            fieldWithPath("[].like.userLikeStatus").type(JsonFieldType.BOOLEAN).description("유저의 좋아요 여부")),
+            fieldWithPath("reviews[].like.count").type(JsonFieldType.NUMBER).description("좋아요 개수"),
+            fieldWithPath("reviews[].like.userLikeStatus").type(JsonFieldType.BOOLEAN).description("유저의 좋아요 여부")),
 
         responseFieldsOfObjectWithConstraintsAndFields(ReviewDetailResponse.class,
-            fieldWithPath("[].reviewId").type(JsonFieldType.NUMBER).description("리뷰 아이디"),
-            fieldWithPath("[].reviewContent").type(JsonFieldType.STRING).description("리뷰 내용"),
-            fieldWithPath("[].reviewScore").type(JsonFieldType.NUMBER).description("리뷰 점수"),
-            fieldWithPath("[].reviewVisibility").type(JsonFieldType.STRING).description("리뷰 게시물의 공개 범위"),
-            fieldWithPath("[].visitedDate").type(JsonFieldType.STRING).description("가게 방문일"),
-            fieldWithPath("[].tags").type(JsonFieldType.ARRAY).description("리뷰를 표현하는 태그들"),
-            fieldWithPath("[].images").type(JsonFieldType.ARRAY).description("리뷰를 위한 사진 URL"),
-            fieldWithPath("[].createdAt").type(JsonFieldType.STRING).description("리뷰 생성 시간"),
-            fieldWithPath("[].updatedAt").type(JsonFieldType.STRING).description("리뷰 수정 시간"))
+            fieldWithPath("reviews[].reviewId").type(JsonFieldType.NUMBER).description("리뷰 아이디"),
+            fieldWithPath("reviews[].reviewContent").type(JsonFieldType.STRING).description("리뷰 내용"),
+            fieldWithPath("reviews[].reviewScore").type(JsonFieldType.NUMBER).description("리뷰 점수"),
+            fieldWithPath("reviews[].reviewVisibility").type(JsonFieldType.STRING).description("리뷰 게시물의 공개 범위"),
+            fieldWithPath("reviews[].visitedDate").type(JsonFieldType.STRING).description("가게 방문일"),
+            fieldWithPath("reviews[].tags").type(JsonFieldType.ARRAY).description("리뷰를 표현하는 태그들"),
+            fieldWithPath("reviews[].images").type(JsonFieldType.ARRAY).description("리뷰를 위한 사진 URL"),
+            fieldWithPath("reviews[].createdAt").type(JsonFieldType.STRING).description("리뷰 생성 시간"),
+            fieldWithPath("reviews[].updatedAt").type(JsonFieldType.STRING).description("리뷰 수정 시간")),
+
+        responsePagingFieldsOfCommon()
     );
 
     Snippet USER_SEARCH_PROFILE_REQUEST_SNIPPET = pathParameters(

--- a/be/src/test/java/com/jjikmuk/sikdorak/documentationtest/user/user/UserSnippet.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/documentationtest/user/user/UserSnippet.java
@@ -11,11 +11,14 @@ import static org.springframework.restdocs.request.RequestDocumentation.paramete
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
 
+import com.jjikmuk.sikdorak.review.controller.response.reviewdetail.ReviewDetailLikeResponse;
+import com.jjikmuk.sikdorak.review.controller.response.reviewdetail.ReviewDetailResponse;
+import com.jjikmuk.sikdorak.review.controller.response.reviewdetail.ReviewDetailStoreResponse;
+import com.jjikmuk.sikdorak.review.controller.response.reviewdetail.ReviewDetailUserResponse;
 import com.jjikmuk.sikdorak.user.user.controller.request.UserFollowAndUnfollowRequest;
 import com.jjikmuk.sikdorak.user.user.controller.request.UserModifyRequest;
 import com.jjikmuk.sikdorak.user.user.controller.response.FollowUserProfile;
 import com.jjikmuk.sikdorak.user.user.controller.response.UserDetailProfileResponse;
-import com.jjikmuk.sikdorak.user.user.controller.response.UserReviewResponse;
 import com.jjikmuk.sikdorak.user.user.controller.response.UserSimpleProfileResponse;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.restdocs.snippet.Snippet;
@@ -45,20 +48,34 @@ public interface UserSnippet {
     Snippet USER_SEARCH_REVIEWS_RESPONSE_SNIPPET = createResponseSnippetWithFields(
         responseFieldsOfCommon(),
 
-        responseFieldsOfListWithConstraintsAndFields(
-            UserReviewResponse.class,
-            fieldWithPath("id").type(JsonFieldType.NUMBER).description("리뷰 아이디"),
-            fieldWithPath("userId").type(JsonFieldType.NUMBER).description("리뷰를 작성한 유저 아이디"),
-            fieldWithPath("storeId").type(JsonFieldType.NUMBER).description("리뷰 작성 대상 가게 아이디"),
-            fieldWithPath("reviewContent").type(JsonFieldType.STRING).description("리뷰 내용"),
-            fieldWithPath("reviewScore").type(JsonFieldType.NUMBER).description("리뷰 평점"),
-            fieldWithPath("reviewVisibility").type(JsonFieldType.STRING).description("리뷰 보기 권한"),
-            fieldWithPath("visitedDate").type(JsonFieldType.STRING).description("가게 방문 날짜"),
-            fieldWithPath("tags").type(JsonFieldType.ARRAY).description("리뷰 태그들"),
-            fieldWithPath("images").type(JsonFieldType.ARRAY).description("리뷰 이미지"),
-            fieldWithPath("createdAt").type(JsonFieldType.STRING).description("리뷰 생성 시간"),
-            fieldWithPath("updatedAt").type(JsonFieldType.STRING).description("리뷰 수정 시간")
-        )
+        responseFieldsOfObjectWithConstraintsAndFields(ReviewDetailUserResponse.class,
+            fieldWithPath("[].user").type(JsonFieldType.OBJECT).description("유저 정보"),
+            fieldWithPath("[].user.userId").type(JsonFieldType.NUMBER).description("유저 아이디"),
+            fieldWithPath("[].user.userNickname").type(JsonFieldType.STRING).description("유저 이름"),
+            fieldWithPath("[].user.userProfileImage").type(JsonFieldType.STRING)
+                .description("유저 프로필 이미지")),
+
+        responseFieldsOfObjectWithConstraintsAndFields(ReviewDetailStoreResponse.class,
+            fieldWithPath("[].store").type(JsonFieldType.OBJECT).description("가게 정보"),
+            fieldWithPath("[].store.storeId").type(JsonFieldType.NUMBER).description("가게 아이디"),
+            fieldWithPath("[].store.storeName").type(JsonFieldType.STRING).description("가게 이름"),
+            fieldWithPath("[].store.addressName").type(JsonFieldType.STRING).description("가게 주소"),
+            fieldWithPath("[].store.roadAddressName").type(JsonFieldType.STRING).description("가게 주소")),
+
+        responseFieldsOfObjectWithConstraintsAndFields(ReviewDetailLikeResponse.class,
+            fieldWithPath("[].like.count").type(JsonFieldType.NUMBER).description("좋아요 개수"),
+            fieldWithPath("[].like.userLikeStatus").type(JsonFieldType.BOOLEAN).description("유저의 좋아요 여부")),
+
+        responseFieldsOfObjectWithConstraintsAndFields(ReviewDetailResponse.class,
+            fieldWithPath("[].reviewId").type(JsonFieldType.NUMBER).description("리뷰 아이디"),
+            fieldWithPath("[].reviewContent").type(JsonFieldType.STRING).description("리뷰 내용"),
+            fieldWithPath("[].reviewScore").type(JsonFieldType.NUMBER).description("리뷰 점수"),
+            fieldWithPath("[].reviewVisibility").type(JsonFieldType.STRING).description("리뷰 게시물의 공개 범위"),
+            fieldWithPath("[].visitedDate").type(JsonFieldType.STRING).description("가게 방문일"),
+            fieldWithPath("[].tags").type(JsonFieldType.ARRAY).description("리뷰를 표현하는 태그들"),
+            fieldWithPath("[].images").type(JsonFieldType.ARRAY).description("리뷰를 위한 사진 URL"),
+            fieldWithPath("[].createdAt").type(JsonFieldType.STRING).description("리뷰 생성 시간"),
+            fieldWithPath("[].updatedAt").type(JsonFieldType.STRING).description("리뷰 수정 시간"))
     );
 
     Snippet USER_SEARCH_PROFILE_REQUEST_SNIPPET = pathParameters(

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/review/ReviewsRecommendIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/review/ReviewsRecommendIntegrationTest.java
@@ -6,7 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.jjikmuk.sikdorak.common.controller.request.CursorPageRequest;
 import com.jjikmuk.sikdorak.common.exception.InvalidPageParameterException;
 import com.jjikmuk.sikdorak.integration.InitIntegrationTest;
-import com.jjikmuk.sikdorak.review.controller.response.RecommendedReviewResponse;
+import com.jjikmuk.sikdorak.review.controller.response.ReviewListResponse;
 import com.jjikmuk.sikdorak.review.domain.ReviewVisibility;
 import com.jjikmuk.sikdorak.review.service.ReviewService;
 import com.jjikmuk.sikdorak.user.auth.controller.Authority;
@@ -29,7 +29,7 @@ class ReviewsRecommendIntegrationTest extends InitIntegrationTest {
         LoginUser loginUser = new LoginUser(Authority.ANONYMOUS);
         CursorPageRequest cursorPageRequest = new CursorPageRequest(0L, cursorPage, size, true);
 
-        RecommendedReviewResponse recommendedReviews = reviewService.getRecentRecommendedReviews(
+        ReviewListResponse recommendedReviews = reviewService.getRecentRecommendedReviews(
             loginUser, cursorPageRequest);
         long firstReviewLikeCount = recommendedReviews.reviews().get(0).like().count();
         long secondReviewLikeCount = recommendedReviews.reviews().get(1).like().count();
@@ -47,7 +47,7 @@ class ReviewsRecommendIntegrationTest extends InitIntegrationTest {
         LoginUser loginUser = new LoginUser(testData.kukim.getId(), Authority.USER);
         CursorPageRequest cursorPageRequest = new CursorPageRequest(0L, cursorPage, size, true);
 
-        RecommendedReviewResponse recommendedReviews = reviewService.getRecentRecommendedReviews(
+        ReviewListResponse recommendedReviews = reviewService.getRecentRecommendedReviews(
             loginUser, cursorPageRequest);
 
         assertThat(recommendedReviews.reviews().stream().anyMatch(
@@ -62,7 +62,7 @@ class ReviewsRecommendIntegrationTest extends InitIntegrationTest {
         LoginUser loginUser = new LoginUser(Authority.ANONYMOUS);
         CursorPageRequest cursorPageRequest = new CursorPageRequest(0L, invalidPage, size, true);
 
-        RecommendedReviewResponse recommendedReviews = reviewService.getRecentRecommendedReviews(
+        ReviewListResponse recommendedReviews = reviewService.getRecentRecommendedReviews(
             loginUser, cursorPageRequest);
 
         assertThat(recommendedReviews.reviews()).isEmpty();
@@ -76,7 +76,7 @@ class ReviewsRecommendIntegrationTest extends InitIntegrationTest {
         LoginUser loginUser = new LoginUser(Authority.ANONYMOUS);
         CursorPageRequest cursorPageRequest = new CursorPageRequest(0L, cursorPage, size, true);
 
-        RecommendedReviewResponse recommendedReviews = reviewService.getRecentRecommendedReviews(
+        ReviewListResponse recommendedReviews = reviewService.getRecentRecommendedReviews(
             loginUser, cursorPageRequest);
 
         assertThat(recommendedReviews.reviews()).hasSize(size);
@@ -90,7 +90,7 @@ class ReviewsRecommendIntegrationTest extends InitIntegrationTest {
         LoginUser loginUser = new LoginUser(Authority.ANONYMOUS);
         CursorPageRequest cursorPageRequest = new CursorPageRequest(0L, cursorPage, size, true);
 
-        RecommendedReviewResponse recommendedReviews = reviewService.getRecentRecommendedReviews(
+        ReviewListResponse recommendedReviews = reviewService.getRecentRecommendedReviews(
             loginUser, cursorPageRequest);
 
         assertThat(recommendedReviews.reviews()).hasSize(size);

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserReviewsSearchByUserIdIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserReviewsSearchByUserIdIntegrationTest.java
@@ -3,13 +3,13 @@ package com.jjikmuk.sikdorak.integration.user.user;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.jjikmuk.sikdorak.common.controller.request.CursorPageRequest;
 import com.jjikmuk.sikdorak.integration.InitIntegrationTest;
-import com.jjikmuk.sikdorak.review.controller.response.reviewdetail.ReviewDetailResponse;
+import com.jjikmuk.sikdorak.review.controller.response.ReviewListResponse;
 import com.jjikmuk.sikdorak.review.service.ReviewService;
 import com.jjikmuk.sikdorak.user.auth.controller.Authority;
 import com.jjikmuk.sikdorak.user.auth.controller.LoginUser;
 import com.jjikmuk.sikdorak.user.user.exception.NotFoundUserException;
-import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,63 +23,95 @@ class UserReviewsSearchByUserIdIntegrationTest extends InitIntegrationTest {
 	@Test
 	@DisplayName("게스트가 특정 유저의 리뷰를 조회한다면 public 리뷰들만 반환한다.")
 	void guest_search_user_reviews_success() {
+		long cursorPage = 10;
+		int size = 5;
+		CursorPageRequest cursorPageRequest = new CursorPageRequest(0L, cursorPage, size, true);
 		LoginUser loginUser = new LoginUser(Authority.ANONYMOUS);
 
-		List<ReviewDetailResponse> reviews = reviewService.searchUserReviewsByUserIdAndRelationType(testData.hoi.getId(), loginUser);
+		ReviewListResponse reviews = reviewService.searchUserReviewsByUserIdAndRelationType(testData.hoi.getId(), loginUser, cursorPageRequest);
 
-		assertThat(reviews).hasSize(1);
+		assertThat(reviews.reviews()).hasSize(1);
 	}
 
 	@Test
 	@DisplayName("친구가 아닌 유저가 특정 유저의 리뷰를 조회한다면 public 리뷰들만 반환한다.")
 	void disconnection_user_search_user_reviews_success() {
+		long cursorPage = 10;
+		int size = 5;
+		CursorPageRequest cursorPageRequest = new CursorPageRequest(0L, cursorPage, size, true);
 		LoginUser loginUser = new LoginUser(testData.jay.getId(), Authority.USER);
 
-		List<ReviewDetailResponse> reviews = reviewService.searchUserReviewsByUserIdAndRelationType(testData.hoi.getId(), loginUser);
+		ReviewListResponse reviews = reviewService.searchUserReviewsByUserIdAndRelationType(testData.hoi.getId(), loginUser, cursorPageRequest);
 
-		assertThat(reviews).hasSize(1);
+		assertThat(reviews.reviews()).hasSize(1);
 	}
 
 	@Test
 	@DisplayName("친구인 유저가 특정 유저의 리뷰를 조회한다면 public|protected 리뷰들을 반환한다.")
 	void connection_user_search_user_reviews_success() {
+		long cursorPage = 10;
+		int size = 5;
+		CursorPageRequest cursorPageRequest = new CursorPageRequest(0L, cursorPage, size, true);
 		LoginUser loginUser = new LoginUser(testData.forky.getId(), Authority.USER);
 
-		List<ReviewDetailResponse> reviews = reviewService.searchUserReviewsByUserIdAndRelationType(testData.hoi.getId(), loginUser);
+		ReviewListResponse reviews = reviewService.searchUserReviewsByUserIdAndRelationType(testData.hoi.getId(), loginUser, cursorPageRequest);
 
-		assertThat(reviews).hasSize(2);
+		assertThat(reviews.reviews()).hasSize(2);
 	}
 
 	@Test
 	@DisplayName("스스로 자신의 리뷰를 조회한다면 public|protected|private 전체 리뷰를 반환한다.")
 	void user_search_user_reviews_success() {
+		long cursorPage = 10;
+		int size = 5;
+		CursorPageRequest cursorPageRequest = new CursorPageRequest(0L, cursorPage, size, true);
 		LoginUser loginUser = new LoginUser(testData.hoi.getId(), Authority.USER);
 
-		List<ReviewDetailResponse> reviews = reviewService.searchUserReviewsByUserIdAndRelationType(testData.hoi.getId(), loginUser);
+		ReviewListResponse reviews = reviewService.searchUserReviewsByUserIdAndRelationType(testData.hoi.getId(), loginUser, cursorPageRequest);
 
-		assertThat(reviews).hasSize(3);
+		assertThat(reviews.reviews()).hasSize(3);
 	}
 
 	@Test
 	@DisplayName("존재하지 않는 유저의 리뷰를 조회한다면 예외를 발생시킨다.")
 	void search_invalid_user_reviews_failed() {
+		long cursorPage = 10;
+		int size = 5;
+		CursorPageRequest cursorPageRequest = new CursorPageRequest(0L, cursorPage, size, true);
 		LoginUser loginUser = new LoginUser(Authority.ANONYMOUS);
 		long invalidUserId = Long.MAX_VALUE;
 
 		assertThatThrownBy(() ->
-			reviewService.searchUserReviewsByUserIdAndRelationType(invalidUserId, loginUser))
+			reviewService.searchUserReviewsByUserIdAndRelationType(invalidUserId, loginUser, cursorPageRequest))
 			.isInstanceOf(NotFoundUserException.class);
 	}
 
 	@Test
 	@DisplayName("조회할 리뷰가 존재하지 않는다면 빈 리스트를 반환한다.")
 	void search_empty_user_reviews_failed() {
+		long cursorPage = 10;
+		int size = 5;
+		CursorPageRequest cursorPageRequest = new CursorPageRequest(0L, cursorPage, size, true);
 		LoginUser loginUser = new LoginUser(Authority.ANONYMOUS);
 
-		List<ReviewDetailResponse> reviews = reviewService.searchUserReviewsByUserIdAndRelationType(
-			testData.jay.getId(), loginUser);
+		ReviewListResponse reviews = reviewService.searchUserReviewsByUserIdAndRelationType(
+			testData.jay.getId(), loginUser,cursorPageRequest);
 
-		assertThat(reviews).isEmpty();
+		assertThat(reviews.reviews()).isEmpty();
+	}
+
+	@Test
+	@DisplayName("유저에 대한 리뷰조회 요청시 결과가 페이징 되어서 나온다.")
+	void search_user_reviews_by_paging() {
+		long cursorPage = 15;
+		int size = 5;
+		CursorPageRequest cursorPageRequest = new CursorPageRequest(0L, cursorPage, size, true);
+		LoginUser loginUser = new LoginUser(Authority.ANONYMOUS);
+
+		ReviewListResponse reviews = reviewService.searchUserReviewsByUserIdAndRelationType(
+			testData.forky.getId(), loginUser,cursorPageRequest);
+
+		assertThat(reviews.reviews()).hasSize(5);
 	}
 
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserReviewsSearchByUserIdIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserReviewsSearchByUserIdIntegrationTest.java
@@ -5,10 +5,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.jjikmuk.sikdorak.integration.InitIntegrationTest;
 import com.jjikmuk.sikdorak.review.controller.response.reviewdetail.ReviewDetailResponse;
+import com.jjikmuk.sikdorak.review.service.ReviewService;
 import com.jjikmuk.sikdorak.user.auth.controller.Authority;
 import com.jjikmuk.sikdorak.user.auth.controller.LoginUser;
 import com.jjikmuk.sikdorak.user.user.exception.NotFoundUserException;
-import com.jjikmuk.sikdorak.user.user.service.UserService;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,14 +18,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 class UserReviewsSearchByUserIdIntegrationTest extends InitIntegrationTest {
 
 	@Autowired
-	private UserService userService;
+	private ReviewService reviewService;
 
 	@Test
 	@DisplayName("게스트가 특정 유저의 리뷰를 조회한다면 public 리뷰들만 반환한다.")
 	void guest_search_user_reviews_success() {
 		LoginUser loginUser = new LoginUser(Authority.ANONYMOUS);
 
-		List<ReviewDetailResponse> reviews = userService.searchUserReviewsByUserIdAndRelationType(testData.hoi.getId(), loginUser);
+		List<ReviewDetailResponse> reviews = reviewService.searchUserReviewsByUserIdAndRelationType(testData.hoi.getId(), loginUser);
 
 		assertThat(reviews).hasSize(1);
 	}
@@ -35,7 +35,7 @@ class UserReviewsSearchByUserIdIntegrationTest extends InitIntegrationTest {
 	void disconnection_user_search_user_reviews_success() {
 		LoginUser loginUser = new LoginUser(testData.jay.getId(), Authority.USER);
 
-		List<ReviewDetailResponse> reviews = userService.searchUserReviewsByUserIdAndRelationType(testData.hoi.getId(), loginUser);
+		List<ReviewDetailResponse> reviews = reviewService.searchUserReviewsByUserIdAndRelationType(testData.hoi.getId(), loginUser);
 
 		assertThat(reviews).hasSize(1);
 	}
@@ -45,7 +45,7 @@ class UserReviewsSearchByUserIdIntegrationTest extends InitIntegrationTest {
 	void connection_user_search_user_reviews_success() {
 		LoginUser loginUser = new LoginUser(testData.forky.getId(), Authority.USER);
 
-		List<ReviewDetailResponse> reviews = userService.searchUserReviewsByUserIdAndRelationType(testData.hoi.getId(), loginUser);
+		List<ReviewDetailResponse> reviews = reviewService.searchUserReviewsByUserIdAndRelationType(testData.hoi.getId(), loginUser);
 
 		assertThat(reviews).hasSize(2);
 	}
@@ -55,7 +55,7 @@ class UserReviewsSearchByUserIdIntegrationTest extends InitIntegrationTest {
 	void user_search_user_reviews_success() {
 		LoginUser loginUser = new LoginUser(testData.hoi.getId(), Authority.USER);
 
-		List<ReviewDetailResponse> reviews = userService.searchUserReviewsByUserIdAndRelationType(testData.hoi.getId(), loginUser);
+		List<ReviewDetailResponse> reviews = reviewService.searchUserReviewsByUserIdAndRelationType(testData.hoi.getId(), loginUser);
 
 		assertThat(reviews).hasSize(3);
 	}
@@ -67,7 +67,7 @@ class UserReviewsSearchByUserIdIntegrationTest extends InitIntegrationTest {
 		long invalidUserId = Long.MAX_VALUE;
 
 		assertThatThrownBy(() ->
-			userService.searchUserReviewsByUserIdAndRelationType(invalidUserId, loginUser))
+			reviewService.searchUserReviewsByUserIdAndRelationType(invalidUserId, loginUser))
 			.isInstanceOf(NotFoundUserException.class);
 	}
 
@@ -76,7 +76,7 @@ class UserReviewsSearchByUserIdIntegrationTest extends InitIntegrationTest {
 	void search_empty_user_reviews_failed() {
 		LoginUser loginUser = new LoginUser(Authority.ANONYMOUS);
 
-		List<ReviewDetailResponse> reviews = userService.searchUserReviewsByUserIdAndRelationType(
+		List<ReviewDetailResponse> reviews = reviewService.searchUserReviewsByUserIdAndRelationType(
 			testData.jay.getId(), loginUser);
 
 		assertThat(reviews).isEmpty();

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserReviewsSearchByUserIdIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserReviewsSearchByUserIdIntegrationTest.java
@@ -4,9 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.jjikmuk.sikdorak.integration.InitIntegrationTest;
+import com.jjikmuk.sikdorak.review.controller.response.reviewdetail.ReviewDetailResponse;
 import com.jjikmuk.sikdorak.user.auth.controller.Authority;
 import com.jjikmuk.sikdorak.user.auth.controller.LoginUser;
-import com.jjikmuk.sikdorak.user.user.controller.response.UserReviewResponse;
 import com.jjikmuk.sikdorak.user.user.exception.NotFoundUserException;
 import com.jjikmuk.sikdorak.user.user.service.UserService;
 import java.util.List;
@@ -25,7 +25,7 @@ class UserReviewsSearchByUserIdIntegrationTest extends InitIntegrationTest {
 	void guest_search_user_reviews_success() {
 		LoginUser loginUser = new LoginUser(Authority.ANONYMOUS);
 
-		List<UserReviewResponse> reviews = userService.searchUserReviewsByUserIdAndRelationType(testData.hoi.getId(), loginUser);
+		List<ReviewDetailResponse> reviews = userService.searchUserReviewsByUserIdAndRelationType(testData.hoi.getId(), loginUser);
 
 		assertThat(reviews).hasSize(1);
 	}
@@ -35,7 +35,7 @@ class UserReviewsSearchByUserIdIntegrationTest extends InitIntegrationTest {
 	void disconnection_user_search_user_reviews_success() {
 		LoginUser loginUser = new LoginUser(testData.jay.getId(), Authority.USER);
 
-		List<UserReviewResponse> reviews = userService.searchUserReviewsByUserIdAndRelationType(testData.hoi.getId(), loginUser);
+		List<ReviewDetailResponse> reviews = userService.searchUserReviewsByUserIdAndRelationType(testData.hoi.getId(), loginUser);
 
 		assertThat(reviews).hasSize(1);
 	}
@@ -45,7 +45,7 @@ class UserReviewsSearchByUserIdIntegrationTest extends InitIntegrationTest {
 	void connection_user_search_user_reviews_success() {
 		LoginUser loginUser = new LoginUser(testData.forky.getId(), Authority.USER);
 
-		List<UserReviewResponse> reviews = userService.searchUserReviewsByUserIdAndRelationType(testData.hoi.getId(), loginUser);
+		List<ReviewDetailResponse> reviews = userService.searchUserReviewsByUserIdAndRelationType(testData.hoi.getId(), loginUser);
 
 		assertThat(reviews).hasSize(2);
 	}
@@ -55,7 +55,7 @@ class UserReviewsSearchByUserIdIntegrationTest extends InitIntegrationTest {
 	void user_search_user_reviews_success() {
 		LoginUser loginUser = new LoginUser(testData.hoi.getId(), Authority.USER);
 
-		List<UserReviewResponse> reviews = userService.searchUserReviewsByUserIdAndRelationType(testData.hoi.getId(), loginUser);
+		List<ReviewDetailResponse> reviews = userService.searchUserReviewsByUserIdAndRelationType(testData.hoi.getId(), loginUser);
 
 		assertThat(reviews).hasSize(3);
 	}
@@ -76,7 +76,7 @@ class UserReviewsSearchByUserIdIntegrationTest extends InitIntegrationTest {
 	void search_empty_user_reviews_failed() {
 		LoginUser loginUser = new LoginUser(Authority.ANONYMOUS);
 
-		List<UserReviewResponse> reviews = userService.searchUserReviewsByUserIdAndRelationType(
+		List<ReviewDetailResponse> reviews = userService.searchUserReviewsByUserIdAndRelationType(
 			testData.jay.getId(), loginUser);
 
 		assertThat(reviews).isEmpty();


### PR DESCRIPTION
### ❗️ 이슈 번호

[SDR-297]

<br><br>

### 📝 구현 내용

- 유저의 리뷰목록 api의 응답값에 스토어 정보 추가
- 기능을 UserService -> ReviewService로 이동
- 페이징 추가

### 변경된 API

<img width="700" alt="Screen Shot 2022-09-13 at 17 41 23" src="https://user-images.githubusercontent.com/57708971/189854831-cabdf2f3-6b61-4098-b5bb-3d8c9e7d0ba2.png">

<img width="600" alt="Screen Shot 2022-09-13 at 17 24 21" src="https://user-images.githubusercontent.com/57708971/189854862-36c8c74f-8145-462d-8012-efc0475b2a43.png">


[SDR-297]: https://jjikmuk.atlassian.net/browse/SDR-297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ