### PR TITLE
[SDR-420] BE - 리뷰 조회 로직에서 삭제된 리뷰도 검색되는 버그 수정

### DIFF
--- a/be/src/main/java/com/jjikmuk/sikdorak/review/command/domain/ReviewRepository.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/command/domain/ReviewRepository.java
@@ -43,7 +43,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     @Query(value = """
         select * from review as r
-        where r.review_visibility = 'PUBLIC' and r.review_id <= :targetId
+        where r.review_visibility = 'PUBLIC' and r.review_id <= :targetId and r.deleted = false
         order by (select count(*) from likes as l where l.review_id = r.review_id) desc, r.review_id desc 
         """,
         nativeQuery = true)
@@ -89,7 +89,7 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
         select * from review as r
         join store as s on s.store_id = r.store_id
         where r.review_id <= :targetId and r.user_id = :authorId
-        and r.review_visibility = 'PUBLIC'
+        and r.review_visibility = 'PUBLIC' and r.deleted= false
         and s.x between :minX and :maxX
         and s.y between :minY and :maxY  
         order by (select count(*) from likes as l where l.review_id = r.review_id) desc, r.review_id desc 
@@ -117,5 +117,21 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
         Pageable pageable,
         double maxX, double maxY,
         double minX, double minY);
+
+    @Query("""
+        select r from Review r
+        join Store as s on s.id = r.storeId
+        where r.id <= :targetId and r.userId = :authorId
+        and s.location.x between :minX and :maxX
+        and s.location.y between :minY and :maxY
+        order by r.id desc
+        """)
+    Slice<Review> findAllReviewsByRadius(
+        @Param("authorId") long authorId,
+        @Param("targetId") long targetId,
+        Pageable pageable,
+        double maxX, double maxY,
+        double minX, double minY);
+
 
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/review/query/ReviewDao.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/review/query/ReviewDao.java
@@ -245,7 +245,7 @@ public class ReviewDao {
         PagingInfo pagingInfo,
         UserLocationBasedMaxRange coordinates) {
         if (loginUser.isAnonymous()
-            || !RelationType.CONNECTION.equals(searchUser.relationTypeTo(loginUser))) {
+            || RelationType.DISCONNECTION.equals(searchUser.relationTypeTo(loginUser))) {
             return reviewRepository.findPublicReviewsByRadius(
                 searchUser.getId(),
                 pagingInfo.cursor(),
@@ -259,6 +259,17 @@ public class ReviewDao {
 
         if (!userRepository.existsById(loginUser.getId())) {
             throw new NotFoundUserException();
+        }
+
+        if (RelationType.SELF.equals(searchUser.relationTypeTo(loginUser))) {
+            return reviewRepository.findAllReviewsByRadius(
+                searchUser.getId(),
+                pagingInfo.cursor(),
+                pagingInfo.pageable(),
+                coordinates.getMaxX(),
+                coordinates.getMaxY(),
+                coordinates.getMinX(),
+                coordinates.getMinY());
         }
 
         return reviewRepository.findPublicAndProtectedReviewsByRadius(

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserReviewsSearchByRadiusIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/user/user/UserReviewsSearchByRadiusIntegrationTest.java
@@ -36,6 +36,22 @@ class UserReviewsSearchByRadiusIntegrationTest extends InitIntegrationTest {
     }
 
     @Test
+    @DisplayName("회원이 위치기반 자신의 리뷰목록 조회 요청을 한다면 public 리뷰 목록을 제공한다.")
+    void search_self_reviews_by_radius() {
+        long cursorPage = 0;
+        int size = 5;
+        CursorPageRequest cursorPageRequest = new CursorPageRequest(0L, cursorPage, size, true);
+        UserLocationInfoRequest userLocationInfoRequest = new UserLocationInfoRequest(127.067, 37.6557, 1000);
+        LoginUser loginUser = new LoginUser(testData.hoi.getId(), Authority.USER);
+
+        ReviewListForMapResponse reviewListResponse = reviewDao.searchUserReviewsByRadius(
+            testData.hoi.getId(), loginUser,
+            userLocationInfoRequest, cursorPageRequest);
+
+        assertThat(reviewListResponse.reviews()).hasSize(3);
+    }
+
+    @Test
     @DisplayName("회원이 위치기반 팔로우하지 않은 유저 리뷰목록 조회 요청을 한다면 public 리뷰 목록을 제공한다.")
     void search_unfollowing_user_reviews_by_radius() {
         long cursorPage = 0;


### PR DESCRIPTION
- 사용자 자신이 검색 시 protected, private 리뷰까지 검색되도록 변경

### ❗️ 이슈 번호

[SDR-420]

<br><br>

### 📝 구현 내용

- 리뷰 조회 로직에서 삭제된 리뷰도 검색되는 버그 수정
- 유저가 위치기반 리뷰목록 조회 시 자신의 이름을 검색할 경우 private, protected 상태의 게시물 모두 제공하도록 수정

<br><br>

### 🙇🏻‍♂️ 리뷰어에게 부탁합니다!

- (리뷰어에게 부탁하는 말을 작성해주세요. 없다면 지워도 됩니다!)

<br><br>

### 💡 참고 자료

- (없다면 지워도 됩니다!)


[SDR-420]: https://jjikmuk.atlassian.net/browse/SDR-420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ