### PR TITLE
[SDR-313] BE : 위치기반 근처 가게목록 조회 시 페이징에 last값 수정

### DIFF
--- a/be/src/main/java/com/jjikmuk/sikdorak/store/service/StoreService.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/service/StoreService.java
@@ -104,7 +104,7 @@ public class StoreService {
 			Pageable.ofSize(cursorPageRequest.getSize()));
 
 		List<StoreRadiusSearchResponse> storeListResponse = getStoreListResponse(stores);
-		CursorPageResponse cursorPageResponse = getCursorPageResponse(storeListResponse);
+		CursorPageResponse cursorPageResponse = getCursorPageResponse(storeListResponse, cursorPageRequest);
 
 		return StoreListByRadiusResponse.of(storeListResponse, cursorPageResponse);
 	}
@@ -233,14 +233,17 @@ public class StoreService {
 			.toList();
 	}
 
-	private CursorPageResponse getCursorPageResponse(List<StoreRadiusSearchResponse> storeListResponse) {
+	private CursorPageResponse getCursorPageResponse(List<StoreRadiusSearchResponse> storeListResponse,
+		CursorPageRequest cursorPageRequest) {
 
 		if (storeListResponse.isEmpty()) {
 			return new CursorPageResponse(0, 0L, 0L, true);
 		}
 
+		boolean isLast = cursorPageRequest.getSize() > storeListResponse.size();
+
 		return new CursorPageResponse(storeListResponse.size(), 0L,
-			storeListResponse.get(storeListResponse.size() - 1).id());
+			storeListResponse.get(storeListResponse.size() - 1).id(), isLast);
 	}
 
 	private void validateCursorRequest(CursorPageRequest cursorPageRequest) {


### PR DESCRIPTION
### ❗️ 이슈 번호

[SDR-313]

<br><br>

### 📝 구현 내용

- 위치기반 근처 가게목록 조회 시 데이터가 요청한 페이지 사이즈보다 적을경우 last값을 true로 반환하도록 로직 수정




[SDR-313]: https://jjikmuk.atlassian.net/browse/SDR-313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ