### PR TITLE
[SDR-337] 모니터링 도구 적용

### DIFF
--- a/be/.gitignore
+++ b/be/.gitignore
@@ -107,6 +107,7 @@ Temporary Items
 
 # 빌드 시 복사된 application.yml 파일
 src/main/resources/*.yml
+src/main/resources/*.xml
 
 # 빌드 시 복사된 db 관련 파일들
 src/main/resources/db/**

--- a/be/build.gradle
+++ b/be/build.gradle
@@ -87,6 +87,14 @@ dependencies {
     // aws : https://spring.io/blog/2021/03/17/spring-cloud-aws-2-3-is-now-available#why-has-the-package-name-changed
     implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.2'
     testImplementation "org.testcontainers:localstack:1.17.3"
+
+    // Monitoring
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-cloudwatch2:1.9.1'
+
+    // Logging
+    implementation 'ca.pjer:logback-awslogs-appender:1.6.0'
+    implementation 'org.codehaus.janino:janino:3.1.8'
 }
 
 test {
@@ -102,6 +110,7 @@ task copyGitSubmodule(type: Copy) {
     from './config'
     into './src/main/resources'
     include '*.yml'
+    include '*.xml'
     include 'db/**'
 }
 

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/config/ExceptionNameConverter.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/config/ExceptionNameConverter.java
@@ -1,0 +1,12 @@
+package com.jjikmuk.sikdorak.common.config;
+
+import ch.qos.logback.classic.pattern.ThrowableProxyConverter;
+import ch.qos.logback.classic.spi.IThrowableProxy;
+
+public class ExceptionNameConverter extends ThrowableProxyConverter {
+
+    @Override
+    protected String throwableProxyToString(IThrowableProxy tp) {
+        return tp.getClassName();
+    }
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/config/MonitoringConfig.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/config/MonitoringConfig.java
@@ -1,0 +1,71 @@
+package com.jjikmuk.sikdorak.common.config;
+
+import io.micrometer.cloudwatch2.CloudWatchConfig;
+import io.micrometer.cloudwatch2.CloudWatchMeterRegistry;
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.time.Duration;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient;
+
+@Configuration
+public class MonitoringConfig {
+
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+
+    @Bean
+    public CloudWatchAsyncClient cloudWatchAsyncClient() {
+        return CloudWatchAsyncClient
+            .builder()
+            .region(Region.AP_NORTHEAST_2)
+            .credentialsProvider(
+                StaticCredentialsProvider.create(
+                    new AwsCredentials() {
+                        @Override
+                        public String accessKeyId() {
+                            return accessKey;
+                        }
+
+                        @Override
+                        public String secretAccessKey() {
+                            return secretKey;
+                        }
+                    }
+                )
+            )
+            .build();
+    }
+
+    @Bean
+    public MeterRegistry getMeterRegistry() {
+        return new CloudWatchMeterRegistry(
+            setupCloudWatchConfig(),
+            Clock.SYSTEM,
+            cloudWatchAsyncClient());
+    }
+
+    private CloudWatchConfig setupCloudWatchConfig() {
+        return new CloudWatchConfig() {
+
+            private final Map<String, String> config = Map.of(
+                "cloudwatch.namespace", "sikdorak",
+                "cloudwatch.step", Duration.ofMinutes(1).toString()
+            );
+
+            @Override
+            public String get(String key) {
+                return config.get(key);
+            }
+        };
+    }
+}


### PR DESCRIPTION
### ❗️ 이슈 번호

[SDR-337]

<br><br>

### 📝 구현 내용

#### 모니터링 관련 의존성 추가
- `org.springframework.boot:spring-boot-starter-actuator`
    - 어플리케이션 상태 성능 측정
- `io.micrometer:micrometer-core`
    - 측정 결과를 외부로 보내는 로직 구현을 간편하게 해주는 라이브러리
- `io.micrometer:micrometer-registry-cloudwatch2`
    - core 의 구현으로, 측정 결과를 cloudwatch 로 전송하는 역할

#### 로깅 관련 의존성 추가
- `ca.pjer:logback-awslogs-appender`
    - logback 에서 cloudwatch 로 로그 전송 설정을 쉽게 할 수 있도록 도와주는 라이브러리
    - ⚠️ 이 라이브러리의 경우에는 [Repo](https://github.com/pierredavidbelanger/logback-awslogs-appender) 의 start 의 개수나 업데이트가 많지는 않지만, 지금 당장 시간 단축을 위해 도입하였음
    - 추후 대체 라이브러리를 찾거나, 이 라이브러리에 대한 의존성을 줄일 필요는 있음
- `org.codehaus.janino:janino`
    - logback 설정 파일에서 문법을 사용할 수 있도록 도와주는 라이브러리
    - if 등 사용으로 설정 중복 최소화

#### Spring 의 Metric 을 CloudWatch 로 전송하는 설정 추가
- `MonitoringConfig`

#### Logback 설정 파일에서 사용할 추가 기능 확장
- `ExceptionNameConverter `
  - 이 클래스는 Logback 의 로그에서 예외 클래스의 FQCN 을 활용할 수 있도록 해줌
<br><br>

**일반 로그**
![image](https://user-images.githubusercontent.com/45728407/196211079-5b10485c-883d-4991-ab1d-f85e470adb31.png)

**(FQCN 이 포함된)에러 로그**
![image](https://user-images.githubusercontent.com/45728407/196211060-200488f5-74da-48e9-beb7-f0a3307ddde2.png)

(클릭해서 보시면, 제일 마지막 [] 에 예외 클래스의 FQCN 이 있습니다)

### 💡 참고 자료

- (없다면 지워도 됩니다!)


[SDR-337]: https://jjikmuk.atlassian.net/browse/SDR-337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ