### PR TITLE
[SDR-306] BE: 런타임에 NullPointerException 이 발생할 수 있는 부분 개선

### DIFF
--- a/be/src/main/java/com/jjikmuk/sikdorak/common/controller/CursorPageableArgumentResolver.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/controller/CursorPageableArgumentResolver.java
@@ -2,7 +2,7 @@ package com.jjikmuk.sikdorak.common.controller;
 
 import com.jjikmuk.sikdorak.common.controller.request.CursorPageRequest;
 import com.jjikmuk.sikdorak.common.exception.InvalidPageParameterException;
-import com.jjikmuk.sikdorak.common.exception.UnsupportedParameterTypeException;
+import com.jjikmuk.sikdorak.common.exception.SikdorakServerError;
 import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
@@ -36,17 +36,23 @@ public class CursorPageableArgumentResolver implements HandlerMethodArgumentReso
 		validateBeforeAfterParameter(beforeParam, afterParam);
 
 		// before, after, size 파싱
+		CursorPageable annotation = parameter.getParameterAnnotation(CursorPageable.class);
+        
+        if (annotation == null) {
+			throw new SikdorakServerError();
+        }
+
 		return new CursorPageRequest(
 			getCursorOrNull(beforeParam),
 			getCursorOrNull(afterParam),
-			getSizeOrDefault(webRequest, parameter.getParameterAnnotation(CursorPageable.class)),
+			getSizeOrDefault(webRequest, annotation),
 			(afterParam != null)
 		);
 	}
 
 	private void validateParameter(MethodParameter parameter) {
 		if (!parameter.getParameterType().equals(CursorPageRequest.class)) {
-			 throw new UnsupportedParameterTypeException();
+			 throw new SikdorakServerError();
 		}
 	}
 

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/exception/ExceptionCodeAndMessages.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/exception/ExceptionCodeAndMessages.java
@@ -47,7 +47,7 @@ import lombok.Getter;
 public enum ExceptionCodeAndMessages implements CodeAndMessages {
     NOT_FOUND_ERROR_CODE("F-G001", "에러 코드를 찾을 수 없습니다.", NotFoundErrorCodeException.class),
     INVALID_PAGE_PARAMETER("F-G002", "유효하지 않은 페이징 값 입니다.", InvalidPageParameterException.class),
-    INTERNAL_SERVER_ERROR("F-G003", "서버 에러입니다.(관리자에게 문의하세요)", UnsupportedParameterTypeException.class),
+    INTERNAL_SERVER_ERROR("F-G003", "서버 에러입니다.(관리자에게 문의하세요)", SikdorakServerError.class),
 
     // Review
     INVALID_REVIEW_CONTENT("F-R001", "유효하지 않은 리뷰 컨텐츠 입니다.", InvalidReviewContentException.class),

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/exception/SikdorakServerError.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/exception/SikdorakServerError.java
@@ -2,7 +2,7 @@ package com.jjikmuk.sikdorak.common.exception;
 
 import org.springframework.http.HttpStatus;
 
-public class UnsupportedParameterTypeException extends SikdorakRuntimeException {
+public class SikdorakServerError extends SikdorakRuntimeException {
 
 	@Override
 	public HttpStatus getHttpStatus() {


### PR DESCRIPTION
### ❗️ 이슈 번호

[SDR-306]

<br><br>

### 📝 구현 내용

- CursorPageableArgumentResolver 에서 런타임에 NullPointerException 발생할 수 있는 부분 개선

<br><br>

### 💡 참고 자료

- https://sonarcloud.io/project/issues?issues=AYLtgDERVz8vUTF3_QKf&open=AYLtgDERVz8vUTF3_QKf&id=jjik-muk_sikdorak

![image](https://user-images.githubusercontent.com/45728407/190107448-ffeead5a-6554-4399-90b0-d6cacf3859d0.png)

[SDR-306]: https://jjikmuk.atlassian.net/browse/SDR-306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ