### PR TITLE
[SDR-361] 로그인 하지 않아도 서비스 이용할 수 있게 수정

### DIFF
--- a/fe/src/components/Common/CommonHeader/CommonHeader.tsx
+++ b/fe/src/components/Common/CommonHeader/CommonHeader.tsx
@@ -1,3 +1,4 @@
+import AccountCircleIcon from '@mui/icons-material/AccountCircle';
 import { useOutsideClick } from 'hooks/useOutsideClick';
 import useToggle from 'hooks/useToggle';
 import { observer } from 'mobx-react';
@@ -9,7 +10,7 @@ import { createKey } from 'utils/utils';
 import Icon, { IconComponentsKeys } from '../Icon/Icon';
 import Logo from '../Logo/Logo';
 import Portal from '../Portal/Portal';
-import { ButtonWrap, Header, Wrap, ProfileImageWrap } from './CommonHeader.styled';
+import { ButtonWrap, Header, ProfileImageWrap, Wrap } from './CommonHeader.styled';
 
 const CommonHeader = observer(({ dispatchReviews }: any) => {
   const [isReviewWrite, toggleIsReviewWrite] = useToggle(false);
@@ -17,11 +18,16 @@ const CommonHeader = observer(({ dispatchReviews }: any) => {
   const reviewWriteModalRef = useRef(null);
   const userDetailModalRef = useRef(null);
 
-  const iconInfo: IconInfoProps[] = [
-    { icon: 'Home', handler: toggleIsUserProfile, to: '/' },
-    { icon: 'Map', to: '/map' },
-    { icon: 'PostBtn', handler: toggleIsReviewWrite, to: '' },
-  ];
+  const iconInfo: IconInfoProps[] = accountStore.id
+    ? [
+        { icon: 'Home', handler: toggleIsUserProfile, to: '/' },
+        { icon: 'Map', to: '/map' },
+        { icon: 'PostBtn', handler: toggleIsReviewWrite, to: '' },
+      ]
+    : [
+        { icon: 'Home', handler: toggleIsUserProfile, to: '/' },
+        { icon: 'Map', to: '/map' },
+      ];
 
   useOutsideClick(reviewWriteModalRef, toggleIsReviewWrite);
   useOutsideClick(userDetailModalRef, toggleIsUserProfile);
@@ -42,9 +48,9 @@ const CommonHeader = observer(({ dispatchReviews }: any) => {
               </div>
             </Link>
           ))}
-          <Link to={`/user/${accountStore.id}`}>
+          <Link to={accountStore.id ? `/user/${accountStore.id}` : '/login'}>
             <ProfileImageWrap>
-              <img src={accountStore.profileImage} alt="profile" width={24} height={24} />
+              {accountStore.profileImage ? <img src={accountStore.profileImage} alt="profile" width={24} height={24} /> : <AccountCircleIcon sx={{ width: 24, height: 24 }} />}
             </ProfileImageWrap>
           </Link>
         </ButtonWrap>

--- a/fe/src/components/Common/FeedCard/FeedCard.tsx
+++ b/fe/src/components/Common/FeedCard/FeedCard.tsx
@@ -6,11 +6,12 @@ import KebabMenu from 'components/Common/KebabMenu/KebabMenu';
 import CompnayProfile from 'components/ReviewDetail/RestaurantProfile/RestaurantProfile';
 import Rating from 'components/ReviewDetail/TotalRating/Rating';
 import UserProfile from 'components/ReviewDetail/UserProfile/UserProfile';
+import { observer } from 'mobx-react';
 import { useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { accountStore } from 'stores/AccountStore';
 
-function FeedCard({ images, reviewContent, reviewId, reviewScore, store, user, isActiveHeart, likeCnt, postLike, toggleIsClikedFeed, isUsedModal }: any) {
+const FeedCard = observer(({ images, reviewContent, reviewId, reviewScore, store, user, isActiveHeart, likeCnt, postLike, toggleIsClikedFeed, isUsedModal }: any) => {
   const [copyText, setCopyText] = useState('');
   const myUserId = accountStore.id;
   const isMyFeed = user?.userId === myUserId;
@@ -32,9 +33,11 @@ function FeedCard({ images, reviewContent, reviewId, reviewScore, store, user, i
           <FavoriteIcon color={isActiveHeart ? 'warning' : 'action'} />
           <Typography>{likeCnt}</Typography>
         </IconButton>
-        <IconButton aria-label="comment">
-          <ModeCommentIcon />
-        </IconButton>
+        {accountStore.id && (
+          <IconButton aria-label="comment">
+            <ModeCommentIcon />
+          </IconButton>
+        )}
         <IconButton aria-label="share" onClick={handleCopyURL}>
           <ShareIcon />
         </IconButton>
@@ -55,7 +58,7 @@ function FeedCard({ images, reviewContent, reviewId, reviewScore, store, user, i
     alert('공유할 리뷰 페이지가 복사되었습니다.');
     e.stopPropagation();
   }
-}
+});
 
 export default FeedCard;
 

--- a/fe/src/components/Common/Feeds/Feeds.tsx
+++ b/fe/src/components/Common/Feeds/Feeds.tsx
@@ -12,16 +12,7 @@ function Feeds({ reviews }: FeedsProps) {
       {hasReviews ? (
         reviews.map(({ images, like, reviewContent, reviewId, reviewScore, store, user, tags }) => (
           <div key={reviewId}>
-            <Feed
-              images={images}
-              like={like}
-              reviewContent={reviewContent}
-              reviewId={reviewId}
-              reviewScore={reviewScore}
-              store={store}
-              user={user}
-              tags={tags}
-            />
+            <Feed images={images} like={like} reviewContent={reviewContent} reviewId={reviewId} reviewScore={reviewScore} store={store} user={user} tags={tags} />
           </div>
         ))
       ) : (

--- a/fe/src/components/UserDetail/FollowButton/FollowButton.tsx
+++ b/fe/src/components/UserDetail/FollowButton/FollowButton.tsx
@@ -1,47 +1,21 @@
 import Button from '@mui/material/Button';
-import { useEffect, useState } from 'react';
+import { observer } from 'mobx-react';
 import { useLocation } from 'react-router-dom';
-import { fetchDataThatNeedToLogin } from 'utils/utils';
+import { userStore } from 'stores/userStore';
 
-function FollowButton({ alreadyFollowed }: FollowButtonProps) {
-  const [isFriendship, setIsFriendship] = useState(alreadyFollowed);
+const FollowButton = observer(() => {
   const { pathname } = useLocation();
   const IDtoFollow = Number(pathname.split('/').at(-1));
 
-  useEffect(() => {
-    setIsFriendship(alreadyFollowed);
-  }, [alreadyFollowed]);
-
-  return isFriendship ? (
-    <Button variant="contained" onClick={postUnFollow}>
+  return userStore?.followStatus ? (
+    <Button variant="contained" onClick={() => userStore.postUnFollow(IDtoFollow)}>
       언팔로우
     </Button>
   ) : (
-    <Button variant="contained" onClick={postFollow}>
+    <Button variant="contained" onClick={() => userStore.postFollow(IDtoFollow)}>
       팔로우
     </Button>
   );
-
-  function postFollow() {
-    fetchDataThatNeedToLogin(`api/users/follow`, {
-      method: 'PUT',
-      bodyData: { userId: IDtoFollow },
-    });
-    setIsFriendship(!isFriendship);
-    // TODO: UserStore.fetchUser();
-  }
-  function postUnFollow() {
-    fetchDataThatNeedToLogin(`api/users/unfollow`, {
-      method: 'PUT',
-      bodyData: { userId: IDtoFollow },
-    });
-    setIsFriendship(!isFriendship);
-    // TODO: UserStore.fetchUser();
-  }
-}
-
-type FollowButtonProps = {
-  alreadyFollowed?: boolean;
-};
+});
 
 export default FollowButton;

--- a/fe/src/hooks/useAuth.tsx
+++ b/fe/src/hooks/useAuth.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { fetchDataThatNeedToLogin } from 'utils/utils';
+import { accountStore } from '../stores/AccountStore';
 
 function useAuth() {
   const navigate = useNavigate();
@@ -9,8 +10,12 @@ function useAuth() {
     moveToLoginPageIfExpiredAccessToken();
 
     async function moveToLoginPageIfExpiredAccessToken() {
+      if (!accountStore.id) {
+        return;
+      }
       const isExpiredAccessToken = await validateAccessToken();
       if (isExpiredAccessToken) {
+        console.log('?!!!');
         navigate('/login');
       }
     }

--- a/fe/src/hooks/useReviews.tsx
+++ b/fe/src/hooks/useReviews.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useReducer, useState } from 'react';
-import { fetchDataThatNeedToLogin } from 'utils/utils';
+import { accountStore } from 'stores/AccountStore';
+import { fetchData, fetchDataThatNeedToLogin } from 'utils/utils';
 
 function useReviews() {
   const [reviews, dispatchReviews] = useReducer(reducer, []);
@@ -15,7 +16,7 @@ function useReviews() {
     }
   }
   const fetchNextReviews = useCallback(async (url) => {
-    const res = await fetchDataThatNeedToLogin(url);
+    const res = accountStore.id ? await fetchDataThatNeedToLogin(url) : await fetchData(`${process.env.REACT_APP_BE_SERVER_URL}/${url}`);
     const nextReviews = res.data.reviews;
     const nextAfterParam = res.data.page.next;
 

--- a/fe/src/pages/ReviewDetail/ReviewDetail.tsx
+++ b/fe/src/pages/ReviewDetail/ReviewDetail.tsx
@@ -8,6 +8,7 @@ import TagList from 'components/ReviewDetail/TagList/TagList';
 import WriteComment from 'components/ReviewDetail/WriteComment/WriteComment';
 import useAuth from 'hooks/useAuth';
 import { useEffect, useRef, useState, useCallback } from 'react';
+import { accountStore } from 'stores/AccountStore';
 import { fetchDataThatNeedToLogin } from 'utils/utils';
 import { ContentsWrap, Wrap } from './ReviewDetail.styled';
 
@@ -46,7 +47,7 @@ function ReviewDetail({ images, reviewContent, reviewId, reviewScore, store, use
           {Boolean(tags.length) && <TagList tags={tags} imgUrl={user.userProfileImage} />}
           {comments && comments.map(({ author, content, id }) => <Comment key={id} authorId={author.id} title={author.nickname} content={content} imgUrl={author.profileImage} />)}
           {hasNextComments && <Button onClick={fetchNextComment}>댓글 더보기</Button>}
-          <WriteComment commentRef={commentRef} reviewId={reviewId} comments={comments} setComments={setComments} />
+          {accountStore.id && <WriteComment commentRef={commentRef} reviewId={reviewId} comments={comments} setComments={setComments} />}
         </div>
       </ContentsWrap>
     </Wrap>

--- a/fe/src/pages/UserDetail/UserDetail.tsx
+++ b/fe/src/pages/UserDetail/UserDetail.tsx
@@ -4,15 +4,15 @@ import FollowButton from 'components/UserDetail/FollowButton/FollowButton';
 import UserProfilePhoto from 'components/UserDetail/UserProfilePhoto/UserProfilePhoto';
 import useAuth from 'hooks/useAuth';
 import useReviews from 'hooks/useReviews';
-import { useEffect, useState } from 'react';
+import { observer } from 'mobx-react';
+import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import { accountStore } from 'stores/AccountStore';
-import { fetchDataThatNeedToLogin } from 'utils/utils';
+import { userStore } from 'stores/userStore';
 import { ActivityInfoWrap, UserDetailWrap, UserInfoHeader, UserInfoWrap, Wrap } from './UserDetail.styled';
 
-function UserDetail() {
+const UserDetail = observer(() => {
   const { reviews, dispatchReviews, fetchNextReviews, afterParam, handleScroll } = useReviews();
-  const [userProfile, setUserProfile] = useState(null);
   const myUserId = accountStore.id;
   const { pathname } = useLocation();
   const targetId = Number(pathname.split('/').at(-1));
@@ -21,12 +21,7 @@ function UserDetail() {
   useAuth();
 
   useEffect(() => {
-    fetchUserInfo();
-
-    async function fetchUserInfo() {
-      const res = await fetchDataThatNeedToLogin(`api/users/${targetId}`);
-      setUserProfile(res.data);
-    }
+    userStore.fetchUserProfile(targetId);
   }, [targetId]);
 
   useEffect(() => {
@@ -42,23 +37,23 @@ function UserDetail() {
     >
       <CommonHeader dispatchReviews={dispatchReviews} />
       <UserDetailWrap>
-        <UserProfilePhoto src={userProfile?.profileImage} />
+        <UserProfilePhoto src={userStore?.userProfile?.profileImage} />
         <UserInfoWrap>
           <UserInfoHeader>
-            {userProfile?.nickname}
-            {!isMyUserDetailPage && <FollowButton alreadyFollowed={userProfile?.relationStatus?.followStatus} />}
+            {userStore?.userProfile?.nickname}
+            {!isMyUserDetailPage && accountStore.id && <FollowButton />}
           </UserInfoHeader>
           <ActivityInfoWrap>
-            <div>게시물 {userProfile?.reviewCount}</div>
-            <div>팔로우 {userProfile?.followingCount}</div>
-            <div>팔로워 {userProfile?.followersCount}</div>
+            <div>게시물 {userStore?.userProfile?.reviewCount}</div>
+            <div>팔로우 {userStore?.userProfile?.followingCount}</div>
+            <div>팔로워 {userStore?.userProfile?.followersCount}</div>
           </ActivityInfoWrap>
         </UserInfoWrap>
       </UserDetailWrap>
       <Feeds reviews={reviews} />
     </Wrap>
   );
-}
+});
 
 function getUrl(after, reviewSize, targetId) {
   return `api/users/${targetId}/reviews?after=${after}&size=${reviewSize}`;

--- a/fe/src/stores/AccountStore.ts
+++ b/fe/src/stores/AccountStore.ts
@@ -1,5 +1,5 @@
 import { STATUS_CODE } from 'constants/statusCode';
-import { action, makeObservable, observable } from 'mobx';
+import { action, makeObservable, observable, runInAction } from 'mobx';
 import { fetchDataThatNeedToLogin } from 'utils/utils';
 
 class AccountStore {
@@ -7,7 +7,7 @@ class AccountStore {
   accessToken: string;
 
   @observable
-  id: number;
+  id: number | null;
 
   @observable
   nickname: string;
@@ -16,6 +16,7 @@ class AccountStore {
   profileImage: string;
 
   constructor() {
+    this.id = null;
     makeObservable(this);
   }
 
@@ -24,24 +25,22 @@ class AccountStore {
     const myInfo = await fetchDataThatNeedToLogin(`api/users/me`);
 
     if (!myInfo.data) {
-      alert('내 정보를 찾을 수 없습니다.');
       return;
     }
 
-    const { id, nickname, profileImage } = myInfo.data;
-    this.id = id;
-    this.nickname = nickname;
-    this.profileImage = profileImage;
+    runInAction(() => {
+      const { id, nickname, profileImage } = myInfo.data;
+      this.id = id;
+      this.nickname = nickname;
+      this.profileImage = profileImage;
+    });
   }
 
   @action
   async setAccessToken(kakaoAuthorizationCode) {
-    const res = await fetch(
-      `${process.env.REACT_APP_BE_SERVER_URL}/api/oauth/callback?code=${kakaoAuthorizationCode}`,
-      {
-        credentials: 'include',
-      },
-    );
+    const res = await fetch(`${process.env.REACT_APP_BE_SERVER_URL}/api/oauth/callback?code=${kakaoAuthorizationCode}`, {
+      credentials: 'include',
+    });
     const resJson = await res.json();
     const { code, data } = resJson;
 

--- a/fe/src/stores/userStore.ts
+++ b/fe/src/stores/userStore.ts
@@ -1,0 +1,41 @@
+import { action, makeObservable, observable, runInAction } from 'mobx';
+import { fetchData, fetchDataThatNeedToLogin } from 'utils/utils';
+
+class UserStore {
+  @observable userProfile;
+
+  @observable followStatus: boolean | undefined;
+
+  constructor() {
+    makeObservable(this);
+  }
+
+  @action
+  async fetchUserProfile(id: number) {
+    const res = await fetchData(`${process.env.REACT_APP_BE_SERVER_URL}/api/users/${id}`);
+    runInAction(() => {
+      this.userProfile = res.data;
+      this.followStatus = res.data?.relationStatus?.followStatus;
+    });
+  }
+
+  @action
+  async postFollow(id: number) {
+    await fetchDataThatNeedToLogin(`api/users/follow`, {
+      method: 'PUT',
+      bodyData: { userId: id },
+    });
+    this.followStatus = true;
+  }
+
+  @action
+  async postUnFollow(id: number) {
+    await fetchDataThatNeedToLogin(`api/users/unfollow`, {
+      method: 'PUT',
+      bodyData: { userId: id },
+    });
+    this.followStatus = false;
+  }
+}
+
+export const userStore = new UserStore();


### PR DESCRIPTION
### ❗️ 이슈 번호 [SDR-361]

<br><br>

### 📝 구현 내용

- 로그인 하지 않아도 서비스 이용할 수 있게 수정 (기존에 있던 accountStore.id 방식 개선해서 구분)

- 비로그인시 불가능한 작업

  1. 내 정보를 찾을 수 없습니다.
  2. 유저 본인 프로필 조회
  3. 유저 탈퇴, 팔로우 요청
  4. 리뷰 생성, 수정 삭제
  5. 댓글 생성, 수정, 삭제

- 유저 디테일 정보 조회, 팔로우, 언팔로우 기능 비즈니스로직 분리
- 기존 accountStore에서 비동기 로직 적용 안되던 버그 수정

<br><br>

### 🙇🏻‍♂️ 리뷰어에게 부탁합니다!

- 현재 피드목록조회 api가 사용이 안되서 mock데이터를 사용해서 개발했습니다. 혹시 실행이 안될 위험이 있기 때문에 merge 전에 꼼꼼한 확인 부탁드립니다.

<br><br>

[SDR-361]: https://jjikmuk.atlassian.net/browse/SDR-361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ