### PR TITLE
[SDR-406] FE : 지도 페이지 버튼 위치 변경, 첫 진입 시 fetch

### DIFF
--- a/fe/src/components/Common/FeedCard/FeedCard.tsx
+++ b/fe/src/components/Common/FeedCard/FeedCard.tsx
@@ -9,17 +9,13 @@ import CompnayProfile from 'components/ReviewDetail/RestaurantProfile/Restaurant
 import Rating from 'components/ReviewDetail/TotalRating/Rating';
 import UserProfile from 'components/ReviewDetail/UserProfile/UserProfile';
 import { observer } from 'mobx-react';
-import { useState } from 'react';
-import { useLocation } from 'react-router-dom';
 import { accountStore } from 'stores/AccountStore';
 import { openSuccessToast } from 'utils/toast';
 
 const FeedCard = observer(({ review, isActiveHeart, likeCnt, postLike, toggleIsClikedFeed, isUsedModal, postUnlike }: any) => {
   const { user, images, reviewId, reviewScore, reviewContent, store } = review;
-  const [copyText, setCopyText] = useState('');
   const myUserId = accountStore.id;
   const isMyFeed = user?.userId === myUserId;
-  const location = useLocation();
   const hasPicture = images.length > 0;
 
   return (
@@ -61,9 +57,9 @@ const FeedCard = observer(({ review, isActiveHeart, likeCnt, postLike, toggleIsC
 
   function handleCopyURL(e) {
     const { clipboard } = navigator;
-    const hostUrl = window.location.href.replace(location.pathname, '');
-    setCopyText(`${hostUrl}/review/${reviewId}`);
-    clipboard.writeText(copyText);
+    const locationOrigin = window.location.origin;
+    const reviewUrl = `${locationOrigin}/review/${reviewId}`;
+    clipboard.writeText(reviewUrl);
     openSuccessToast(MESSAGE.SUCCESS.SHARE_REVIEW);
     e.stopPropagation();
   }

--- a/fe/src/hooks/useStores.ts
+++ b/fe/src/hooks/useStores.ts
@@ -1,11 +1,11 @@
 import { useState } from 'react';
 import { fetchData } from 'utils/fetch';
 
-const MAP_POS_DEFAULT = { x: 37.509389, y: 127.105143 };
+export const MAP_POS_DEFAULT = { x: 37.509389, y: 127.105143 };
 const PAGING_SIZE = 5;
 const RADIUS = 2000;
 
-function useStores() {
+export function useStores() {
   const [stores, setStores] = useState([]);
   const [mapPos, setMapPos] = useState(MAP_POS_DEFAULT);
   const [afterParam, setAfterParam] = useState(0);
@@ -21,5 +21,3 @@ function useStores() {
 
   return { stores, setStores, mapPos, setMapPos, fetchAndSetStores };
 }
-
-export default useStores;

--- a/fe/src/pages/Map/Map.tsx
+++ b/fe/src/pages/Map/Map.tsx
@@ -9,7 +9,7 @@ import Stores from 'components/Map/Stores/Stores';
 import useAuth from 'hooks/useAuth';
 import useReviews from 'hooks/useReviews';
 import useSearchBar from 'hooks/useSearchBar';
-import useStores from 'hooks/useStores';
+import { useStores, MAP_POS_DEFAULT } from 'hooks/useStores';
 import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { Z_INDEX } from 'styles/zIndex';
@@ -21,12 +21,28 @@ const TABS = [{ label: '가게 목록' }, { label: '유저 리뷰' }];
 function Map() {
   const [activeTabIdx, setActiveTabIdx] = useState(0);
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isMovedMap, setIsMovedMap] = useState(false);
   const { stores, mapPos, setMapPos, fetchAndSetStores } = useStores();
   const { inputValue, searchResults, setInputValue, debouncedSearch } = useSearchBar();
   const { dispatchReviews } = useReviews();
   useAuth();
   const isSelectedRestaurantList = activeTabIdx === 0;
   const isSelectedUserReviews = activeTabIdx === 1;
+
+  useEffect(
+    function handleIsMovedState() {
+      const isInitLocation = mapPos.x === MAP_POS_DEFAULT.x && mapPos.y === MAP_POS_DEFAULT.y;
+      if (isInitLocation) {
+        return;
+      }
+      setIsMovedMap(true);
+    },
+    [mapPos],
+  );
+
+  useEffect(() => {
+    fetchAndSetStores();
+  }, []);
 
   useEffect(() => {
     const hasInputValue = inputValue.length > 0;
@@ -82,13 +98,20 @@ function Map() {
         </FeedsArea>
         <MapArea>
           <MapComponent stores={stores} mapPos={mapPos} setMapPos={setMapPos} />
-          <Button variant="contained" onClick={fetchAndSetStores} sx={{ position: 'absolute', top: '80%', left: '50%', zIndex: Z_INDEX.MAP_SEARCH_BTN }}>
-            현 지도에서 재검색
-          </Button>
+          {isMovedMap && (
+            <Button variant="contained" onClick={handleSearchMap} sx={{ position: 'absolute', top: '16px', left: '48%', zIndex: Z_INDEX.MAP_SEARCH_BTN }}>
+              현 지도에서 재검색
+            </Button>
+          )}
         </MapArea>
       </ContentArea>
     </>
   );
+
+  function handleSearchMap() {
+    fetchAndSetStores();
+    setIsMovedMap(false);
+  }
 
   function closeModal() {
     setIsModalOpen(false);

--- a/fe/src/pages/ReivewShare/ReviewShare.tsx
+++ b/fe/src/pages/ReivewShare/ReviewShare.tsx
@@ -1,11 +1,20 @@
 import CommonHeader from 'components/Common/CommonHeader/CommonHeader';
-import Feed from 'components/Common/Feed/Feed';
+import Feed, { ReviewType } from 'components/Common/Feed/Feed';
 import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 import { fetchData } from 'utils/fetch';
 
-const INIT_STATE: any = {};
+const INIT_STATE: ReviewType = {
+  images: [],
+  like: { count: 0, userLikeStatus: false },
+  reviewContent: '',
+  reviewId: 0,
+  reviewScore: 0,
+  store: { storeId: 0, storeName: '', storeAddress: '' },
+  user: { userId: 0, userNickname: '', userProfileImage: '' },
+  tags: [],
+};
 
 function ReviewShare() {
   const { pathname } = useLocation();
@@ -39,6 +48,6 @@ const Wrap = styled.div`
 `;
 
 const FeedWrap = styled.div`
-  width: fit-content;
-  margin: 10px auto;
+  max-width: 600px;
+  margin: 20px auto 0 auto;
 `;


### PR DESCRIPTION
### 📝 구현 내용

- `현 지도에서 재검색` 버튼 위치 수정합니다.
- 지도 페이지 처음 진입할 때 현 위치 기준으로 API 요청합니다.
- 지도를 옮겼을 때만 `현 지도에서 재검색` 버튼 표시합니다.