### PR TITLE
[SDR-319] BE : 리뷰목록 조회 시 페이징 커서 초기화를 maxId로 하도록 수정 및 리뷰의 좋아요 정보 수정

### DIFF
--- a/be/src/main/java/com/jjikmuk/sikdorak/review/controller/response/reviewdetail/ReviewDetailResponse.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/controller/response/reviewdetail/ReviewDetailResponse.java
@@ -2,10 +2,12 @@ package com.jjikmuk.sikdorak.review.controller.response.reviewdetail;
 
 import com.jjikmuk.sikdorak.review.domain.Review;
 import com.jjikmuk.sikdorak.store.domain.Store;
+import com.jjikmuk.sikdorak.user.auth.controller.LoginUser;
 import com.jjikmuk.sikdorak.user.user.domain.User;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
@@ -55,11 +57,12 @@ public record ReviewDetailResponse(
 	LocalDateTime updatedAt
 ) {
 
-	public static ReviewDetailResponse of(Review review, Store store, User user) {
+	public static ReviewDetailResponse of(Review review, Store store, User author, LoginUser loginUser) {
+		boolean likeStatus = !Objects.isNull(loginUser.getId()) && review.isLikedBy(loginUser.getId());
 		return new ReviewDetailResponse(
-			new ReviewDetailUserResponse(user),
+			new ReviewDetailUserResponse(author),
 			new ReviewDetailStoreResponse(store),
-			new ReviewDetailLikeResponse(review.getLikesCount(), review.isLikedBy(user.getId())),
+			new ReviewDetailLikeResponse(review.getLikesCount(), likeStatus),
 			review.getId(),
 			review.getReviewContent(),
 			review.getReviewScore(),

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/repository/ReviewRepository.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/repository/ReviewRepository.java
@@ -81,6 +81,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
         @Param("targetId") long targetId,
         Pageable pageable);
 
-    @Query(value = "select count(*) from review" , nativeQuery = true)
-    long countAll();
+    @Query(value = "select max(review_id) from review", nativeQuery = true)
+    long findMaxId();
+
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/controller/StoreController.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/controller/StoreController.java
@@ -116,11 +116,12 @@ public class StoreController {
 	@GetMapping("/{storeId}/reviews")
 	public CommonResponseEntity<ReviewListResponse> searchStoreReviews(
 		@PathVariable long storeId,
+		@AuthenticatedUser LoginUser loginUser,
 		@CursorPageable CursorPageRequest cursorPageRequest
 	) {
 		return new CommonResponseEntity<>(
 			ResponseCodeAndMessages.STORE_SEARCH_REVIEW_SUCCESS,
-			reviewService.searchReviewsByStoreId(storeId, cursorPageRequest),
+			reviewService.searchReviewsByStoreId(storeId, loginUser, cursorPageRequest),
 			HttpStatus.OK);
 	}
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/review/ReviewsSearchByStoreIdIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/review/ReviewsSearchByStoreIdIntegrationTest.java
@@ -12,6 +12,8 @@ import com.jjikmuk.sikdorak.review.domain.ReviewVisibility;
 import com.jjikmuk.sikdorak.review.service.ReviewService;
 import com.jjikmuk.sikdorak.store.domain.Store;
 import com.jjikmuk.sikdorak.store.exception.NotFoundStoreException;
+import com.jjikmuk.sikdorak.user.auth.controller.LoginUser;
+import com.jjikmuk.sikdorak.user.user.domain.Authority;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -34,10 +36,11 @@ class ReviewsSearchByStoreIdIntegrationTest extends InitIntegrationTest {
             // given
             Store store = testData.store;
             CursorPageRequest pageRequest = new CursorPageRequest(0L, 0L, 10, true);
+            LoginUser loginUser = new LoginUser(Authority.ANONYMOUS);
 
             // when
             ReviewListResponse reviewResponse = reviewService.searchReviewsByStoreId(
-                store.getId(), pageRequest);
+                store.getId(), loginUser, pageRequest);
 
             // then
             assertThat(reviewResponse).isNotNull();
@@ -60,10 +63,12 @@ class ReviewsSearchByStoreIdIntegrationTest extends InitIntegrationTest {
             // given
             long notExistingStoreId = Long.MIN_VALUE;
             CursorPageRequest pageRequest = new CursorPageRequest(0L, 0L, 10, true);
+            LoginUser loginUser = new LoginUser(Authority.ANONYMOUS);
 
             // then
             assertThatThrownBy(
-                () -> reviewService.searchReviewsByStoreId(notExistingStoreId, pageRequest))
+                () -> reviewService.searchReviewsByStoreId(notExistingStoreId, loginUser,
+                    pageRequest))
                 .isInstanceOf(NotFoundStoreException.class);
         }
 
@@ -73,10 +78,11 @@ class ReviewsSearchByStoreIdIntegrationTest extends InitIntegrationTest {
             // given
             Store store = testData.store;
             CursorPageRequest pageRequest = new CursorPageRequest(0L, 0L, 10, true);
+            LoginUser loginUser = new LoginUser(Authority.ANONYMOUS);
 
             // when
             ReviewListResponse reviewResponse = reviewService.searchReviewsByStoreId(
-                store.getId(), pageRequest);
+                store.getId(), loginUser, pageRequest);
 
             // then
             assertThat(reviewResponse).isNotNull();

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserReviewsSearchByUserIdIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserReviewsSearchByUserIdIntegrationTest.java
@@ -49,7 +49,7 @@ class UserReviewsSearchByUserIdIntegrationTest extends InitIntegrationTest {
 	@Test
 	@DisplayName("친구인 유저가 특정 유저의 리뷰를 조회한다면 public|protected 리뷰들을 반환한다.")
 	void connection_user_search_user_reviews_success() {
-		long cursorPage = 10;
+		long cursorPage = 0;
 		int size = 5;
 		CursorPageRequest cursorPageRequest = new CursorPageRequest(0L, cursorPage, size, true);
 		LoginUser loginUser = new LoginUser(testData.forky.getId(), Authority.USER);


### PR DESCRIPTION
### ❗️ 이슈 번호

[SDR-319]

<br><br>

### 📝 구현 내용

- 리뷰목록 조회 시 페이징 커서를 count 대신 max쿼리를 사용해서 초기화하도록 수정
- 요청자의 좋아요 정보를 제공하도록 수정




[SDR-319]: https://jjikmuk.atlassian.net/browse/SDR-319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ