### PR TITLE
[SDR-339] BE - 부하테스트에 따른 성능 개선

### DIFF
--- a/be/src/main/java/com/jjikmuk/sikdorak/review/command/domain/Review.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/command/domain/Review.java
@@ -14,6 +14,8 @@ import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.Table;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
@@ -22,6 +24,8 @@ import org.hibernate.annotations.Where;
 @NoArgsConstructor
 @SQLDelete(sql = "update review set deleted = true where review_id = ?")
 @Where(clause = "deleted = false")
+@Table(name = "review",
+	indexes = @Index(name = "reviewVisibility", columnList = "reviewVisibility"))
 public class Review extends BaseTimeEntity {
 
 	@Id

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/command/domain/ReviewRepository.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/command/domain/ReviewRepository.java
@@ -22,7 +22,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     @Query("""
         select r from Review as r
-        where r.userId = :userId and not r.reviewVisibility = 'PRIVATE' and r.id <= :targetId
+        where r.userId = :userId and r.id <= :targetId and not r.reviewVisibility = 'PRIVATE'
         order by r.id desc
         """)
     List<Review> findByUserIdAndConnection(@Param("userId") long userId,
@@ -31,7 +31,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     @Query("""
         select r from Review as r
-        where r.userId = :userId and r.reviewVisibility = 'PUBLIC' and r.id <= :targetId
+        where r.userId = :userId and r.id <= :targetId and r.reviewVisibility = 'PUBLIC'
         order by r.id desc
         """)
     List<Review> findByUserIdAndDisconnection(@Param("userId") Long userId,
@@ -42,7 +42,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     @Query(value = """
         select * from review as r
-        where r.review_visibility = 'PUBLIC' and r.review_id <= :targetId
+        where r.review_id <= :targetId and r.review_visibility = 'PUBLIC'  
         order by (select count(*) from likes as l where l.review_id = r.review_id) desc, r.review_id desc 
         """,
         nativeQuery = true)
@@ -52,8 +52,8 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     @Query("""
         select r from Review r
-        where not r.reviewVisibility = 'PRIVATE'
-        and r.id <= :targetId and r.userId <> :authorId
+        where r.id <= :targetId and r.userId <> :authorId
+        and not r.reviewVisibility = 'PRIVATE'
         order by r.id desc
         """)
     List<Review> findPublicAndProtectedRecommendedReviewsInRecentOrder(


### PR DESCRIPTION
### ❗️ 이슈 번호

[SDR-339]

<br><br>

### 📝 구현 내용

- 리뷰 데이터 100만건 추가
- 비회원의 리뷰 조회 api에 대해 ngrinder 부하테스트를 한 뒤 리뷰의 review_visibility 컬럼에 대한 인덱스 생성

### 테스트 환경

- agent : 1 대 (로컬)
- vuser : 60 (동시접속자)

#### 인덱스 이전

- 평균 tps : 2530
- 요청당 평균 처리 시간 : 0.019초

<img width="800" alt="비회원 조회(no-index)" src="https://user-images.githubusercontent.com/57708971/196980179-9d997aa3-f67d-4a70-afd6-93e555ce0490.png">


#### 인덱스 후

- 평균 tps : 2911
- 요청당 평균 처리 시간 : 0.014초

<img width="800" alt="비회원 조회(visibility-index)" src="https://user-images.githubusercontent.com/57708971/196980293-7416b415-2c74-4fe5-a501-9a80a170371d.png">




[SDR-339]: https://jjikmuk.atlassian.net/browse/SDR-339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ