### PR TITLE
[SDR-367] common: 프론트 테스트 서버 배포 Github Action 배포 오류 수정

### DIFF
--- a/.github/workflows/CD-FE-Test-Firebase.yml
+++ b/.github/workflows/CD-FE-Test-Firebase.yml
@@ -67,6 +67,7 @@ jobs:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_SIKDORAK_FE_TEST }}'
           projectId: sikdorak-fe-test
+          entryPoint: ./fe
 
       - name: Print outputs
         run: |


### PR DESCRIPTION
### ❗️ 이슈 번호

[SDR-367]

<br><br>

### 💡 참고 자료

![image](https://user-images.githubusercontent.com/45728407/195554894-f9ae67fc-4aa9-4998-8628-45a424cc1207.png)

위와 같은 오류가 발생하여, firebase.json 위치를 지정하는 `entryPoint` 항목을 추가했습니다.
Github Action 에 있는 `working-directory` 옵션이 먹을 줄 알고 추가 안했었는데 안먹는것같네요😅



[SDR-367]: https://jjikmuk.atlassian.net/browse/SDR-367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ