### PR TITLE
[SDR-275] FE : 작성자, 가게 클릭하면 해당 상세페이지로 이동

### DIFF
--- a/fe/src/components/Map/Store/Store.styled.tsx
+++ b/fe/src/components/Map/Store/Store.styled.tsx
@@ -7,4 +7,5 @@ export const Wrap = styled.div`
   gap: 5px;
   ${STYLE.BOX_CONTAINER}
   padding: 10px;
+  cursor: pointer;
 `;

--- a/fe/src/components/Map/Store/Store.tsx
+++ b/fe/src/components/Map/Store/Store.tsx
@@ -1,8 +1,14 @@
+import { useNavigate } from 'react-router-dom';
 import { Wrap } from './Store.styled';
 
-function Store({ storeName, contactNumber, roadAddressName }: any) {
+function Store({ id, storeName, contactNumber, roadAddressName }: any) {
+  const navigate = useNavigate();
   return (
-    <Wrap>
+    <Wrap
+      onClick={() => {
+        navigate(`/store/${id}`);
+      }}
+    >
       <div>{storeName}</div>
       <div>{contactNumber}</div>
       <div>{roadAddressName}</div>

--- a/fe/src/components/ReviewDetail/Comment/Comment.styled.ts
+++ b/fe/src/components/ReviewDetail/Comment/Comment.styled.ts
@@ -11,6 +11,7 @@ export const Picture = styled.img`
   width: 42px;
   height: 42px;
   border-radius: 50%;
+  cursor: pointer;
 `;
 
 export const CommentWrapper = styled.div`
@@ -28,6 +29,7 @@ export const Title = styled.div`
   font-size: 18px;
   font-weight: 500;
   margin-top: 5px;
+  cursor: pointer;
 `;
 
 export const Content = styled.div`

--- a/fe/src/components/ReviewDetail/Comment/Comment.styled.ts
+++ b/fe/src/components/ReviewDetail/Comment/Comment.styled.ts
@@ -10,6 +10,7 @@ export const Wrap = styled.div`
 export const Picture = styled.img`
   width: 42px;
   height: 42px;
+  border-radius: 50%;
 `;
 
 export const CommentWrapper = styled.div`

--- a/fe/src/components/ReviewDetail/Comment/Comment.tsx
+++ b/fe/src/components/ReviewDetail/Comment/Comment.tsx
@@ -1,19 +1,18 @@
-import { useState } from 'react';
-import { Wrap, Picture, Title, Content, ContentWrapper, ButtonWrapper, Button, CommentWrapper } from './Comment.styled';
+import { Wrap, Picture, Title, Content, ContentWrapper, CommentWrapper } from './Comment.styled';
 
 const DEFAULT_IMG_URL = 'https://flyclipart.com/thumb2/profile-user-png-icon-free-download-196388.png';
 
-function Comment({ imgUrl = DEFAULT_IMG_URL, title = '식도락', content = '댓글 달아 봤습니다.' }: CommentProps) {
-  const [isActiveAdditionComment, setIsActiveAdditionComment] = useState(false);
-  const [commentCnt, setCommentCnt] = useState(0);
+function Comment({ imgUrl = DEFAULT_IMG_URL, title, content }: CommentProps) {
+  // const [isActiveAdditionComment, setIsActiveAdditionComment] = useState(false);
+  // const [commentCnt, setCommentCnt] = useState(0);
 
-  const clickComment = (type?: string) => {
-    if (type === 'ADD') {
-      setCommentCnt(commentCnt + 1);
-      return;
-    }
-    setCommentCnt(commentCnt - 1);
-  };
+  // const clickComment = (type?: string) => {
+  //   if (type === 'ADD') {
+  //     setCommentCnt(commentCnt + 1);
+  //     return;
+  //   }
+  //   setCommentCnt(commentCnt - 1);
+  // };
 
   return (
     <Wrap>
@@ -23,25 +22,25 @@ function Comment({ imgUrl = DEFAULT_IMG_URL, title = '식도락', content = '댓
           <Title>{title}</Title>
           <Content>{content}</Content>
         </ContentWrapper>
-        <ButtonWrapper>
+        {/* <ButtonWrapper>
           {commentCnt ? (
             <Button onClick={() => clickComment()}>{commentCnt} 좋아요</Button>
           ) : (
             <Button onClick={() => clickComment('ADD')}>좋아요</Button>
           )}
           <Button onClick={handleAdditionComment}>댓글 추가</Button>
-        </ButtonWrapper>
+        </ButtonWrapper> */}
       </CommentWrapper>
     </Wrap>
   );
 
-  function handleAdditionComment() {
-    if (isActiveAdditionComment) {
-      setIsActiveAdditionComment(false);
-      return;
-    }
-    setIsActiveAdditionComment(true);
-  }
+  // function handleAdditionComment() {
+  //   if (isActiveAdditionComment) {
+  //     setIsActiveAdditionComment(false);
+  //     return;
+  //   }
+  //   setIsActiveAdditionComment(true);
+  // }
 }
 
 export default Comment;

--- a/fe/src/components/ReviewDetail/Comment/Comment.tsx
+++ b/fe/src/components/ReviewDetail/Comment/Comment.tsx
@@ -1,8 +1,10 @@
+import { useNavigate } from 'react-router-dom';
 import { Wrap, Picture, Title, Content, ContentWrapper, CommentWrapper } from './Comment.styled';
 
 const DEFAULT_IMG_URL = 'https://flyclipart.com/thumb2/profile-user-png-icon-free-download-196388.png';
 
-function Comment({ imgUrl = DEFAULT_IMG_URL, title, content }: CommentProps) {
+function Comment({ imgUrl = DEFAULT_IMG_URL, title, content, authorId }: CommentProps) {
+  const navigate = useNavigate();
   // const [isActiveAdditionComment, setIsActiveAdditionComment] = useState(false);
   // const [commentCnt, setCommentCnt] = useState(0);
 
@@ -16,10 +18,21 @@ function Comment({ imgUrl = DEFAULT_IMG_URL, title, content }: CommentProps) {
 
   return (
     <Wrap>
-      <Picture src={imgUrl} />
+      <Picture
+        src={imgUrl}
+        onClick={() => {
+          navigate(`/user/${authorId}`);
+        }}
+      />
       <CommentWrapper>
         <ContentWrapper>
-          <Title>{title}</Title>
+          <Title
+            onClick={() => {
+              navigate(`/user/${authorId}`);
+            }}
+          >
+            {title}
+          </Title>
           <Content>{content}</Content>
         </ContentWrapper>
         {/* <ButtonWrapper>
@@ -49,4 +62,5 @@ type CommentProps = {
   imgUrl?: string;
   title?: string;
   content?: string;
+  authorId?: number;
 };

--- a/fe/src/components/ReviewDetail/RestaurantProfile/RestaurantProfile.tsx
+++ b/fe/src/components/ReviewDetail/RestaurantProfile/RestaurantProfile.tsx
@@ -1,10 +1,18 @@
+import { useNavigate } from 'react-router-dom';
 import { CompanyName, Picture, Wrap, Region } from './RestaurantProfile.styled';
 
 const DEFAULT_IMG_URL = 'https://flyclipart.com/thumb2/profile-user-png-icon-free-download-196388.png';
 
-function RestaurantProfile({ imgUrl = DEFAULT_IMG_URL, company, region }: RestaurantProfileProps) {
+function RestaurantProfile({ imgUrl = DEFAULT_IMG_URL, company, region, storeId }: RestaurantProfileProps) {
+  const navigate = useNavigate();
+
   return (
-    <Wrap>
+    <Wrap
+      onClick={(e) => {
+        e.stopPropagation();
+        navigate(`/store/${storeId}`);
+      }}
+    >
       <Picture src={imgUrl} />
       <div>
         <CompanyName>{company}</CompanyName>
@@ -20,4 +28,5 @@ type RestaurantProfileProps = {
   imgUrl?: string;
   company: string;
   region: string;
+  storeId?: number;
 };

--- a/fe/src/components/ReviewDetail/UserProfile/UserProfile.tsx
+++ b/fe/src/components/ReviewDetail/UserProfile/UserProfile.tsx
@@ -1,10 +1,18 @@
+import { useNavigate } from 'react-router-dom';
 import { Nickname, Picture, Wrap } from './UserProfile.styled';
 
 const DEFAULT_IMG_URL = 'https://flyclipart.com/thumb2/profile-user-png-icon-free-download-196388.png';
 
-function UserProfile({ imgUrl = DEFAULT_IMG_URL, nickname }: UserProfileProps) {
+function UserProfile({ imgUrl = DEFAULT_IMG_URL, nickname, userId }: UserProfileProps) {
+  const navigate = useNavigate();
+
   return (
-    <Wrap>
+    <Wrap
+      onClick={(e) => {
+        e.stopPropagation();
+        navigate(`/user/${userId}`);
+      }}
+    >
       <Picture src={imgUrl} />
       <Nickname>{nickname}</Nickname>
     </Wrap>
@@ -16,4 +24,5 @@ export default UserProfile;
 type UserProfileProps = {
   imgUrl?: string;
   nickname: string;
+  userId?: number;
 };

--- a/fe/src/components/ReviewList/Feed/Feed.tsx
+++ b/fe/src/components/ReviewList/Feed/Feed.tsx
@@ -55,7 +55,7 @@ function Feed({
       <Wrap onClick={toggleIsClikedFeed}>
         <ContentsWrap wrapWidth={isUsedMapPage ? 500 : DETAIL.WRAP.WIDTH_NO_IMG}>
           <Header>
-            <UserProfile nickname={user?.userNickname} />
+            <UserProfile nickname={user?.userNickname} imgUrl={user?.userProfileImage} userId={user?.userId} />
             <MenuWrap onClick={handleMenu}>
               {isMyFeed && <Icon icon="MenuBtn" />}
               {isActiveMenu && <Menu menuRef={menuRef} reviewId={reviewId} />}
@@ -77,7 +77,7 @@ function Feed({
             </Pictures>
             <Rating rating={reviewScore} />
             <MainFooter>
-              <CompnayProfile company={store?.storeName} region={store?.storeAddress} />
+              <CompnayProfile company={store?.storeName} region={store?.storeAddress} storeId={store?.storeId} />
             </MainFooter>
           </Main>
           <ButtonWrapper>

--- a/fe/src/components/ReviewWrite/Tag/TagList/TagList.styled.ts
+++ b/fe/src/components/ReviewWrite/Tag/TagList/TagList.styled.ts
@@ -11,6 +11,7 @@ export const Wrap = styled.div`
 export const Picture = styled.img`
   width: 42px;
   height: 42px;
+  border-radius: 50%;
 `;
 
 export const CommentWrapper = styled.div`

--- a/fe/src/hooks/useAuth.tsx
+++ b/fe/src/hooks/useAuth.tsx
@@ -17,7 +17,7 @@ function useAuth() {
 
     async function isValidAccessToken() {
       const res = await fetchDataThatNeedToLogin('api/users/me');
-      return res.code === 'F-O003';
+      return res.code === 'F-O003' || res.code === 'F-O004';
     }
   }, []);
 }

--- a/fe/src/pages/ReviewDetail/ReviewDetail.tsx
+++ b/fe/src/pages/ReviewDetail/ReviewDetail.tsx
@@ -50,7 +50,7 @@ function ReviewDetail({
       {hasPicture && <Carousel urls={images} />}
       <ContentsWrap wrapWidth={wrapWidth}>
         <Header>
-          <Profile nickname={user?.userNickname} />
+          <Profile nickname={user?.userNickname} imgUrl={user?.userProfileImage} userId={user?.userId} />
           <div onClick={toggleIsActiveMenu}>
             <Icon icon="MenuBtn" />
             {isActiveMenu && <Menu menuRef={menuRef} reviewId={reviewId} />}
@@ -60,7 +60,7 @@ function ReviewDetail({
           <Contents>{reviewContent}</Contents>
           <Rating rating={reviewScore} />
           <MainFooter>
-            <CompnayProfile company={store?.storeName} region={store?.storeAddress} />
+            <CompnayProfile company={store?.storeName} region={store?.storeAddress} storeId={store?.storeId} />
           </MainFooter>
         </Main>
         <ButtonWrapper>
@@ -81,9 +81,11 @@ function ReviewDetail({
             </IconWrap>
           </div>
         </ButtonWrapper>
-        <TagList tags={tags} />
+        <TagList tags={tags} imgUrl={user.userProfileImage} />
         {comments &&
-          comments.map(({ author, content, id }) => <Comment key={id} title={author.nickname} content={content} />)}
+          comments.map(({ author, content, id }) => (
+            <Comment key={id} title={author.nickname} content={content} imgUrl={author.profileImage} />
+          ))}
         {hasNextComments && (
           <button onClick={fetchNextComment} type="button">
             댓글 더보기

--- a/fe/src/pages/ReviewDetail/ReviewDetail.tsx
+++ b/fe/src/pages/ReviewDetail/ReviewDetail.tsx
@@ -84,7 +84,13 @@ function ReviewDetail({
         <TagList tags={tags} imgUrl={user.userProfileImage} />
         {comments &&
           comments.map(({ author, content, id }) => (
-            <Comment key={id} title={author.nickname} content={content} imgUrl={author.profileImage} />
+            <Comment
+              key={id}
+              authorId={author.id}
+              title={author.nickname}
+              content={content}
+              imgUrl={author.profileImage}
+            />
           ))}
         {hasNextComments && (
           <button onClick={fetchNextComment} type="button">

--- a/fe/src/pages/ReviewDetail/ReviewDetail.tsx
+++ b/fe/src/pages/ReviewDetail/ReviewDetail.tsx
@@ -36,7 +36,7 @@ function ReviewDetail({
   const [comments, setComments] = useState([]);
   const [afterParam, setAfterParam] = useState(0);
   const COMMENT_SIZE = 2;
-  const hasNextComments = afterParam !== 1 && comments.length > 0;
+  const [hasNextComments, setHasNextComments] = useState(true);
   const menuRef = useRef(null);
   useOutsideClick(menuRef, toggleIsActiveMenu);
   useAuth();
@@ -106,7 +106,7 @@ function ReviewDetail({
     const commentRes = await fetchDataThatNeedToLogin(
       `api/reviews/${reviewId}/comments?size=${COMMENT_SIZE}&after=${afterParam}`,
     );
-
+    setHasNextComments(!commentRes.data.page.last);
     if (!commentRes.data) return;
 
     const nextComments = commentRes.data.comments;


### PR DESCRIPTION
### 📝 구현 내용

- 지도의 가게 리스트 클릭하면 가게 상세페이지로 이동
- 태그 리스트, 댓글 작성자, 리뷰 작성자 프로필 사진 연동
- 댓글 작성자, 프사 클릭하면 해당 유저 디테일 페이지로 이동
- 댓글 더보기 버튼 로직 변경(response의 last 값을 참조)