### PR TITLE
[SDR-431] BE: Infra: Terraform을 활용한 ElastiCache 프로비저닝

### DIFF
--- a/infra/elasticache/.terraform.lock.hcl
+++ b/infra/elasticache/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "4.46.0"
+  hashes = [
+    "h1:WFBUQj7XI7gknCtGR+3yDhdlUiDYrONOA8HA7h2yWqY=",
+    "zh:1678e6a4bdb3d81a6713adc62ca0fdb8250c584e10c10d1daca72316e9db8df2",
+    "zh:329903acf86ef6072502736dff4c43c2b50f762a958f76aa924e2d74c7fca1e3",
+    "zh:33db8131fe0ec7e1d9f30bc9f65c2440e9c1f708d681b6062757a351f1df7ce6",
+    "zh:3a3b010bc393784c16f4b6cdce7f76db93d5efa323fce4920bfea9e9ba6abe44",
+    "zh:979e2713a5759a7483a065e149e3cb69db9225326fc0457fa3fc3a48aed0c63f",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9efcf0067e16ad53da7504178a05eb2118770b4ae00c193c10ecad4cbfce308e",
+    "zh:a10655bf1b6376ab7f3e55efadf54dc70f7bd07ca11369557c312095076f9d62",
+    "zh:b0394dd42cbd2a718a7dd7ae0283f04769aaf8b3d52664e141da59c0171a11ab",
+    "zh:b958e614c2cf6d9c05a6ad5e94dc5c04b97ebfb84415da068be5a081b5ebbe24",
+    "zh:ba5069e624210c63ad9e633a8eb0108b21f2322bc4967ba2b82d09168c466888",
+    "zh:d7dfa597a17186e7f4d741dd7111849f1c0dd6f7ebc983043d8262d2fb37b408",
+    "zh:e8a641ca2c99f96d64fa2725875e797273984981d3e54772a2823541c44e3cd3",
+    "zh:f89898b7067c4246293a8007f59f5cfcac7b8dd251d39886c7a53ba596251466",
+    "zh:fb1e1df1d5cc208e08a850f8e84423bce080f01f5e901791c79df369d3ed52f2",
+  ]
+}

--- a/infra/elasticache/elasticache.tf
+++ b/infra/elasticache/elasticache.tf
@@ -1,0 +1,21 @@
+# elasticache에 subnet group 연결
+resource "aws_elasticache_subnet_group" "elasticache-subnet-group" {
+  name       = "elasticache-subnet-group"
+  subnet_ids = [data.terraform_remote_state.vpc.outputs.vpc_private_subnet]
+}
+
+# create elasticache (redis)
+resource "aws_elasticache_cluster" "single-node-redis-for-springboot" {
+  cluster_id           = "single-node-redis-for-springboo"
+  engine               = "redis"
+  node_type            = "cache.t2.micro"
+  num_cache_nodes      = 1 # node 1개
+  parameter_group_name = "default.redis7" # 파라미터 그룹
+  engine_version       = "7.0" # 레디스 버전
+  port                 = 6379
+  security_group_ids = [
+    aws_security_group.security_group_redis.id
+  ]
+
+  subnet_group_name    = aws_elasticache_subnet_group.elasticache-subnet-group.name
+}

--- a/infra/elasticache/main.tf
+++ b/infra/elasticache/main.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = "ap-northeast-2"
+}

--- a/infra/elasticache/security_group.tf
+++ b/infra/elasticache/security_group.tf
@@ -1,0 +1,25 @@
+# redis에서 사용할 보안그룹
+resource "aws_security_group" "security_group_redis" {
+  name = "security_group_redis"
+
+  vpc_id = data.terraform_remote_state.vpc.outputs.vpc_id
+
+  ingress {
+    from_port   = 6379
+    to_port     = 6379
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 65535
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+
+  tags = {
+    Name = "be"
+  }
+}

--- a/infra/elasticache/variables.tf
+++ b/infra/elasticache/variables.tf
@@ -1,0 +1,7 @@
+data "terraform_remote_state" "vpc" {
+  backend = "local"
+
+  config = {
+    path = "${path.module}/../vpc/terraform.tfstate"
+  }
+}


### PR DESCRIPTION
### ❗️ 이슈 번호

[SDR-431]

<br><br>

### 📝 구현 내용

**Terraform 프로비저닝** 
- 보안 그룹 생성
- elasticache에서 사용할 subnet group 연결
- elasticache 생성

**Redis 옵션 설정**
- Redis는 replication, cluster mode가 아닌 single mode / 프리티어 t2.micro로 설정하였습니다.
- Redis를 활용한 api 구현 후 확장하려 합니다.

**결과**
- terraform apply, destroy 시간이 약 4~6분 정도 걸립니다.
- 현재는 레디스 활용 api구현이 안되어있기 때문에 자원은 destroy 되어있습니다.

**프로비저닝 결과 예**

![image](https://user-images.githubusercontent.com/57086195/207625327-64e8fd46-f203-4499-b7d0-a8791ddf9ecc.png)


### 💡 참고 자료

- https://github.com/ku-kim/springboot-redis-example/pull/14

- AWS Console : https://docs.aws.amazon.com/ko_kr/AmazonElastiCache/latest/red-ug/GettingStarted.html

- ec2에서 elasticach 연결
  - https://docs.aws.amazon.com/ko_kr/AmazonElastiCache/latest/red-ug/GettingStarted.ConnectToCacheNode.html
  - https://devlog-wjdrbs96.tistory.com/314

- 테라폼 프로비저닝
  - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_cluster#redis-log-delivery-configuration
  - https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_replication_group

[SDR-431]: https://jjikmuk.atlassian.net/browse/SDR-431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ