### PR TITLE
[SDR-310] BE : 위치기반 근처 가게목록 조회 API 문서에 x,y,radius에 대한 범위설명 추가

### DIFF
--- a/be/src/test/java/com/jjikmuk/sikdorak/documentationtest/store/StoreSnippet.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/documentationtest/store/StoreSnippet.java
@@ -269,9 +269,9 @@ public interface StoreSnippet {
 		private static final String CONTACT_NUMBER_DESCRIPTION = "가게 연락처";
 		private static final String ADDRESS_NAME_DESCRIPTION = "지번 주소";
 		private static final String ROAD_ADDRESS_NAME_DESCRIPTION = "도로명 주소";
-		private static final String Y_DESCRIPTION = "위도";
-		private static final String X_DESCRIPTION = "경도";
-		private static final String RADIUS_DESCRIPTION = "위치 반경";
+		private static final String Y_DESCRIPTION = "위도(최대값: 90.0 / 최소값: -90.0)";
+		private static final String X_DESCRIPTION = "경도(최대값: 180.0 / 최소값: -180.0)";
+		private static final String RADIUS_DESCRIPTION = "위치 반경(최대값: 100 / 최소값: 20000)";
 		private static final String KAKAO_PLACE_ID_DESCRIPTION = "API 에서 제공된 장소 ID";
 		private static final String REQUEST_PAGE_TYPE_DESCRIPTION = "요청하는 페이지 타입 - feed | maps 로 나뉩니다.";
 		private static final String REVIEW_SCORE_AVERAGE = "가게의 리뷰 평균 점수 입니다.";


### PR DESCRIPTION
### ❗️ 이슈 번호

[SDR-310]

<br><br>

### 📝 구현 내용

- api 문서에 x,y,radius값에 대한 범위 설명 추가
- dev.yml 파일에 액세스 토큰 만료시간을 30분으로 변경

<br><br>

### 💡 참고 자료
<img width="991" alt="Screen Shot 2022-09-15 at 12 20 10" src="https://user-images.githubusercontent.com/57708971/190306199-c4cfe5b0-9119-4c05-9bdd-1d15b3807ded.png">



[SDR-310]: https://jjikmuk.atlassian.net/browse/SDR-310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ