### PR TITLE
[SDR-433] BE: Redis를 활용한 공통으로 사용할 수 있는 Rate Limiter Service 구현

### DIFF
--- a/be/build.gradle
+++ b/be/build.gradle
@@ -57,6 +57,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'mysql:mysql-connector-java'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     // Dev
     compileOnly 'org.projectlombok:lombok'

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/config/RedisConfig.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/config/RedisConfig.java
@@ -1,0 +1,40 @@
+package com.jjikmuk.sikdorak.common.config;
+
+import com.jjikmuk.sikdorak.common.properties.RedisProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+@RequiredArgsConstructor
+public class RedisConfig {
+
+	private final RedisProperties redisProperties;
+
+	@Bean
+	public RedisConnectionFactory redisConnectionFactory() {
+		return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+	}
+
+	@Bean
+	public StringRedisTemplate stringRedisTemplate() {
+		StringRedisTemplate stringRedisTemplate = new StringRedisTemplate();
+		stringRedisTemplate.setConnectionFactory(redisConnectionFactory());
+		stringRedisTemplate.setKeySerializer(new StringRedisSerializer());
+		stringRedisTemplate.setValueSerializer(new StringRedisSerializer());
+		stringRedisTemplate.setEnableTransactionSupport(true);
+		return stringRedisTemplate;
+	}
+
+	@Bean // 만약 PlatformTransactionManager 등록이 안되어 있다면 해야함, 되어있다면 할 필요 없음
+	public PlatformTransactionManager transactionManager()  {
+		return new JpaTransactionManager();
+	}
+
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/config/RedisConfig.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/config/RedisConfig.java
@@ -32,7 +32,7 @@ public class RedisConfig {
 		return stringRedisTemplate;
 	}
 
-	@Bean // 만약 PlatformTransactionManager 등록이 안되어 있다면 해야함, 되어있다면 할 필요 없음
+	@Bean
 	public PlatformTransactionManager transactionManager()  {
 		return new JpaTransactionManager();
 	}

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/exception/ExceptionCodeAndMessages.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/exception/ExceptionCodeAndMessages.java
@@ -9,6 +9,7 @@ import com.jjikmuk.sikdorak.image.exception.InvalidImageSizeException;
 import com.jjikmuk.sikdorak.image.exception.InvalidImagesExtensionException;
 import com.jjikmuk.sikdorak.image.exception.NotFoundImageException;
 import com.jjikmuk.sikdorak.image.exception.NotFoundImageMetaDataException;
+import com.jjikmuk.sikdorak.ratelimit.exception.ApiLimitExceededException;
 import com.jjikmuk.sikdorak.review.exception.DuplicateLikeUserException;
 import com.jjikmuk.sikdorak.review.exception.InvalidReviewContentException;
 import com.jjikmuk.sikdorak.review.exception.InvalidReviewImageException;
@@ -53,6 +54,7 @@ public enum ExceptionCodeAndMessages implements CodeAndMessages {
     NOT_FOUND_ERROR_CODE("F-G001", "에러 코드를 찾을 수 없습니다.", NotFoundErrorCodeException.class),
     INVALID_PAGE_PARAMETER("F-G002", "유효하지 않은 페이징 값 입니다.", InvalidPageParameterException.class),
     INTERNAL_SERVER_ERROR("F-G003", "서버 에러입니다.(관리자에게 문의하세요)", SikdorakServerError.class),
+    API_LIMIT_EXCEEDED("F-G004", "너무 많은 요청을 하였습니다.", ApiLimitExceededException.class),
 
     // Review
     INVALID_REVIEW_CONTENT("F-R001", "유효하지 않은 리뷰 컨텐츠 입니다.", InvalidReviewContentException.class),

--- a/be/src/main/java/com/jjikmuk/sikdorak/common/properties/RedisProperties.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/common/properties/RedisProperties.java
@@ -1,0 +1,28 @@
+package com.jjikmuk.sikdorak.common.properties;
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import lombok.Getter;
+import org.hibernate.validator.constraints.Range;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.validation.annotation.Validated;
+
+@Getter
+@Validated
+@ConstructorBinding
+@ConfigurationProperties(prefix = "spring.redis")
+public class RedisProperties {
+
+	@NotEmpty
+	private final String host;
+
+	@NotNull
+	@Range(min = 0, max = 65535)
+	private final int port;
+
+	public RedisProperties(String host, int port) {
+		this.host = host;
+		this.port = port;
+	}
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/ratelimit/command/app/ApiRateLimiterService.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/ratelimit/command/app/ApiRateLimiterService.java
@@ -4,6 +4,6 @@ import javax.servlet.http.HttpServletRequest;
 
 public interface ApiRateLimiterService {
 
-	Boolean checkRateLimit(HttpServletRequest request, long rangeMinutes, long apiMaximumNumber);
+	Boolean checkRateLimit(HttpServletRequest request, long windowSize, long apiMaximumNumber);
 
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/ratelimit/command/app/ApiRateLimiterService.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/ratelimit/command/app/ApiRateLimiterService.java
@@ -4,6 +4,6 @@ import javax.servlet.http.HttpServletRequest;
 
 public interface ApiRateLimiterService {
 
-	Boolean checkRateLimit(HttpServletRequest request, Long rangeSeconds, Long apiMaximumNumber);
+	Boolean checkRateLimit(HttpServletRequest request, long rangeMinutes, long apiMaximumNumber);
 
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/ratelimit/command/app/ApiRateLimiterService.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/ratelimit/command/app/ApiRateLimiterService.java
@@ -1,0 +1,9 @@
+package com.jjikmuk.sikdorak.ratelimit.command.app;
+
+import javax.servlet.http.HttpServletRequest;
+
+public interface ApiRateLimiterService {
+
+	Boolean checkRateLimit(HttpServletRequest request, Long rangeSeconds, Long apiMaximumNumber);
+
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/ratelimit/command/app/RedisApiRateLimiterService.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/ratelimit/command/app/RedisApiRateLimiterService.java
@@ -1,0 +1,30 @@
+package com.jjikmuk.sikdorak.ratelimit.command.app;
+
+import javax.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RedisApiRateLimiterService implements ApiRateLimiterService{
+
+	private final StringRedisTemplate redisTemplate;
+
+	/**
+	 *  클라이언트 ip를 활용하여 요청하는 api에 대해 rate limit을 확인한다.
+	 *  가능한 경우 해당 api 사용횟수를 1회 증가시킨다.
+	 *  불가능한 경우 Exception을 발생시킨다.
+	 *
+	 * @param request 클라이언트의 ip, servlet path를 사용한다.
+	 * @param rangeMinutes api 사용 빈도 검색 시간 범위
+	 * @param apiMaximumNumber rangeMinutes 내 최대 api 요청수
+	 *
+	 * @return true : api 사용 가능
+	 */
+	@Override
+	public Boolean checkRateLimit(HttpServletRequest request, Long rangeMinutes, Long apiMaximumNumber) {
+		throw new UnsupportedOperationException(
+			"RedisApiRateLimiterService#checkRateLimit 아직 구현하지 않음 !!");
+	}
+}

--- a/be/src/main/java/com/jjikmuk/sikdorak/ratelimit/command/app/RedisApiRateLimiterService.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/ratelimit/command/app/RedisApiRateLimiterService.java
@@ -51,7 +51,6 @@ public class RedisApiRateLimiterService implements ApiRateLimiterService {
 	}
 
 	private String getApiPathAndIpKey(HttpServletRequest request) {
-		// 클라 정보 뽑기 (ip, request uri)
 		String servletPath = request.getServletPath();
 		String clientIp = getClientIp(request); // ip 가져올 때 ipv4 vs ipv6
 
@@ -62,8 +61,8 @@ public class RedisApiRateLimiterService implements ApiRateLimiterService {
 	}
 
 	/**
-	 * 	클라이언트의 ip 주소를 추출한다.
-	 * 	ref : <a href="https://www.lesstif.com/software-architect/proxy-client-ip-x-forwarded-for-xff-http-header-20775886.html">...</a>.
+	 * 클라이언트의 ip 주소를 추출한다.
+	 * ref : <a href="https://www.lesstif.com/software-architect/proxy-client-ip-x-forwarded-for-xff-http-header-20775886.html">...</a>.
 	 *
 	 * @param request Client의 HttpServletRequest
 	 * @return Client Ip

--- a/be/src/main/java/com/jjikmuk/sikdorak/ratelimit/command/app/RedisApiRateLimiterService.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/ratelimit/command/app/RedisApiRateLimiterService.java
@@ -126,7 +126,7 @@ public class RedisApiRateLimiterService implements ApiRateLimiterService {
 	 * @param currentDate - 현재 시간의 Date 객체
 	 * @param rangeMinutes - api 사용 빈도 검색 시간 범위 & Redis Key expire time
 	 */
-	public void upsertApiCount(String apiPathAndIpKey, Date currentDate, long rangeMinutes) {
+	private void upsertApiCount(String apiPathAndIpKey, Date currentDate, long rangeMinutes) {
 		String currentRateLimitKey =
 			apiPathAndIpKey + new SimpleDateFormat("yyyyMMddHHmm").format(currentDate);
 

--- a/be/src/main/java/com/jjikmuk/sikdorak/ratelimit/command/app/RedisApiRateLimiterService.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/ratelimit/command/app/RedisApiRateLimiterService.java
@@ -1,30 +1,146 @@
 package com.jjikmuk.sikdorak.ratelimit.command.app;
 
+import com.jjikmuk.sikdorak.ratelimit.exception.ApiLimitExceededException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 import javax.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.redis.core.RedisOperations;
+import org.springframework.data.redis.core.SessionCallback;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class RedisApiRateLimiterService implements ApiRateLimiterService{
+public class RedisApiRateLimiterService implements ApiRateLimiterService {
 
 	private final StringRedisTemplate redisTemplate;
 
 	/**
-	 *  클라이언트 ip를 활용하여 요청하는 api에 대해 rate limit을 확인한다.
-	 *  가능한 경우 해당 api 사용횟수를 1회 증가시킨다.
-	 *  불가능한 경우 Exception을 발생시킨다.
+	 * Redis 저장소를 활용하여 Rate Limit 여부를 확인한다.
+	 * Redis Key Format - API:ip:yyyyMMddHHmm , e.g. /api/images/url:127.0.0.1:202212161449
+	 * API 사용 가능한 경우 해당 key의 값을 1 증가시킨다.
+	 * 불가능한 경우 Exception을 발생시킨다.
 	 *
-	 * @param request 클라이언트의 ip, servlet path를 사용한다.
-	 * @param rangeMinutes api 사용 빈도 검색 시간 범위
+	 * @param request          클라이언트의 ip, servlet path를 사용한다.
+	 * @param rangeMinutes     api 사용 빈도 검색 시간 범위 & Redis Key expire time
 	 * @param apiMaximumNumber rangeMinutes 내 최대 api 요청수
-	 *
 	 * @return true : api 사용 가능
 	 */
 	@Override
-	public Boolean checkRateLimit(HttpServletRequest request, Long rangeMinutes, Long apiMaximumNumber) {
-		throw new UnsupportedOperationException(
-			"RedisApiRateLimiterService#checkRateLimit 아직 구현하지 않음 !!");
+	public Boolean checkRateLimit(HttpServletRequest request, long rangeMinutes, long apiMaximumNumber) {
+		Date currentDate = new Date();
+		String apiPathAndIpKey = getApiPathAndIpKey(request);
+
+		long totalApiCounts = findTotalApiCounts(apiPathAndIpKey, currentDate, rangeMinutes);
+
+		// 검증
+		if (totalApiCounts < apiMaximumNumber) {
+			upsertApiCount(apiPathAndIpKey, currentDate, rangeMinutes);
+			return true;
+		}
+
+		throw new ApiLimitExceededException();
+	}
+
+	private String getApiPathAndIpKey(HttpServletRequest request) {
+		// 클라 정보 뽑기 (ip, request uri)
+		String servletPath = request.getServletPath();
+		String clientIp = getClientIp(request); // ip 가져올 때 ipv4 vs ipv6
+
+		StringBuilder sb = new StringBuilder();
+		sb.append(servletPath).append(":").append(clientIp).append(":");
+
+		return sb.toString();
+	}
+
+	/**
+	 * 	클라이언트의 ip 주소를 추출한다.
+	 * 	ref : <a href="https://www.lesstif.com/software-architect/proxy-client-ip-x-forwarded-for-xff-http-header-20775886.html">...</a>.
+	 *
+	 * @param request Client의 HttpServletRequest
+	 * @return Client Ip
+	 */
+	private String getClientIp(HttpServletRequest request) {
+		String ip = request.getHeader("X-Forwarded-For");
+		if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+			ip = request.getHeader("Proxy-Client-IP");
+		}
+		if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+			ip = request.getHeader("WL-Proxy-Client-IP");
+		}
+		if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+			ip = request.getHeader("HTTP_CLIENT_IP");
+		}
+		if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+			ip = request.getHeader("HTTP_X_FORWARDED_FOR");
+		}
+		if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
+			ip = request.getRemoteAddr();
+		}
+
+		return ip;
+	}
+
+	/**
+	 * 현재 시간부터 rangeMinutes 이전까지의 시간의 api counts 총합을 리턴합니다.
+	 *
+	 * @param apiPathAndIpKey - /api/images/url:127.0.0.1
+	 * @param currentDate - 현재 시간의 Date 객체
+	 * @param rangeMinutes - api 사용 빈도 검색 시간 범위
+	 * @return totalApiCounts
+	 */
+	private long findTotalApiCounts(String apiPathAndIpKey, Date currentDate, long rangeMinutes) {
+		// 현재 시간 key 기준 검색할 key List e.g. 202212161449, 202212161448, 202212161447 ...
+		List<String> searchRateLimitKeys = new ArrayList<>();
+		Calendar calendar = Calendar.getInstance();
+		calendar.setTime(currentDate);
+		for (int i = 0; i < rangeMinutes; i++) {
+			searchRateLimitKeys.add(apiPathAndIpKey + new SimpleDateFormat("yyyyMMddHHmm").format(calendar.getTime()));
+			calendar.add(Calendar.MINUTE, -1);
+		}
+
+		// 전체 카운트 조회
+		ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+		List<String> values = valueOperations.multiGet(searchRateLimitKeys);
+		long totalCounts = 0L;
+		for (String value : Objects.requireNonNull(values)) {
+			if (Objects.nonNull(value)) {
+				totalCounts = totalCounts + Long.parseLong(value);
+			}
+		}
+
+		return totalCounts;
+	}
+
+	/**
+	 * Redis Key의 value를 1 증가 시키고 expire time을 설정한다.
+	 *
+	 * @param apiPathAndIpKey - /api/images/url:127.0.0.1
+	 * @param currentDate - 현재 시간의 Date 객체
+	 * @param rangeMinutes - api 사용 빈도 검색 시간 범위 & Redis Key expire time
+	 */
+	public void upsertApiCount(String apiPathAndIpKey, Date currentDate, long rangeMinutes) {
+		String currentRateLimitKey =
+			apiPathAndIpKey + new SimpleDateFormat("yyyyMMddHHmm").format(currentDate);
+
+		redisTemplate.execute(new SessionCallback<>() {
+			@Override
+			public <K, V> Object execute(RedisOperations<K, V> operations)
+				throws DataAccessException {
+
+				operations.multi();
+				operations.opsForValue().increment((K) currentRateLimitKey);
+				operations.expire((K) currentRateLimitKey, rangeMinutes, TimeUnit.MINUTES);
+				return operations.exec();
+			}
+		});
 	}
 }

--- a/be/src/main/java/com/jjikmuk/sikdorak/ratelimit/exception/ApiLimitExceededException.java
+++ b/be/src/main/java/com/jjikmuk/sikdorak/ratelimit/exception/ApiLimitExceededException.java
@@ -1,0 +1,12 @@
+package com.jjikmuk.sikdorak.ratelimit.exception;
+
+import com.jjikmuk.sikdorak.common.exception.SikdorakRuntimeException;
+import org.springframework.http.HttpStatus;
+
+public class ApiLimitExceededException extends SikdorakRuntimeException {
+
+	@Override
+	public HttpStatus getHttpStatus() {
+		return HttpStatus.TOO_MANY_REQUESTS;
+	}
+}

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/InitIntegrationTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/InitIntegrationTest.java
@@ -8,11 +8,28 @@ import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
 
 
 @SpringBootTest(classes = AWSMockConfig.class)
 @ActiveProfiles("test")
 public abstract class InitIntegrationTest {
+
+	static final GenericContainer redis;
+
+	static {
+		redis = new GenericContainer("redis:7.0.5")
+			.withExposedPorts(6379);
+		redis.start();
+	}
+
+	@DynamicPropertySource
+	public static void overrideProps(DynamicPropertyRegistry registry) {
+		registry.add("spring.redis.host", redis::getHost);
+		registry.add("spring.redis.port", () -> redis.getMappedPort(6379));
+	}
 
 	@Autowired
 	protected DatabaseConfigurator testData;

--- a/be/src/test/java/com/jjikmuk/sikdorak/integration/ratelimit/RedisApiRateLimiterServiceTest.java
+++ b/be/src/test/java/com/jjikmuk/sikdorak/integration/ratelimit/RedisApiRateLimiterServiceTest.java
@@ -1,0 +1,131 @@
+package com.jjikmuk.sikdorak.integration.ratelimit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
+
+import com.jjikmuk.sikdorak.ratelimit.command.app.ApiRateLimiterService;
+import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.containers.GenericContainer;
+
+@DisplayName("통합 테스트 : 특정 api에 대한 RateLimit 확인")
+@SpringBootTest // 임시
+@ActiveProfiles("test") // 임시
+class RedisApiRateLimiterServiceTest {
+
+	static final GenericContainer redis;
+
+	static {
+		redis = new GenericContainer("redis:7.0.5")
+			.withExposedPorts(6379);
+		redis.start();
+		System.setProperty("spring.redis.host", redis.getHost());
+		System.setProperty("spring.redis.port", redis.getMappedPort(6379).toString());
+	}
+
+	@Autowired
+	private ApiRateLimiterService apiRateLimiterService;
+
+	@Autowired
+	private StringRedisTemplate redisTemplate;
+
+	@AfterEach
+	void setUp() {
+		Objects.requireNonNull(redisTemplate.getConnectionFactory()).getConnection().flushAll();
+	}
+
+	@Test
+	@DisplayName("클라이언트가 api 요청 최대 이하로 요청한다면, api에 요청할 수 있다.")
+	void api_request_less_than_maximum_number() throws InterruptedException {
+		// given
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setServletPath("/api/images/url");
+		int threadCount = 8;
+		ExecutorService executorService = Executors.newFixedThreadPool(16);
+		CountDownLatch latch = new CountDownLatch(threadCount);
+
+		// when
+		for (int i = 0; i < threadCount; i++) {
+			executorService.submit(() -> {
+				try {
+					apiRateLimiterService.checkRateLimit(request, 60 * 5L, threadCount + 1L);
+				} finally {
+					latch.countDown();
+				}
+			});
+		}
+		latch.await();
+
+		Boolean result = apiRateLimiterService.checkRateLimit(request, 60 * 5L, threadCount + 1L);
+
+		// then
+		assertThat(result).isTrue();
+	}
+
+	@Test
+	@DisplayName("클라이언트가 api 요청 최대개수 -1으로 요청하고 만료 시간이 지난 뒤 요청해도 api에 요청할 수 있다.")
+	void api_request_less_than_maximum_number_and_sleep() throws InterruptedException {
+		// given
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setServletPath("/api/images/url");
+		int threadCount = 8;
+		ExecutorService executorService = Executors.newFixedThreadPool(16);
+		CountDownLatch latch = new CountDownLatch(threadCount);
+
+		// when
+		for (int i = 0; i < threadCount; i++) {
+			executorService.submit(() -> {
+				try {
+					apiRateLimiterService.checkRateLimit(request, 60 * 5L, threadCount + 1L);
+				} finally {
+					latch.countDown();
+				}
+			});
+		}
+		latch.await();
+
+		await().atMost(10, TimeUnit.SECONDS).until(() -> true); // 10초 대기
+		Boolean result = apiRateLimiterService.checkRateLimit(request, 60 * 5L, threadCount + 1L);
+
+		assertThat(result).isTrue();
+	}
+
+	@Test
+	@DisplayName("클라이언트가 api 요청 최대 이상으로 요청한다면, 예외를 발생시킨다")
+	void api_request_more_than_maximum_number() throws InterruptedException {
+		// given
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setServletPath("/api/images/url");
+		int threadCount = 9;
+		ExecutorService executorService = Executors.newFixedThreadPool(16);
+		CountDownLatch latch = new CountDownLatch(threadCount);
+
+		// when
+		for (int i = 0; i < threadCount; i++) {
+			executorService.submit(() -> {
+				try {
+					apiRateLimiterService.checkRateLimit(request, 60 * 5L, threadCount + 1L);
+				} finally {
+					latch.countDown();
+				}
+			});
+		}
+		latch.await();
+
+		assertThatThrownBy(() -> apiRateLimiterService.checkRateLimit(request, 60 * 5L, threadCount + 1L))
+			.isInstanceOf(ApiRateLimiterService.class);
+	}
+
+}


### PR DESCRIPTION
### ❗️ 이슈 번호

[SDR-433]

<br><br>

### 📝 구현 내용

- Rate Limit 기능 구현
  - 선택 알고리즘 : Sliding Window Counter
  - 작동 방식 : Redis 저장소를 활용함
    - Redis의 Set 자료구조 사용
    - Redis Key Format - `API:ip:yyyyMMddHHmm` , e.g. `/api/images/url:127.0.0.1:202212161449`
      - API, 유저의 ip, 요청 일시를 기준으로 Redis key를 만듭니다. 만료시간은 각자 api에 맞게 조절합니다.
        - 단, 유저 ip로 유저 식별하고 있기 때문에 UID로 변경할 수 있습니다.
      - 현재 시간이 202212161449 이고 window 사이즈가 5분이라면, 202212161445 ~ 202212161449 의 Redis key들의 카운드들을 모두 조회하여 api count 제한 조건이 넘는지 체크합니다.

- 사용 방법
  - Rate Limit 기능이 필요한 Controller Api에서 `ApiRateLimiterService.checkRateLimit()` 메서드를 사용하면 됩니다.

- 트랜잭션 이슈
  - 레디스에서 트랜잭션 사용하는 문제가 있어 SessionCallBack() 이란 방식으로 구현했습니다. 이에 대한 초안 문서는 `삽질 기록` 문서에 초안으로 작성되어있습니다. 이후 수정하여 wiki에 추가하겠습니다. (https://kukim.tistory.com/184)

- 테스트
  - [x] TestContainers + Redis 활용
  - [] 기존에 사용하던 테스트 서버(헤로쿠) 이전이 안되어 CI 테스트가 깨지고 있습니다. 추후 변경이 필요합니다.

<br><br>

### 🙇🏻‍♂️ 리뷰어에게 부탁합니다!
- 해당 PR 이후 PresignedURL API에 기능을 추가하려 합니다.
- 공통적으로 사용할 Rate Limiter를 구현했기에 리뷰, 댓글 생성 API에 적용할 수 있다고 생각하는데 어떻게 생각하시나요? 리뷰, 댓글 말고 더 적용할 곳이 있을까요?
- Redis에 관한 레포지토리가 없고 서비스에서 레디스를 접근하고 있습니다. 이후 Spring Data Redis Repository로 옮기거나 해당 로직을 별도로 빼야하나 고민중입니다. 

<br><br>

### 💡 참고 자료

- 삽질 기록 docs - https://www.notion.so/kukim/Rate-Limit-a0329ca500b9492e91691d0578ad36cb
- [Rate Limit 알고리즘 정리(원본, Java version)](https://www.mimul.com/blog/about-rate-limit-algorithm/)
- [Rate Limit 알고리즘 정리(python version)](https://etloveguitar.tistory.com/126)
- 구현 예 (redis, bucket4j, mutex, atomic …)
    - [https://github.com/qwlake/oscar/tree/main/api-call-limit/redis](https://github.com/qwlake/oscar/tree/main/api-call-limit/redis)
- spring cloud gateway 활용하여 구현 예
    - [https://devs0n.tistory.com/68](https://devs0n.tistory.com/68)


[SDR-433]: https://jjikmuk.atlassian.net/browse/SDR-433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ