### PR TITLE
[SDR-413] BE - 지도맵에서 유저의 리뷰목록 조회 시 가게의 위치 정보를 담은 Dto 추가 및 패키지 추가

### DIFF
--- a/be/src/docs/asciidoc/user/user.adoc
+++ b/be/src/docs/asciidoc/user/user.adoc
@@ -75,16 +75,15 @@ API : `GET /api/users/{userId}/reviews?type=maps&y={value}&x={value}&after={valu
 사용자의 위치를 기반으로 특정유저의 리뷰 목록을 조회합니다.
 (팔로우 관계의 유저면 public|protected 공개범위, 아니면 public 공개범위의 데이터를 반환합니다.)
 
-=== `200 OK`
+==== `200 OK`
 
-=== Request
+===== Request
 
 operation::user_reviews_search_by_radius_documentation_test/reviews_radius_success[snippets='http-request,path-parameters,request-parameters']
 
-=== Response
+===== Response
 
 operation::user_reviews_search_by_radius_documentation_test/reviews_radius_success[snippets='http-response,response-fields']
-
 
 === 유저 본인 프로필 조회
 

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/query/response/ReviewListForMapResponse.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/query/response/ReviewListForMapResponse.java
@@ -1,0 +1,16 @@
+package com.jjikmuk.sikdorak.review.query.response;
+
+import com.jjikmuk.sikdorak.common.controller.response.CursorPageResponse;
+import com.jjikmuk.sikdorak.review.query.response.reviewdetail.map.ReviewDetailForMapResponse;
+import java.util.List;
+
+public record ReviewListForMapResponse(
+    List<ReviewDetailForMapResponse> reviews,
+    CursorPageResponse page
+) {
+
+    public static ReviewListForMapResponse of(List<ReviewDetailForMapResponse> reviewDetailResponse,
+        CursorPageResponse page) {
+        return new ReviewListForMapResponse(reviewDetailResponse, page);
+    }
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/query/response/reviewdetail/map/ReviewDetailForMapResponse.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/query/response/reviewdetail/map/ReviewDetailForMapResponse.java
@@ -1,0 +1,81 @@
+package com.jjikmuk.sikdorak.review.query.response.reviewdetail.map;
+
+import com.jjikmuk.sikdorak.review.command.domain.Review;
+import com.jjikmuk.sikdorak.review.query.response.reviewdetail.ReviewDetailLikeResponse;
+import com.jjikmuk.sikdorak.review.query.response.reviewdetail.ReviewDetailUserResponse;
+import com.jjikmuk.sikdorak.store.command.domain.Store;
+import com.jjikmuk.sikdorak.user.auth.api.LoginUser;
+import com.jjikmuk.sikdorak.user.user.command.domain.User;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.PastOrPresent;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
+import org.hibernate.validator.constraints.URL;
+
+public record ReviewDetailForMapResponse(
+	ReviewDetailUserResponse user,
+	ReviewDetailStoreForMapResponse store,
+	ReviewDetailLikeResponse like,
+
+	@NotNull
+	long reviewId,
+
+	@NotBlank
+	@Size(min = 1, max = 500)
+	String reviewContent,
+
+	@NotNull
+	@Pattern(regexp = "1-5")
+	float reviewScore,
+
+	@NotNull
+	@Pattern(regexp = "public\\|protected\\|private")
+	String reviewVisibility,
+
+	@NotNull
+	@PastOrPresent
+	@Pattern(regexp = "yyyy-MM-dd")
+	LocalDate visitedDate,
+
+	@Size(max = 30)
+	Set<String> tags,
+
+	@URL
+	@Size(max = 10)
+	List<String> images,
+
+	@NotNull
+	@Pattern(regexp = "yyyy-MM-dd")
+	LocalDateTime createdAt,
+
+	@NotNull
+	@Pattern(regexp = "yyyy-MM-dd")
+	LocalDateTime updatedAt
+) {
+
+	public static ReviewDetailForMapResponse of(Review review, Store store, User author, LoginUser loginUser) {
+		boolean likeStatus = !Objects.isNull(loginUser.getId()) && review.isLikedBy(loginUser.getId());
+		return new ReviewDetailForMapResponse(
+			new ReviewDetailUserResponse(author),
+			new ReviewDetailStoreForMapResponse(store),
+			new ReviewDetailLikeResponse(review.getLikesCount(), likeStatus),
+			review.getId(),
+			review.getReviewContent(),
+			review.getReviewScore(),
+			review.getReviewVisibility(),
+			review.getVisitedDate(),
+			review.getTags(),
+			review.getImages(),
+			review.getCreatedAt(),
+			review.getUpdatedAt()
+		);
+
+	}
+
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/query/response/reviewdetail/map/ReviewDetailStoreForMapResponse.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/query/response/reviewdetail/map/ReviewDetailStoreForMapResponse.java
@@ -1,0 +1,37 @@
+package com.jjikmuk.sikdorak.review.query.response.reviewdetail.map;
+
+import com.jjikmuk.sikdorak.store.command.domain.Store;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+/*
+- [ ] TODO : Store 대표 이미지 추가.
+ */
+public record ReviewDetailStoreForMapResponse(
+	@NotNull
+	long storeId,
+
+	@NotBlank
+	@Size(min = 1, max = 500)
+	String storeName,
+
+	String addressName,
+	String roadAddressName,
+	double x,
+	double y
+
+	// String storeImage
+) {
+
+	public ReviewDetailStoreForMapResponse(Store store) {
+		this(store.getId(),
+			store.getStoreName(),
+			store.getAddressName(),
+			store.getRoadAddressName(),
+			store.getX(),
+			store.getY()
+		);
+	}
+}
+

--- a/be/src/main/java/com/jjikmuk/sikdorak/user/user/api/UserQueryApi.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/user/user/api/UserQueryApi.java
@@ -6,6 +6,7 @@ import com.jjikmuk.sikdorak.common.controller.CursorPageable;
 import com.jjikmuk.sikdorak.common.controller.request.CursorPageRequest;
 import com.jjikmuk.sikdorak.common.response.CommonResponseEntity;
 import com.jjikmuk.sikdorak.review.query.ReviewDao;
+import com.jjikmuk.sikdorak.review.query.response.ReviewListForMapResponse;
 import com.jjikmuk.sikdorak.review.query.response.ReviewListResponse;
 import com.jjikmuk.sikdorak.store.query.request.UserLocationInfoRequest;
 import com.jjikmuk.sikdorak.user.auth.api.LoginUser;
@@ -61,13 +62,13 @@ public class UserQueryApi {
     }
 
     @GetMapping(path = "/{userId}/reviews", params = {"type=maps"})
-    public CommonResponseEntity<ReviewListResponse> searchReviewsByRadius(
+    public CommonResponseEntity<ReviewListForMapResponse> searchReviewsByRadius(
         @PathVariable Long userId,
         @AuthenticatedUser LoginUser loginUser,
         UserLocationInfoRequest userLocationInfoRequest,
         @CursorPageable CursorPageRequest cursorPageRequest) {
 
-        ReviewListResponse userReviewResponses =
+        ReviewListForMapResponse userReviewResponses =
             reviewDao.searchUserReviewsByRadius(userId, loginUser, userLocationInfoRequest,
                 cursorPageRequest);
 

--- a/be/src/test/java/com/jjikmuk/sikdorak/documentationtest/user/user/UserSnippet.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/documentationtest/user/user/UserSnippet.java
@@ -179,7 +179,9 @@ public interface UserSnippet {
             fieldWithPath("reviews[].store.storeId").type(JsonFieldType.NUMBER).description("가게 아이디"),
             fieldWithPath("reviews[].store.storeName").type(JsonFieldType.STRING).description("가게 이름"),
             fieldWithPath("reviews[].store.addressName").type(JsonFieldType.STRING).description("지번 주소"),
-            fieldWithPath("reviews[].store.roadAddressName").type(JsonFieldType.STRING).description("도로명 주소")),
+            fieldWithPath("reviews[].store.roadAddressName").type(JsonFieldType.STRING).description("도로명 주소"),
+            fieldWithPath("reviews[].store.x").type(JsonFieldType.NUMBER).description("경도(최대값: 180.0 / 최소값: -180.0)"),
+            fieldWithPath("reviews[].store.y").type(JsonFieldType.NUMBER).description("위도(최대값: 90.0 / 최소값: -90.0)")),
 
         responseFieldsOfObjectWithConstraintsAndFields(ReviewDetailLikeResponse.class,
             fieldWithPath("reviews[].like.count").type(JsonFieldType.NUMBER).description("좋아요 개수"),

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserReviewsSearchByRadiusIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserReviewsSearchByRadiusIntegrationTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.jjikmuk.sikdorak.common.controller.request.CursorPageRequest;
 import com.jjikmuk.sikdorak.integration.InitIntegrationTest;
 import com.jjikmuk.sikdorak.review.query.ReviewDao;
-import com.jjikmuk.sikdorak.review.query.response.ReviewListResponse;
+import com.jjikmuk.sikdorak.review.query.response.ReviewListForMapResponse;
 import com.jjikmuk.sikdorak.store.query.request.UserLocationInfoRequest;
 import com.jjikmuk.sikdorak.user.auth.api.LoginUser;
 import com.jjikmuk.sikdorak.user.user.command.domain.Authority;
@@ -28,7 +28,7 @@ class UserReviewsSearchByRadiusIntegrationTest extends InitIntegrationTest {
         UserLocationInfoRequest userLocationInfoRequest = new UserLocationInfoRequest(127.067, 37.6557, 1000);
         LoginUser loginUser = new LoginUser(Authority.ANONYMOUS);
 
-        ReviewListResponse reviewListResponse = reviewDao.searchUserReviewsByRadius(
+        ReviewListForMapResponse reviewListResponse = reviewDao.searchUserReviewsByRadius(
             testData.hoi.getId(), loginUser,
             userLocationInfoRequest, cursorPageRequest);
 
@@ -44,7 +44,7 @@ class UserReviewsSearchByRadiusIntegrationTest extends InitIntegrationTest {
         UserLocationInfoRequest userLocationInfoRequest = new UserLocationInfoRequest(127.067, 37.6557, 1000);
         LoginUser loginUser = new LoginUser(testData.jay.getId(), Authority.USER);
 
-        ReviewListResponse reviewListResponse = reviewDao.searchUserReviewsByRadius(
+        ReviewListForMapResponse reviewListResponse = reviewDao.searchUserReviewsByRadius(
             testData.hoi.getId(), loginUser,
             userLocationInfoRequest, cursorPageRequest);
 
@@ -60,7 +60,7 @@ class UserReviewsSearchByRadiusIntegrationTest extends InitIntegrationTest {
         UserLocationInfoRequest userLocationInfoRequest = new UserLocationInfoRequest(127.067, 37.6557, 1000);
         LoginUser loginUser = new LoginUser(testData.forky.getId(), Authority.USER);
 
-        ReviewListResponse reviewListResponse = reviewDao.searchUserReviewsByRadius(
+        ReviewListForMapResponse reviewListResponse = reviewDao.searchUserReviewsByRadius(
             testData.hoi.getId(), loginUser,
             userLocationInfoRequest, cursorPageRequest);
 
@@ -76,7 +76,7 @@ class UserReviewsSearchByRadiusIntegrationTest extends InitIntegrationTest {
         UserLocationInfoRequest userLocationInfoRequest = new UserLocationInfoRequest(127.067, 37.6557, 100);
         LoginUser loginUser = new LoginUser(Authority.ANONYMOUS);
 
-        ReviewListResponse reviewListResponse = reviewDao.searchUserReviewsByRadius(
+        ReviewListForMapResponse reviewListResponse = reviewDao.searchUserReviewsByRadius(
             testData.hoi.getId(), loginUser,
             userLocationInfoRequest, cursorPageRequest);
 


### PR DESCRIPTION
### ❗️ 이슈 번호

[SDR-413]

<br><br>

### 📝 구현 내용

- 지도맵에서 유저의 리뷰목록 조회시 지도상에 마커를 찍기 위해 가게의 좌표 정보를 함께 제공하도록 수정

<img width="686" alt="Screen Shot 2022-10-31 at 13 24 03" src="https://user-images.githubusercontent.com/57708971/198930763-0b71765e-1395-4396-b549-809d39f27e67.png">




[SDR-413]: https://jjikmuk.atlassian.net/browse/SDR-413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ