### PR TITLE
[SDR-389] BE: infra: CloudWatch 연동 비활성화 설정 추가작업

### DIFF
--- a/be/src/main/java/com/jjikmuk/sikdorak/common/config/MonitoringConfig.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/config/MonitoringConfig.java
@@ -9,12 +9,14 @@ import java.util.Map;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient;
 
 @Configuration
+@Profile("prod")
 public class MonitoringConfig {
 
     @Value("${cloud.aws.credentials.accessKey}")
@@ -59,7 +61,8 @@ public class MonitoringConfig {
 
             private final Map<String, String> config = Map.of(
                 "cloudwatch.namespace", "sikdorak",
-                "cloudwatch.step", Duration.ofMinutes(1).toString()
+                "cloudwatch.step", Duration.ofMinutes(1).toString(), // 1분마다 전송
+                "cloudwatch.enabled", Boolean.FALSE.toString() // false(비활성화), true(활성화, 기본값)
             );
 
             @Override


### PR DESCRIPTION
### ❗️ 이슈 번호

[SDR-389]

<br><br>

### 📝 구현 내용

- 중복된 모니터링 설정 저게
- java 설정에 비활성화 플래그 추가

![image](https://user-images.githubusercontent.com/45728407/196868745-800ee69c-fc3f-4976-b8d9-be181ec26576.png)
(모니터링 yml 설정)

![image](https://user-images.githubusercontent.com/45728407/196868793-854a0079-886f-4ec6-ab12-eb5ed71cd0d2.png)
(모니터링 java 설정)

설정이 2개 였는데, java 설정이 우선순위가 높아서 적용되었습니다.
yml 에서는 cloudwatch.enable = false 하였지만, java 설정에서는 설정되어있지 않았었는데요.
기본값이 true 라서 yml 를 변경해도 그대로 metric 들이 전송됐었습니다.

<br><br>

[SDR-389]: https://jjikmuk.atlassian.net/browse/SDR-389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ