### PR TITLE
[SDR-360] BE : SonarCloud 규칙 수정과 Code Smells 제거

### DIFF
--- a/be/build.gradle
+++ b/be/build.gradle
@@ -51,6 +51,7 @@ dependencies {
     // Web
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'commons-validator:commons-validator:1.7'
 
     // Database
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/be/src/main/java/com/jjikmuk/sikdorak/comment/repository/CommentRepository.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/comment/repository/CommentRepository.java
@@ -27,6 +27,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 		@Param("before") long before,
 		Pageable pageable);
 
-//	@Query("select count(c.id) from Comment c where c.id < :lastItemId")
+	//	@Query("select count(c.id) from Comment c where c.id < :lastItemId")
 	long countAllByIdBefore(long id);
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/comment/service/CommentService.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/comment/service/CommentService.java
@@ -16,9 +16,9 @@ import com.jjikmuk.sikdorak.review.repository.ReviewRepository;
 import com.jjikmuk.sikdorak.user.auth.controller.LoginUser;
 import com.jjikmuk.sikdorak.user.user.domain.RelationType;
 import com.jjikmuk.sikdorak.user.user.domain.User;
-import com.jjikmuk.sikdorak.user.user.repository.UserRepository;
 import com.jjikmuk.sikdorak.user.user.exception.NotFoundUserException;
 import com.jjikmuk.sikdorak.user.user.exception.UnauthorizedUserException;
+import com.jjikmuk.sikdorak.user.user.repository.UserRepository;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -125,8 +125,6 @@ public class CommentService {
                 getCursorResponse(commentResponses, FIRST_CURSOR_ID, LAST_CURSOR_ID, pageRequest)
             );
         }
-
-        CommentSearchResponse lastCommentResponse = commentResponses.get(commentResponses.size() - 1);
 
         // 응답 객체 반환
         return new CommentSearchPagingResponse(

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/exception/SikdorakRuntimeException.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/exception/SikdorakRuntimeException.java
@@ -8,10 +8,10 @@ public abstract class SikdorakRuntimeException extends RuntimeException {
 
     private final ExceptionCodeAndMessages codeAndMessages = ExceptionCodeAndMessages.findByExceptionClass(getClass());
 
-    public SikdorakRuntimeException() {
+    protected SikdorakRuntimeException() {
     }
 
-    public SikdorakRuntimeException(Throwable cause) {
+    protected SikdorakRuntimeException(Throwable cause) {
         super(cause);
     }
 

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/domain/Image.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/domain/Image.java
@@ -2,20 +2,19 @@ package com.jjikmuk.sikdorak.review.domain;
 
 import com.jjikmuk.sikdorak.review.exception.InvalidReviewImageException;
 import java.util.Objects;
-import java.util.regex.Pattern;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.apache.commons.validator.routines.UrlValidator;
 
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class Image {
 
-    private static final String URL_REGEX
-        = "^(((https?|http?)://)(%[0-9A-Fa-f]{2}|[-()_.!~*';/?:@&=+$,A-Za-z0-9])+)([).!';/?:,][:blank])?$";
+    private static final UrlValidator urlValidator = new UrlValidator(new String[]{"http", "https"});
 
     @Column(name = "image_url")
     private String url;
@@ -31,6 +30,6 @@ public class Image {
 
     // TODO : 특정 s3 주소만 image로 들어올 수 있도록 수정 가능하다.
     private boolean validateUrlForm(String url) {
-        return Pattern.matches(URL_REGEX, url);
+        return urlValidator.isValid(url);
     }
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/domain/Images.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/domain/Images.java
@@ -4,7 +4,6 @@ import com.jjikmuk.sikdorak.review.exception.InvalidReviewImagesException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import javax.persistence.CollectionTable;
 import javax.persistence.ElementCollection;
 import javax.persistence.Embeddable;
@@ -37,7 +36,7 @@ public class Images {
 		List<Image> filteredImages = images.stream()
 			.distinct()
 			.map(Image::new)
-			.collect(Collectors.toList());
+			.toList();
 
 		if (filteredImages.size() > LIMIT_SIZE) {
 			throw new InvalidReviewImagesException();

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/domain/RecommendationType.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/domain/RecommendationType.java
@@ -3,20 +3,37 @@ package com.jjikmuk.sikdorak.review.domain;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+/**
+ * 리뷰 추천목록 조회 시 정렬 조건.
+ *
+ * @deprecated (서버에서 자체적으로 추천 조건을 설정하도록 수정하도록 변경됨)
+ */
 @Deprecated(since = "1.0", forRemoval = true)
 @Getter
 @NoArgsConstructor
 public enum RecommendationType {
 
     /**
-     * 리뷰 추천목록 조회 시 정렬 조건.
+     * 작성일 기준 추천.
      *
      * @deprecated (서버에서 자체적으로 추천 조건을 설정하도록 수정하도록 변경됨)
      */
     @Deprecated(since = "1.0", forRemoval = true)
     TIME("created_at"),
+
+    /**
+     * 좋아요 개수 기준 추천.
+     *
+     * @deprecated (서버에서 자체적으로 추천 조건을 설정하도록 수정하도록 변경됨)
+     */
     @Deprecated(since = "1.0", forRemoval = true)
     LIKE("like"),
+
+    /**
+     * 평점 기준 추천.
+     *
+     * @deprecated (서버에서 자체적으로 추천 조건을 설정하도록 수정하도록 변경됨)
+     */
     @Deprecated(since = "1.0", forRemoval = true)
     SCORE("review_score");
 

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/repository/ReviewRepository.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/repository/ReviewRepository.java
@@ -52,10 +52,10 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
         Pageable pageable);
 
     @Query("""
-        	select r from Review r
-        	where not r.reviewVisibility = 'PRIVATE'
-        	and r.id <= :targetId and r.userId <> :authorId
-        	order by r.id desc
+        select r from Review r
+        where not r.reviewVisibility = 'PRIVATE'
+        and r.id <= :targetId and r.userId <> :authorId
+        order by r.id desc
         """)
     List<Review> findPublicAndProtectedRecommendedReviewsInRecentOrder(
         @Param("authorId") long authorId,

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/service/ReviewService.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/service/ReviewService.java
@@ -19,9 +19,9 @@ import com.jjikmuk.sikdorak.store.repository.StoreRepository;
 import com.jjikmuk.sikdorak.user.auth.controller.LoginUser;
 import com.jjikmuk.sikdorak.user.user.domain.RelationType;
 import com.jjikmuk.sikdorak.user.user.domain.User;
-import com.jjikmuk.sikdorak.user.user.repository.UserRepository;
 import com.jjikmuk.sikdorak.user.user.exception.NotFoundUserException;
 import com.jjikmuk.sikdorak.user.user.exception.UnauthorizedUserException;
+import com.jjikmuk.sikdorak.user.user.repository.UserRepository;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -64,16 +64,6 @@ public class ReviewService {
         return ReviewDetailResponse.of(review, store, reviewOwner, loginUser);
     }
 
-    /*
-    TODO - 개선사항
-     [x] 비회원인 경우
-        [x] public 상태의 리뷰만 제공한다.
-        [x] 추천하는 피드들을 우선으로 준다. (좋아요 많은 순)
-     [] 회원인 경우
-        [x] public, protected 상태만 준다.
-        [] 친구들의 피드들을 우선으로 준다. (최신순)
-        [] 추천 조건을 변경해서 피드들을 따로 볼 수 있다. (비회원의 추천 피드와 동일하게)
-     */
     @Transactional(readOnly = true)
     public ReviewListResponse getRecentRecommendedReviews(LoginUser loginUser,
         CursorPageRequest cursorPageRequest) {

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/domain/StoreLocation.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/domain/StoreLocation.java
@@ -38,6 +38,6 @@ public class StoreLocation {
     }
 
     private boolean isNotInRange(double value, double min, double max) {
-        return !(min <= value) || !(value <= max);
+        return value < min || max < value;
     }
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/store/service/KakaoPlaceApiService.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/store/service/KakaoPlaceApiService.java
@@ -15,7 +15,6 @@ import com.jjikmuk.sikdorak.store.service.dto.PlaceResponse;
 import com.jjikmuk.sikdorak.store.service.dto.PlaceSearchRequest;
 import com.jjikmuk.sikdorak.store.service.dto.PlaceSearchResponse;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -57,7 +56,7 @@ public class KakaoPlaceApiService implements PlaceApiService {
 				place.getX(),
 				place.getY()
 			))
-			.collect(Collectors.toList());
+			.toList();
 	}
 
 	@Override

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/domain/Email.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/domain/Email.java
@@ -1,16 +1,15 @@
 package com.jjikmuk.sikdorak.user.user.domain;
 
 import com.jjikmuk.sikdorak.user.user.exception.InvalidUserEmailException;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import javax.persistence.Embeddable;
 import lombok.Getter;
+import org.apache.commons.validator.routines.EmailValidator;
 
 @Getter
 @Embeddable
 public class Email {
 
-    private static final String EMAIL_REGEX = "^[_a-z0-9-]+(.[_a-z0-9-]+)*@(?:\\w+\\.)+\\w+$";
+    private static final EmailValidator emailValidator = EmailValidator.getInstance();
 
     private String email;
 
@@ -19,15 +18,10 @@ public class Email {
     }
 
     public Email(String email) {
-        if (!isValidEmailForm(email)) {
+        if (!emailValidator.isValid(email)) {
             throw new InvalidUserEmailException();
         }
         this.email = email;
     }
 
-    private boolean isValidEmailForm(String email) {
-        Pattern pattern = Pattern.compile(EMAIL_REGEX);
-        Matcher matcher = pattern.matcher(email);
-        return matcher.matches();
-    }
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/domain/ProfileImage.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/domain/ProfileImage.java
@@ -2,19 +2,17 @@ package com.jjikmuk.sikdorak.user.user.domain;
 
 import com.jjikmuk.sikdorak.user.user.exception.InvalidUserProfileImageUrlException;
 import java.util.Objects;
-import java.util.regex.Pattern;
 import javax.persistence.Embeddable;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.apache.commons.validator.routines.UrlValidator;
 
 @Getter
 @NoArgsConstructor
 @Embeddable
 public class ProfileImage {
 
-    private static final String URL_REGEX
-        = "^(((https?|http?)://)(%[0-9A-Fa-f]{2}|[-()_.!~*';/?:@&=+$,A-Za-z0-9])+)([).!';/?:,][:blank])?$";
-
+    private static final UrlValidator urlValidator = new UrlValidator(new String[]{"http", "https"});
     private String profileImageUrl;
 
 
@@ -28,7 +26,7 @@ public class ProfileImage {
     }
 
     private boolean validateUrlForm(String profileImageUrl) {
-        return Pattern.matches(URL_REGEX, profileImageUrl);
+        return urlValidator.isValid(profileImageUrl);
     }
 
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/documentationtest/store/StoreSearchDocumentationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/documentationtest/store/StoreSearchDocumentationTest.java
@@ -19,7 +19,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
 @DisplayName("문서화 : Store 검색,조회")
-public class StoreSearchDocumentationTest extends InitDocumentationTest {
+class StoreSearchDocumentationTest extends InitDocumentationTest {
 
     @Test
     @DisplayName("가게를 이름으로 검색할때 조건에 맞는 가게가 있으면 가게 목록이 반환된다.")

--- a/be/src/test/java/com/jjikmuk/sikdorak/documentationtest/user/user/UserModifyDocumentationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/documentationtest/user/user/UserModifyDocumentationTest.java
@@ -25,7 +25,7 @@ class UserModifyDocumentationTest extends InitDocumentationTest {
         UserModifyRequest userModifyRequest = new UserModifyRequest(
             "포키",
             "forkyy@gmail.com",
-            "https://s3.amazon-test/test.jpg"
+            "https://s3.amazon-test.com/test.jpg"
         );
 
         given(this.spec)

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/comment/CommentModifyIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/comment/CommentModifyIntegrationTest.java
@@ -12,6 +12,7 @@ import com.jjikmuk.sikdorak.integration.InitIntegrationTest;
 import com.jjikmuk.sikdorak.review.domain.Review;
 import com.jjikmuk.sikdorak.review.exception.NotFoundReviewException;
 import com.jjikmuk.sikdorak.review.repository.ReviewRepository;
+import com.jjikmuk.sikdorak.user.auth.controller.LoginUser;
 import com.jjikmuk.sikdorak.user.user.domain.User;
 import com.jjikmuk.sikdorak.user.user.exception.UnauthorizedUserException;
 import org.junit.jupiter.api.DisplayName;
@@ -22,116 +23,123 @@ import org.springframework.beans.factory.annotation.Autowired;
 @DisplayName("통합 : Comment 수정")
 class CommentModifyIntegrationTest extends InitIntegrationTest {
 
-	@Autowired
-	private CommentService commentService;
+    @Autowired
+    private CommentService commentService;
 
-	@Autowired
-	private CommentRepository commentRepository;
+    @Autowired
+    private CommentRepository commentRepository;
 
-	@Autowired
-	private ReviewRepository reviewRepository;
+    @Autowired
+    private ReviewRepository reviewRepository;
 
-	@Nested
-	@DisplayName("댓글을 수정할 때")
-	class ModifyCommentTest {
+    @Nested
+    @DisplayName("댓글을 수정할 때")
+    class ModifyCommentTest {
 
-		@Test
-		@DisplayName("정상적인 댓글 수정 요청이 주어진다면, 댓글이 수정된다.")
-		void create_comment_success() {
-			// given
-			Review review = testData.user1PublicReview;
-			User user1 = testData.forky;
-			Comment comment = testData.generator.comment(review, user1, "잘보고가요");
-			String updatedContent = "정말 맛있겠네요";
+        @Test
+        @DisplayName("정상적인 댓글 수정 요청이 주어진다면, 댓글이 수정된다.")
+        void create_comment_success() {
+            // given
+            Review review = testData.user1PublicReview;
+            User user1 = testData.forky;
+            Comment comment = testData.generator.comment(review, user1, "잘보고가요");
+            String updatedContent = "정말 맛있겠네요";
 
-			// when
-			commentService.modifyComment(review.getId(),
-				comment.getId(),
-				testData.generator.createLoginUserWithUserId(user1.getId()),
-				new CommentModifyRequest(updatedContent)
-			);
+            // when
+            commentService.modifyComment(review.getId(),
+                comment.getId(),
+                testData.generator.createLoginUserWithUserId(user1.getId()),
+                new CommentModifyRequest(updatedContent)
+            );
 
-			// then
-			Comment updatedComment = commentRepository.findById(comment.getId()).orElseThrow();
-			assertThat(updatedComment.getId()).isEqualTo(comment.getId());
-			assertThat(updatedComment.getUserId()).isEqualTo(comment.getUserId());
-			assertThat(updatedComment.getReviewId()).isEqualTo(comment.getReviewId());
-			assertThat(updatedComment.getCommentContent()).isEqualTo(updatedContent);
-		}
+            // then
+            Comment updatedComment = commentRepository.findById(comment.getId()).orElseThrow();
+            assertThat(updatedComment.getId()).isEqualTo(comment.getId());
+            assertThat(updatedComment.getUserId()).isEqualTo(comment.getUserId());
+            assertThat(updatedComment.getReviewId()).isEqualTo(comment.getReviewId());
+            assertThat(updatedComment.getCommentContent()).isEqualTo(updatedContent);
+        }
 
-		@Test
-		@DisplayName("삭제 처리된 리뷰에 대해 댓글 수정 요청이 주어진다면 예외를 발생시킨다")
-		void modify_comment_with_deleted_review_will_failed() {
-			// given
-			Review review = testData.user1PublicReview;
-			User user1 = testData.forky;
-			Comment comment = testData.generator.comment(review, user1, "잘보고가요");
+        @Test
+        @DisplayName("삭제 처리된 리뷰에 대해 댓글 수정 요청이 주어진다면 예외를 발생시킨다")
+        void modify_comment_with_deleted_review_will_failed() {
+            // given
+            Review review = testData.user1PublicReview;
+            User user1 = testData.forky;
+            Comment comment = testData.generator.comment(review, user1, "잘보고가요");
+            Long reviewId = review.getId();
+            Long commentId = comment.getId();
+            LoginUser loginUser = testData.generator.createLoginUserWithUserId(user1.getId());
+            CommentModifyRequest modifyRequest = new CommentModifyRequest("맛집이네요!");
 
-			reviewRepository.delete(review);
+            reviewRepository.delete(review);
 
-			// then
-			assertThatThrownBy(
-				() -> commentService.modifyComment(review.getId(),
-					comment.getId(),
-					testData.generator.createLoginUserWithUserId(user1.getId()),
-					new CommentModifyRequest("맛집이네요!")
-				))
-				.isInstanceOf(NotFoundReviewException.class);
-		}
+            // then
+            assertThatThrownBy(() -> commentService.modifyComment(reviewId,
+                commentId,
+                loginUser,
+                modifyRequest))
+                .isInstanceOf(NotFoundReviewException.class);
+        }
 
-		@Test
-		@DisplayName("존재하지 않는 댓글에 대해 수정 요청이 주어진다면 예외를 발생시킨다")
-		void modify_comment_with_not_existing_comment_will_failed() {
-			// given
-			Review review = testData.user1PublicReview;
-			User user1 = testData.forky;
-			long notExistingCommentId = Long.MIN_VALUE;
+        @Test
+        @DisplayName("존재하지 않는 댓글에 대해 수정 요청이 주어진다면 예외를 발생시킨다")
+        void modify_comment_with_not_existing_comment_will_failed() {
+            // given
+            Review review = testData.user1PublicReview;
+            User user1 = testData.forky;
+            long notExistingCommentId = Long.MIN_VALUE;
+            Long reviewId = review.getId();
+            LoginUser loginUser = testData.generator.createLoginUserWithUserId(user1.getId());
+            CommentModifyRequest modifyRequest = new CommentModifyRequest("맛집이네요!");
 
-			// then
-			assertThatThrownBy(
-				() -> commentService.modifyComment(review.getId(),
-					notExistingCommentId,
-					testData.generator.createLoginUserWithUserId(user1.getId()),
-					new CommentModifyRequest("맛집이네요!")
-				))
-				.isInstanceOf(NotFoundCommentException.class);
-		}
+            // then
+            assertThatThrownBy(() -> commentService.modifyComment(reviewId,
+                notExistingCommentId,
+                loginUser,
+                modifyRequest))
+                .isInstanceOf(NotFoundCommentException.class);
+        }
 
-		@Test
-		@DisplayName("삭제 처리된 댓글에 대해 수정 요청이 주어진다면 예외를 발생시킨다")
-		void modify_comment_with_deleted_comment_will_failed() {
-			// given
-			Review review = testData.user1PublicReview;
-			User user1 = testData.forky;
-			Comment comment = testData.generator.comment(review, user1, "잘보고가요");
-			commentRepository.delete(comment);
+        @Test
+        @DisplayName("삭제 처리된 댓글에 대해 수정 요청이 주어진다면 예외를 발생시킨다")
+        void modify_comment_with_deleted_comment_will_failed() {
+            // given
+            Review review = testData.user1PublicReview;
+            User user1 = testData.forky;
+            Comment comment = testData.generator.comment(review, user1, "잘보고가요");
+            commentRepository.delete(comment);
+            Long reviewId = review.getId();
+            Long commentId = comment.getId();
+            LoginUser loginUser = testData.generator.createLoginUserWithUserId(user1.getId());
+            CommentModifyRequest modifyRequest = new CommentModifyRequest("맛집이네요!");
 
-			// then
-			assertThatThrownBy(
-				() -> commentService.modifyComment(review.getId(),
-					comment.getId(),
-					testData.generator.createLoginUserWithUserId(user1.getId()),
-					new CommentModifyRequest("맛집이네요!")
-				))
-				.isInstanceOf(NotFoundCommentException.class);
-		}
+            // then
+            assertThatThrownBy(() -> commentService.modifyComment(reviewId,
+                commentId,
+                loginUser,
+                modifyRequest))
+                .isInstanceOf(NotFoundCommentException.class);
+        }
 
-		@Test
-		@DisplayName("유저가 본인이 작성한 댓글이 아닌데 수정 요청을 한다면 예외를 발생시킨다")
-		void modify_comment_with_not_autor_will_failed() {
-			// given
-			Review review = testData.user1PublicReview;
-			User user1 = testData.forky;
-			Comment comment = testData.generator.comment(review, user1, "잘보고가요");
+        @Test
+        @DisplayName("유저가 본인이 작성한 댓글이 아닌데 수정 요청을 한다면 예외를 발생시킨다")
+        void modify_comment_with_not_autor_will_failed() {
+            // given
+            Review review = testData.user1PublicReview;
+            User user1 = testData.forky;
+            Comment comment = testData.generator.comment(review, user1, "잘보고가요");
+            Long reviewId = review.getId();
+            Long commentId = comment.getId();
+            LoginUser loginUser = testData.generator.createLoginUserWithUserId(testData.kukim.getId());
+            CommentModifyRequest modifyRequest = new CommentModifyRequest("맛집이네요!");
 
-			// then
-			assertThatThrownBy(
-				() -> commentService.modifyComment(review.getId(),
-					comment.getId(),
-					testData.generator.createLoginUserWithUserId(testData.kukim.getId()),
-					new CommentModifyRequest("맛집이네요!")
-				))
-				.isInstanceOf(UnauthorizedUserException.class);
-		}
-	}
+            // then
+            assertThatThrownBy(() -> commentService.modifyComment(reviewId,
+                commentId,
+                loginUser,
+                modifyRequest))
+                .isInstanceOf(UnauthorizedUserException.class);
+        }
+    }
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/comment/CommentSearchIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/comment/CommentSearchIntegrationTest.java
@@ -14,6 +14,7 @@ import com.jjikmuk.sikdorak.review.domain.Review;
 import com.jjikmuk.sikdorak.review.domain.ReviewVisibility;
 import com.jjikmuk.sikdorak.review.exception.NotFoundReviewException;
 import com.jjikmuk.sikdorak.review.repository.ReviewRepository;
+import com.jjikmuk.sikdorak.user.auth.controller.LoginUser;
 import com.jjikmuk.sikdorak.user.user.controller.response.UserSimpleProfileResponse;
 import com.jjikmuk.sikdorak.user.user.domain.User;
 import com.jjikmuk.sikdorak.user.user.exception.UnauthorizedUserException;
@@ -25,151 +26,160 @@ import org.springframework.beans.factory.annotation.Autowired;
 @DisplayName("통합 : Comment 검색")
 class CommentSearchIntegrationTest extends InitIntegrationTest {
 
-	private static final CursorPageRequest FIRST_PAGE_REQUEST = new CursorPageRequest(0L, 0L, 10,
-		true);
+    private static final CursorPageRequest FIRST_PAGE_REQUEST = new CursorPageRequest(0L, 0L, 10,
+        true);
 
-	@Autowired
-	private CommentService commentService;
+    @Autowired
+    private CommentService commentService;
 
-	@Autowired
-	private ReviewRepository reviewRepository;
+    @Autowired
+    private ReviewRepository reviewRepository;
 
-	@Nested
-	@DisplayName("댓글을 조회할 때")
-	class SearchCommentTest {
+    @Nested
+    @DisplayName("댓글을 조회할 때")
+    class SearchCommentTest {
 
-		@Test
-		@DisplayName("정상적인 댓글 조회 요청이 주어진다면, 댓글목록이 반환된다.")
-		void search_comment_success() {
-			// given
-			User forky = testData.forky;
-			Review review = testData.generator.review(forky, ReviewVisibility.PUBLIC);
-			Comment comment = testData.generator.comment(review, forky, "잘보고가요");
+        @Test
+        @DisplayName("정상적인 댓글 조회 요청이 주어진다면, 댓글목록이 반환된다.")
+        void search_comment_success() {
+            // given
+            User forky = testData.forky;
+            Review review = testData.generator.review(forky, ReviewVisibility.PUBLIC);
+            Comment comment = testData.generator.comment(review, forky, "잘보고가요");
+            Long reviewId = review.getId();
+            LoginUser loginUser = testData.generator.createLoginUserWithUserId(
+                forky.getId());
 
-			// when
-			CommentSearchPagingResponse response = commentService.searchCommentsByReviewIdWithPaging(
-				review.getId(),
-				testData.generator.createLoginUserWithUserId(forky.getId()),
-				FIRST_PAGE_REQUEST
-			);
+            // when
+            CommentSearchPagingResponse response = commentService.searchCommentsByReviewIdWithPaging(
+                reviewId,
+                loginUser,
+                FIRST_PAGE_REQUEST
+            );
 
-			// then
-			assertThat(response.comments()).satisfies(
-				commentResponseList -> commentResponseList.forEach(
-					commentResponse -> {
-						// 댓글 검증
-						assertThat(commentResponse.id()).isEqualTo(comment.getId());
-						assertThat(commentResponse.content()).isEqualTo(comment.getCommentContent());
+            // then
+            assertThat(response.comments()).satisfies(
+                commentResponseList -> commentResponseList.forEach(
+                    commentResponse -> {
+                        // 댓글 검증
+                        assertThat(commentResponse.id()).isEqualTo(comment.getId());
+                        assertThat(commentResponse.content()).isEqualTo(
+                            comment.getCommentContent());
 
-						// 작성자 검증
-						UserSimpleProfileResponse author = commentResponse.author();
-						assertThat(author).isNotNull();
-						assertThat(author.id()).isEqualTo(forky.getId());
-						assertThat(author.nickname()).isEqualTo(forky.getNickname());
-						assertThat(author.profileImage()).isEqualTo(forky.getProfileImage());
-					}));
-		}
+                        // 작성자 검증
+                        UserSimpleProfileResponse author = commentResponse.author();
+                        assertThat(author).isNotNull();
+                        assertThat(author.id()).isEqualTo(forky.getId());
+                        assertThat(author.nickname()).isEqualTo(forky.getNickname());
+                        assertThat(author.profileImage()).isEqualTo(forky.getProfileImage());
+                    }));
+        }
 
-		@Test
-		@DisplayName("삭제 처리된 리뷰에 대해 댓글 조회 요청이 주어진다면 예외를 발생시킨다")
-		void search_comment_with_deleted_review_will_failed() {
-			// given
-			Review review = testData.user1PublicReview;
+        @Test
+        @DisplayName("삭제 처리된 리뷰에 대해 댓글 조회 요청이 주어진다면 예외를 발생시킨다")
+        void search_comment_with_deleted_review_will_failed() {
+            // given
+            Review review = testData.user1PublicReview;
+            Long reviewId = review.getId();
+            LoginUser loginUser = testData.generator.createLoginUserWithUserId(
+                testData.kukim.getId());
 
-			reviewRepository.delete(review);
+            reviewRepository.delete(review);
 
-			// then
-			assertThatThrownBy(
-				() -> commentService.searchCommentsByReviewIdWithPaging(review.getId(),
-					testData.generator.createLoginUserWithUserId(testData.kukim.getId()),
-					FIRST_PAGE_REQUEST))
-				.isInstanceOf(NotFoundReviewException.class);
-		}
+            // then
+            assertThatThrownBy(() -> commentService.searchCommentsByReviewIdWithPaging(reviewId,
+                loginUser,
+                FIRST_PAGE_REQUEST))
+                .isInstanceOf(NotFoundReviewException.class);
+        }
 
-		@Test
-		@DisplayName("유저가 볼 수 없는 리뷰의 댓글 조회 요청을 한다면 예외를 발생시킨다")
-		void search_comment_with_not_autor_will_failed() {
-			// given
-			User forky = testData.forky;
-			User jay = testData.jay;
+        @Test
+        @DisplayName("유저가 볼 수 없는 리뷰의 댓글 조회 요청을 한다면 예외를 발생시킨다")
+        void search_comment_with_not_autor_will_failed() {
+            // given
+            User forky = testData.forky;
+            User jay = testData.jay;
+            Review review = testData.generator.review(jay, ReviewVisibility.PROTECTED);
+            Long reviewId = review.getId();
+            LoginUser loginUser = testData.generator.createLoginUserWithUserId(forky.getId());
 
-			forky.unfollow(jay);
+            forky.unfollow(jay);
 
-			Review review = testData.generator.review(jay, ReviewVisibility.PROTECTED);
+            // then
+            assertThatThrownBy(
+                () -> commentService.searchCommentsByReviewIdWithPaging(
+                    reviewId,
+                    loginUser,
+                    FIRST_PAGE_REQUEST))
+                .isInstanceOf(UnauthorizedUserException.class);
+        }
 
-			// then
-			assertThatThrownBy(
-				() -> commentService.searchCommentsByReviewIdWithPaging(
-					review.getId(),
-					testData.generator.createLoginUserWithUserId(forky.getId()),
-					FIRST_PAGE_REQUEST))
-				.isInstanceOf(UnauthorizedUserException.class);
-		}
+        @Test
+        @DisplayName("페이지 크기 최대값을 넘으면 예외가 발생한다.")
+        void search_comment_with_size_max_over_failed() {
+            // given
+            User forky = testData.forky;
+            Review review = testData.generator.review(forky, ReviewVisibility.PROTECTED);
+            Long reviewId = review.getId();
+            LoginUser loginUser = testData.generator.createLoginUserWithUserId(forky.getId());
+            CursorPageRequest cursorPageRequest = new CursorPageRequest(0L, 0L, Integer.MAX_VALUE, true);
 
-		@Test
-		@DisplayName("페이지 크기 최대값을 넘으면 예외가 발생한다.")
-		void search_comment_with_size_max_over_failed() {
-			// given
-			User forky = testData.forky;
+            // then
+            assertThatThrownBy(
+                () -> commentService.searchCommentsByReviewIdWithPaging(
+                    reviewId,
+                    loginUser,
+                    cursorPageRequest))
+                .isInstanceOf(InvalidPageParameterException.class);
+        }
 
-			Review review = testData.generator.review(forky, ReviewVisibility.PROTECTED);
+        @Test
+        @DisplayName("이전 이후 페이지가 정상적으로 조회된다.")
+        void search_comment_with_paging_success() {
+            User jay = testData.jay;
+            Review review = testData.generator.review(testData.jay, ReviewVisibility.PRIVATE);
+            for (int i = 0; i < 15; i++) {
+                testData.generator.comment(review, jay, "내용 " + i);
+            }
 
-			// then
-			assertThatThrownBy(
-				() -> commentService.searchCommentsByReviewIdWithPaging(
-					review.getId(),
-					testData.generator.createLoginUserWithUserId(forky.getId()),
-					new CursorPageRequest(0L, 0L, Integer.MAX_VALUE, true)))
-				.isInstanceOf(InvalidPageParameterException.class);
-		}
+            CommentSearchPagingResponse response = commentService.searchCommentsByReviewIdWithPaging(
+                review.getId(),
+                testData.generator.createLoginUserWithUserId(jay.getId()),
+                new CursorPageRequest(0L, 0L, 5, true));
 
-		@Test
-		@DisplayName("이전 이후 페이지가 정상적으로 조회된다.")
-		void search_comment_with_paging_success() {
-			User jay = testData.jay;
-			Review review = testData.generator.review(testData.jay, ReviewVisibility.PRIVATE);
-			for (int i = 0; i < 15; i++) {
-				testData.generator.comment(review, jay, "내용 " + i);
-			}
+            CursorPageResponse page = response.page();
 
-			CommentSearchPagingResponse response = commentService.searchCommentsByReviewIdWithPaging(
-				review.getId(),
-				testData.generator.createLoginUserWithUserId(jay.getId()),
-				new CursorPageRequest(0L, 0L, 5, true));
+            CommentSearchPagingResponse response2 = commentService.searchCommentsByReviewIdWithPaging(
+                review.getId(),
+                testData.generator.createLoginUserWithUserId(jay.getId()),
+                new CursorPageRequest(0L, page.next(), 5, true));
 
-			CursorPageResponse page = response.page();
+            page = response2.page();
 
-			CommentSearchPagingResponse response2 = commentService.searchCommentsByReviewIdWithPaging(
-				review.getId(),
-				testData.generator.createLoginUserWithUserId(jay.getId()),
-				new CursorPageRequest(0L, page.next(), 5, true));
+            CommentSearchPagingResponse response3 = commentService.searchCommentsByReviewIdWithPaging(
+                review.getId(),
+                testData.generator.createLoginUserWithUserId(jay.getId()),
+                new CursorPageRequest(0L, page.next(), 5, true));
 
-			page = response2.page();
+            page = response3.page();
 
-			CommentSearchPagingResponse response3 = commentService.searchCommentsByReviewIdWithPaging(
-				review.getId(),
-				testData.generator.createLoginUserWithUserId(jay.getId()),
-				new CursorPageRequest(0L, page.next(), 5, true));
+            CommentSearchPagingResponse response4 = commentService.searchCommentsByReviewIdWithPaging(
+                review.getId(),
+                testData.generator.createLoginUserWithUserId(jay.getId()),
+                new CursorPageRequest(page.prev(), 0L, 5, false));
 
-			page = response3.page();
+            page = response4.page();
 
-			CommentSearchPagingResponse response4 = commentService.searchCommentsByReviewIdWithPaging(
-				review.getId(),
-				testData.generator.createLoginUserWithUserId(jay.getId()),
-				new CursorPageRequest(page.prev(), 0L, 5, false));
+            CommentSearchPagingResponse response5 = commentService.searchCommentsByReviewIdWithPaging(
+                review.getId(),
+                testData.generator.createLoginUserWithUserId(jay.getId()),
+                new CursorPageRequest(page.prev(), page.next(), 5, false));
 
-			page = response4.page();
-
-			CommentSearchPagingResponse response5 = commentService.searchCommentsByReviewIdWithPaging(
-				review.getId(),
-				testData.generator.createLoginUserWithUserId(jay.getId()),
-				new CursorPageRequest(page.prev(), page.next(), 5, false));
-
-			assertThat(response.comments()).size().isEqualTo(5);
-			assertThat(response2.comments()).size().isEqualTo(5);
-			assertThat(response3.comments()).size().isEqualTo(5);
-			assertThat(response4.comments()).size().isEqualTo(5);
-			assertThat(response5.comments()).size().isEqualTo(5);
-		}
-	}
+            assertThat(response.comments()).size().isEqualTo(5);
+            assertThat(response2.comments()).size().isEqualTo(5);
+            assertThat(response3.comments()).size().isEqualTo(5);
+            assertThat(response4.comments()).size().isEqualTo(5);
+            assertThat(response5.comments()).size().isEqualTo(5);
+        }
+    }
 }

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/review/ReviewInsertIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/review/ReviewInsertIntegrationTest.java
@@ -23,7 +23,7 @@ import org.springframework.beans.factory.annotation.Autowired;
  * - [ ] Image 추가 통합 테스트
  */
 @DisplayName("통합 : Review 생성")
-public class ReviewInsertIntegrationTest extends InitIntegrationTest {
+class ReviewInsertIntegrationTest extends InitIntegrationTest {
 
 	@Autowired
 	ReviewService reviewService;

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/review/ReviewModifyIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/review/ReviewModifyIntegrationTest.java
@@ -71,6 +71,7 @@ class ReviewModifyIntegrationTest extends InitIntegrationTest {
 	void modify_review_invalid_store() {
 		long invalidStoreId = Long.MAX_VALUE;
 		LoginUser loginUser = new LoginUser(testData.kukim.getId(), Authority.USER);
+		Long reviewId = testData.user1PublicReview.getId();
 		ReviewModifyRequest reviewModifyRequest = new ReviewModifyRequest(
 			"Modify Test review contents",
 			invalidStoreId,
@@ -81,7 +82,7 @@ class ReviewModifyIntegrationTest extends InitIntegrationTest {
 			List.of("https://s3.ap-northeast-2.amazonaws.com/sikdorak/test.jpg"));
 
 		assertThatThrownBy(() ->
-			reviewService.modifyReview(loginUser, testData.user1PublicReview.getId(), reviewModifyRequest))
+			reviewService.modifyReview(loginUser, reviewId, reviewModifyRequest))
 			.isInstanceOf(NotFoundStoreException.class);
 	}
 
@@ -90,6 +91,7 @@ class ReviewModifyIntegrationTest extends InitIntegrationTest {
 	void modify_review_invalid_user() {
 		long invalidUserId = Long.MAX_VALUE;
 		LoginUser loginUser = new LoginUser(invalidUserId, Authority.USER);
+		Long reviewId = testData.user1PublicReview.getId();
 		ReviewModifyRequest reviewModifyRequest = new ReviewModifyRequest(
 			"Modify Test review contents",
 			testData.store.getId(),
@@ -100,7 +102,7 @@ class ReviewModifyIntegrationTest extends InitIntegrationTest {
 			List.of("https://s3.ap-northeast-2.amazonaws.com/sikdorak/test.jpg"));
 
 		assertThatThrownBy(() ->
-			reviewService.modifyReview(loginUser, testData.user1PublicReview.getId(), reviewModifyRequest))
+			reviewService.modifyReview(loginUser, reviewId, reviewModifyRequest))
 			.isInstanceOf(NotFoundUserException.class);
 	}
 

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/review/ReviewRemoveIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/review/ReviewRemoveIntegrationTest.java
@@ -25,8 +25,9 @@ class ReviewRemoveIntegrationTest extends InitIntegrationTest {
 	@DisplayName("만약 유저가 본인 리뷰에 대한 삭제 요청이 주어진다면 리뷰가 Soft 삭제된다.")
 	void remove_review_valid() {
 		LoginUser loginUser = new LoginUser(testData.kukim.getId(), Authority.USER);
+		Long reviewId = testData.user1PublicReview.getId();
 
-		Review removeReview = reviewService.removeReview(loginUser, testData.user1PublicReview.getId());
+		Review removeReview = reviewService.removeReview(loginUser, reviewId);
 
 		assertThat(removeReview.isDeleted()).isTrue();
 	}
@@ -57,8 +58,9 @@ class ReviewRemoveIntegrationTest extends InitIntegrationTest {
 	void remove_review_invalid_user() {
 		long invalidUserId = Long.MAX_VALUE;
 		LoginUser loginUser = new LoginUser(invalidUserId, Authority.USER);
+		Long reviewId = testData.user1PublicReview.getId();
 
-		assertThatThrownBy(() -> reviewService.removeReview(loginUser, testData.user1PublicReview.getId()))
+		assertThatThrownBy(() -> reviewService.removeReview(loginUser, reviewId))
 			.isInstanceOf(NotFoundUserException.class);
 	}
 
@@ -66,8 +68,9 @@ class ReviewRemoveIntegrationTest extends InitIntegrationTest {
 	@DisplayName("만약 유저가 다른 유저의 리뷰에 대한 삭제 요청이 주어진다면 예외를 발생시킨다")
 	void remove_review_invalid_authorized() {
 		LoginUser loginUser = new LoginUser(testData.jay.getId(), Authority.USER);
+		Long reviewId = testData.user1PublicReview.getId();
 
-		assertThatThrownBy(() -> reviewService.removeReview(loginUser, testData.user1PublicReview.getId()))
+		assertThatThrownBy(() -> reviewService.removeReview(loginUser, reviewId))
 			.isInstanceOf(UnauthorizedUserException.class);
 	}
 

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/user/auth/OAuthLoginIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/user/auth/OAuthLoginIntegrationTest.java
@@ -24,7 +24,7 @@ import org.springframework.test.context.TestPropertySource;
     "oauth.kakao.service.api_url=http://localhost:${wiremock.server.port}"
 })
 @DisplayName("통합 : OAuth 로그인")
-public class OAuthLoginIntegrationTest extends InitIntegrationTest {
+class OAuthLoginIntegrationTest extends InitIntegrationTest {
 
     @Autowired
     private OAuthService oAuthService;
@@ -42,7 +42,7 @@ public class OAuthLoginIntegrationTest extends InitIntegrationTest {
 
     @Test
     @DisplayName("이메일 정보를 가진 유저일 경우 이메일을 저장하고 로그인에 성공한다.")
-    public void oauth_login_success_with_user_email() {
+    void oauth_login_success_with_user_email() {
         WireMock.setScenarioState("Email Not Null", "Started");
 
         JwtTokenPair code = oAuthService.login("code");
@@ -56,7 +56,7 @@ public class OAuthLoginIntegrationTest extends InitIntegrationTest {
 
     @Test
     @DisplayName("이메일 정보가 없는 유저일 경우 이메일은 빈칸으로 저장하고 로그인에 성공한다.")
-    public void oauth_login_success_without_user_email() {
+    void oauth_login_success_without_user_email() {
         WireMock.setScenarioState("Email Null", "Started");
 
         JwtTokenPair code = oAuthService.login("code");

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserCreateIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserCreateIntegrationTest.java
@@ -5,15 +5,15 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.jjikmuk.sikdorak.integration.InitIntegrationTest;
 import com.jjikmuk.sikdorak.user.user.domain.User;
-import com.jjikmuk.sikdorak.user.user.repository.UserRepository;
 import com.jjikmuk.sikdorak.user.user.exception.DuplicateUserException;
+import com.jjikmuk.sikdorak.user.user.repository.UserRepository;
 import com.jjikmuk.sikdorak.user.user.service.UserService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 @DisplayName("통합 : User 생성 기능")
-public class UserCreateIntegrationTest extends InitIntegrationTest {
+class UserCreateIntegrationTest extends InitIntegrationTest {
 
     @Autowired
     private UserService userService;

--- a/be/src/test/java/com/jjikmuk/sikdorak/unittest/review/domain/ImageTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/unittest/review/domain/ImageTest.java
@@ -46,7 +46,7 @@ class ImageTest {
 				"https:/s3.ap-northeast-2.amazonaws.com//test2.jpg",
 				"https:s3.ap-northeast-2.amazonaws.com/sikdorak/test.jpg",
 			})
-			@DisplayName("image 객체를 반환한다")
+			@DisplayName("예외를 발생시킨다.")
 			void It_returns_a_object(String reviewImage) {
 				assertThatThrownBy(() -> new Image(reviewImage))
 					.isInstanceOf(InvalidReviewImageException.class);


### PR DESCRIPTION
### ❗️ 이슈 번호

[SDR-360]

<br><br>

### 📝 구현 내용

- 정규표현식 검증 로직 -> Apache commons-validator 패키지로 대체 
- SonarCloud 규칙 수정
- Code Smells 제거
  - Test 코드에서 exception 발생할 수 있는 포인트 제거
  - 주석 indent 추가
  - 미사용 코드 & 주석 제거
  - Stream.collect(Collectors.toList()) -> Stream.toList()
  - Test class public 제거
  - deprecated 주석 추가
  - abstract class 생성자 protected 로 변경
  - 조건문 가독성 좋게 변경

[SDR-360]: https://jjikmuk.atlassian.net/browse/SDR-360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ